### PR TITLE
fix backend share_ptr memory resource deallocate problem

### DIFF
--- a/python/abd_fem_example.py
+++ b/python/abd_fem_example.py
@@ -28,9 +28,9 @@ print(config)
 
 scene = Scene(config)
 
-snh = StableNeoHookean()
+snk = StableNeoHookean()
 abd = AffineBodyConstitution()
-scene.constitution_tabular().insert(snh)
+scene.constitution_tabular().insert(snk)
 scene.constitution_tabular().insert(abd)
 scene.contact_tabular().default_model(0.5, 1e9)
 default_element = scene.contact_tabular().default_element()
@@ -43,7 +43,7 @@ cube = process_surface(cube)
 
 fem_cube = cube.copy()
 moduli = ElasticModuli.youngs_poisson(1e5, 0.49)
-snh.apply_to(fem_cube, moduli)
+snk.apply_to(fem_cube, moduli)
 default_element.apply_to(fem_cube)
 
 abd_cube = cube.copy()
@@ -83,7 +83,6 @@ s = sio.simplicial_surface()
 
 ssio = SpreadSheetIO(workspace)
 ssio.write_csv('surf', s)
-sio.write_surface(f'{workspace}/scene_surface{0}.obj')
 
 v = s.positions().view()
 t = s.triangles().topo().view()
@@ -100,12 +99,6 @@ def on_update():
         s = sio.simplicial_surface()
         v = s.positions().view()
         mesh.update_vertex_positions(v.reshape(-1,3))
-        
-        while(world.frame() < 1000):
-            world.advance()
-            world.retrieve()
-            sio.write_surface(f'{workspace}/scene_surface{world.frame()}.obj')
-            world.dump()
 
 ps.set_user_callback(on_update)
 ps.show()

--- a/python/animator.py
+++ b/python/animator.py
@@ -16,7 +16,7 @@ def process_surface(sc: SimplicialComplex):
     sc = flip_inward_triangles(sc)
     return sc
 
-Logger.set_level(Logger.Level.Warn)
+Logger.set_level(Logger.Level.Info)
 
 workspace = AssetDir.output_path(__file__)
 
@@ -56,26 +56,26 @@ object.geometries().create(tet)
 g = ground(-1.2)
 object.geometries().create(g)
 
-# scripted animation
-def animation(info:Animation.UpdateInfo):
-    geos:list[GeometrySlot] = info.geo_slots()
-    geo:SimplicialComplex = geos[0].geometry()
+# # scripted animation
+# def animation(info:Animation.UpdateInfo):
+#     geos:list[GeometrySlot] = info.geo_slots()
+#     geo:SimplicialComplex = geos[0].geometry()
 
-    # label the constrained vertices
-    is_constrained = geo.vertices().find(builtin.is_constrained)
-    is_constrained_view = view(is_constrained)
-    is_constrained_view[0] = 1 if info.frame() < 180 else 0
+#     # label the constrained vertices
+#     is_constrained = geo.vertices().find(builtin.is_constrained)
+#     is_constrained_view = view(is_constrained)
+#     is_constrained_view[0] = 1 if info.frame() < 180 else 0
 
-    # set the aim position
-    apos = geo.vertices().find(builtin.aim_position)
-    apos_view = view(apos)
+#     # set the aim position
+#     apos = geo.vertices().find(builtin.aim_position)
+#     apos_view = view(apos)
     
-    theta = - info.frame() * 2 * np.pi / 360
-    cos_t = np.cos(theta)
-    sin_t = np.sin(theta)
-    apos_view[0] = Vector3.Values([0, cos_t, sin_t])
-    pass
-scene.animator().insert(object, animation)
+#     theta = - info.frame() * 2 * np.pi / 360
+#     cos_t = np.cos(theta)
+#     sin_t = np.sin(theta)
+#     apos_view[0] = Vector3.Values([0, cos_t, sin_t])
+#     pass
+# scene.animator().insert(object, animation)
 
 world.init(scene)
 

--- a/python/particle_ground.py
+++ b/python/particle_ground.py
@@ -27,13 +27,11 @@ print(config)
 scene = Scene(config)
 
 pt = Particle()
-spc = SoftPositionConstraint()
 scene.constitution_tabular().insert(pt)
-scene.constitution_tabular().insert(spc)
 scene.contact_tabular().default_model(0.5, 1e9)
 default_element = scene.contact_tabular().default_element()
 
-n = 100
+n = 10
 Vs = np.zeros((n, 3), dtype=np.float32)
 for i in range(n):
     Vs[i][1] = i
@@ -52,28 +50,32 @@ object.geometries().create(mesh)
 g = ground(0)
 object.geometries().create(g)
 
+animator = scene.animator()
+
 world.init(scene)
 
-sio = SceneIO(scene)
-run = False
-ps.init()
-ps.set_ground_plane_height(0)
-s = sio.simplicial_surface()
-v = s.positions().view()
-mesh = ps.register_point_cloud('obj', v.reshape(-1,3))
-mesh.set_radius(radius)
-def on_update():
-    global run
-    if(psim.Button("run & stop")):
-        run = not run
+# sio = SceneIO(scene)
+# run = False
+# ps.init()
+# ps.set_ground_plane_height(0)
+# s = sio.simplicial_surface()
+# v = s.positions().view()
+# mesh = ps.register_point_cloud('obj', v.reshape(-1,3))
+# mesh.set_radius(radius * 0.2)
+# def on_update():
+#     global run
+#     if(psim.Button("run & stop")):
+#         run = not run
         
-    if(run):
-        world.advance()
-        world.retrieve()
-        s = sio.simplicial_surface()
-        v = s.positions().view()
-        mesh.update_point_positions(v.reshape(-1,3))
+#     if(run):
+#         world.advance()
+#         world.retrieve()
+#         s = sio.simplicial_surface()
+#         v = s.positions().view()
+#         mesh.update_point_positions(v.reshape(-1,3))
 
-ps.set_user_callback(on_update)
-ps.show()
+# ps.set_user_callback(on_update)
+# ps.show()
+
+
 

--- a/python/pyuipc_gui/__init__.py
+++ b/python/pyuipc_gui/__init__.py
@@ -1,0 +1,34 @@
+import pyuipc_loader
+from pyuipc_loader import pyuipc
+import polyscope as ps
+from pyuipc import Scene, SceneIO
+
+class SceneGUI:
+    def __init__(self, scene:Scene):
+        self.scene_io = SceneIO(scene)
+        self.ps_trimesh:ps.SurfaceMesh = None
+        self.ps_linemesh:ps.CurveNetwork = None
+        self.ps_poincloud:ps.PointCloud = None
+    
+    def register(self)->tuple[ps.SurfaceMesh, ps.CurveNetwork, ps.PointCloud]:
+        trimesh = self.scene_io.simplicial_surface(2)
+        linemesh = self.scene_io.simplicial_surface(1)
+        pointcloud = self.scene_io.simplicial_surface(0)
+        if(trimesh.vertices().size() != 0):
+            self.ps_trimesh = ps.register_surface_mesh('trimesh', trimesh.positions().view().reshape(-1,3), trimesh.triangles().topo().view().reshape(-1,3))
+        if(linemesh.vertices().size() != 0):
+            self.ps_linemesh = ps.register_curve_network('linemesh', linemesh.positions().view().reshape(-1,3), linemesh.edges().topo().view().reshape(-1,2))
+        if(pointcloud.vertices().size() != 0):
+            self.ps_poincloud = ps.register_point_cloud('pointcloud', pointcloud.positions().view().reshape(-1,3))
+        return self.ps_trimesh, self.ps_linemesh, self.ps_poincloud
+    
+    def update(self):
+        if self.ps_trimesh is not None:
+            trimesh = self.scene_io.simplicial_surface(2)
+            self.ps_trimesh.update_vertex_positions(trimesh.positions().view().reshape(-1,3))
+        if self.ps_linemesh is not None:
+            linemesh = self.scene_io.simplicial_surface(1)
+            self.ps_linemesh.update_node_positions(linemesh.positions().view().reshape(-1,3))
+        if self.ps_poincloud is not None:
+            pointcloud = self.scene_io.simplicial_surface(0)
+            self.ps_poincloud.update_point_positions(pointcloud.positions().view().reshape(-1,3))

--- a/python/scene.py
+++ b/python/scene.py
@@ -5,10 +5,21 @@ world = pyuipc.world
 geometry = pyuipc.geometry
 
 scene = world.Scene()
+Vs = np.array([[0, 1, 0], 
+               [0, 0, 1], 
+               [-np.sqrt(3)/2, 0, -0.5], 
+               [np.sqrt(3)/2, 0, -0.5]
+               ], dtype=np.float32)
+Ts = np.array([[0,1,2,3]])
+tet = geometry.tetmesh(Vs, Ts)
+
+
 obj = scene.objects().create("obj")
 
 ground = geometry.ground()
 geo, rest_geo = obj.geometries().create(ground)
+
+obj.geometries().create(tet)
 
 print(geo.geometry().to_json())
 print(rest_geo.geometry().to_json())

--- a/src/pyuipc/pyuipc.cpp
+++ b/src/pyuipc/pyuipc.cpp
@@ -1,5 +1,6 @@
 #include <pyuipc/pyuipc.h>
 #include <uipc/common/config.h>
+#include <uipc/common/log.h>
 #include <fmt/format.h>
 
 namespace pyuipc
@@ -27,5 +28,22 @@ std::string detail::string_with_source_location(std::string_view msg,
                                                 std::size_t      line)
 {
     return fmt::format("{} [{}({})]", msg, process_project_prefix(path), line);
+}
+
+void detail::assert_with_source_location(bool             condition,
+                                         std::string_view condition_str,
+                                         std::string_view msg,
+                                         std::string_view path,
+                                         std::size_t      line)
+{
+    if(!condition)
+    {
+        std::string assert_msg = fmt::format("Assertion {} failed. {} [{}({})]",
+                                             condition_str,
+                                             msg,
+                                             process_project_prefix(path),
+                                             line);
+        throw PyException(assert_msg);
+    }
 }
 }  // namespace pyuipc

--- a/src/pyuipc/pyuipc.h
+++ b/src/pyuipc/pyuipc.h
@@ -2,6 +2,7 @@
 #include <pybind11/pybind11.h>
 #include <functional>
 #include <uipc/common/type_define.h>
+#include <uipc/common/exception.h>
 
 namespace pyuipc
 {
@@ -13,8 +14,24 @@ namespace detail
     std::string string_with_source_location(std::string_view msg,
                                             std::string_view path,
                                             std::size_t      line);
-}
+
+    void assert_with_source_location(bool             condition,
+                                     std::string_view condition_str,
+                                     std::string_view msg,
+                                     std::string_view path,
+                                     std::size_t      line);
+}  // namespace detail
+
+class PyException : public uipc::Exception
+{
+  public:
+    using uipc::Exception::Exception;
+};
 }  // namespace pyuipc
 
 #define PYUIPC_MSG(...)                                                        \
     ::pyuipc::detail::string_with_source_location(fmt::format(__VA_ARGS__), __FILE__, __LINE__)
+
+#define PYUIPC_ASSERT(condition, ...)                                          \
+    ::pyuipc::detail::assert_with_source_location(                             \
+        (condition), #condition, fmt::format(__VA_ARGS__), __FILE__, __LINE__)

--- a/src/pyuipc/world/world.cpp
+++ b/src/pyuipc/world/world.cpp
@@ -9,9 +9,7 @@ PyWorld::PyWorld(py::module& m)
 {
     auto class_World = py::class_<World>(m, "World");
 
-    class_World
-        .def(py::init([](engine::IEngine& e)
-                      { return std::make_unique<World>(e); }))
+    class_World.def(py::init<engine::IEngine&>())
         .def("init", &World::init, py::arg("scene"))
         .def("advance", &World::advance)
         .def("sync", &World::sync)

--- a/src/uipc/common/log.h
+++ b/src/uipc/common/log.h
@@ -2,30 +2,31 @@
 #include <spdlog/spdlog.h>
 #include <uipc/common/string.h>
 #include <uipc/common/config.h>
-#define UIPC_INFO_WITH_LOCATION(...)                                           \
+
+#define UIPC_LOG_WITH_LOCATION(level, ...)                                     \
     {                                                                          \
-        SPDLOG_INFO(__VA_ARGS__);                                              \
+        ::uipc::string msg = ::fmt::format(__VA_ARGS__);                       \
+        spdlog::log((level), "{} {}({})", msg, __FILE__, __LINE__);            \
     }
+
+#define UIPC_INFO_WITH_LOCATION(...)                                           \
+    UIPC_LOG_WITH_LOCATION(spdlog::level::info, __VA_ARGS__)
 
 #define UIPC_WARN_WITH_LOCATION(...)                                           \
-    {                                                                          \
-        SPDLOG_WARN(__VA_ARGS__);                                              \
-    }
+    UIPC_LOG_WITH_LOCATION(spdlog::level::warn, __VA_ARGS__)
 
 #define UIPC_ERROR_WITH_LOCATION(...)                                          \
-    {                                                                          \
-        SPDLOG_ERROR(__VA_ARGS__);                                             \
-    }
+    UIPC_LOG_WITH_LOCATION(spdlog::level::err, __VA_ARGS__)
 
-#define UIPC_ASSERT(condition, ...)                                            \
-    if constexpr(::uipc::RUNTIME_CHECK)                                        \
-    {                                                                          \
-        if(!(condition))                                                       \
-        {                                                                      \
-            ::uipc::string msg = ::fmt::format(__VA_ARGS__);                   \
-            ::uipc::string assert_meg =                                        \
-                ::fmt::format("Assertion " #condition " failed. {}", msg);     \
-            SPDLOG_ERROR(assert_meg);                                          \
-            ::std::abort();                                                    \
-        }                                                                      \
+#define UIPC_ASSERT(condition, ...)                                                       \
+    if constexpr(::uipc::RUNTIME_CHECK)                                                   \
+    {                                                                                     \
+        if(!(condition))                                                                  \
+        {                                                                                 \
+            ::uipc::string msg = ::fmt::format(__VA_ARGS__);                              \
+            ::uipc::string assert_meg =                                                   \
+                ::fmt::format("Assertion " #condition " failed. {}", msg);                \
+            spdlog::log(spdlog::level::err, "{} {}({})", assert_meg, __FILE__, __LINE__); \
+            ::std::abort();                                                               \
+        }                                                                                 \
     }

--- a/src/uipc/constitution/fem_constitution.cpp
+++ b/src/uipc/constitution/fem_constitution.cpp
@@ -32,5 +32,7 @@ void FiniteElementConstitution::apply_to(geometry::SimplicialComplex& sc,
 
     auto thickness_view = geometry::view(*attr_thickness);
     std::ranges::fill(thickness_view, thickness);
+
+    sc.meta().create<IndexT>(builtin::backend_fem_vertex_offset, -1);
 }
 }  // namespace uipc::constitution

--- a/src/uipc/geometry/abstract_simplicial_complex.cpp
+++ b/src/uipc/geometry/abstract_simplicial_complex.cpp
@@ -3,10 +3,10 @@
 namespace uipc::geometry
 {
 AbstractSimplicialComplex::AbstractSimplicialComplex()
-    : m_vertices(std::make_shared<Vertices>())
-    , m_edges(std::make_shared<Edges>())
-    , m_triangles(std::make_shared<Triangles>())
-    , m_tetrahedra(std::make_shared<Tetrahedra>())
+    : m_vertices(make_shared<Vertices>())
+    , m_edges(make_shared<Edges>())
+    , m_triangles(make_shared<Triangles>())
+    , m_tetrahedra(make_shared<Tetrahedra>())
 {
 }
 

--- a/src/uipc/geometry/details/attribute.inl
+++ b/src/uipc/geometry/details/attribute.inl
@@ -79,12 +79,12 @@ void Attribute<T>::do_reserve(SizeT N)
 template <typename T>
 S<IAttribute> Attribute<T>::do_clone() const
 {
-    return std::make_shared<Attribute<T>>(*this);
+    return uipc::make_shared<Attribute<T>>(*this);
 }
 template <typename T>
 inline S<IAttribute> Attribute<T>::do_clone_empty() const
 {
-    return std::make_shared<Attribute<T>>(m_default_value);
+    return uipc::make_shared<Attribute<T>>(m_default_value);
 }
 template <typename T>
 void Attribute<T>::do_reorder(span<const SizeT> O) noexcept

--- a/src/uipc/geometry/details/attribute_slot.inl
+++ b/src/uipc/geometry/details/attribute_slot.inl
@@ -45,21 +45,21 @@ void AttributeSlot<T>::do_make_owned()
 {
     // if I am not the only one who is using the attribute, then I need to make a copy_from
     if(m_attribute.use_count() > 1)
-        m_attribute = std::make_shared<Attribute<T>>(*m_attribute);
+        m_attribute = uipc::make_shared<Attribute<T>>(*m_attribute);
 }
 
 template <typename T>
 S<IAttributeSlot> AttributeSlot<T>::do_clone() const
 {
-    return std::make_shared<AttributeSlot<T>>(
+    return uipc::make_shared<AttributeSlot<T>>(
         name(), std::static_pointer_cast<Attribute<T>>(m_attribute), m_allow_destroy);
 }
 
 template <typename T>
 S<IAttributeSlot> AttributeSlot<T>::do_clone_empty() const
 {
-    return std::make_shared<AttributeSlot<T>>(
-        name(), std::make_shared<Attribute<T>>(m_attribute->m_default_value), m_allow_destroy);
+    return uipc::make_shared<AttributeSlot<T>>(
+        name(), uipc::make_shared<Attribute<T>>(m_attribute->m_default_value), m_allow_destroy);
 }
 
 template <typename T>

--- a/src/uipc/geometry/details/geometry_collection.inl
+++ b/src/uipc/geometry/details/geometry_collection.inl
@@ -8,7 +8,7 @@ S<geometry::GeometrySlotT<GeometryT>> GeometryCollection::emplace(const Geometry
 
     auto id = m_next_id++;
 
-    auto slot = std::make_shared<geometry::GeometrySlotT<GeometryT>>(id, geometry);
+    auto slot = uipc::make_shared<geometry::GeometrySlotT<GeometryT>>(id, geometry);
     slot->state(geometry::GeometrySlotState::Normal);
     m_geometries.emplace(id, slot);
 
@@ -22,7 +22,7 @@ S<geometry::GeometrySlotT<GeometryT>> GeometryCollection::pending_emplace(const 
 
     auto id = m_next_id++;
 
-    auto slot = std::make_shared<geometry::GeometrySlotT<GeometryT>>(id, geometry);
+    auto slot = uipc::make_shared<geometry::GeometrySlotT<GeometryT>>(id, geometry);
     slot->state(geometry::GeometrySlotState::PendingCreate);
     m_pending_create.emplace(id, slot);
 

--- a/src/uipc/geometry/details/simplex_slot.inl
+++ b/src/uipc/geometry/details/simplex_slot.inl
@@ -24,7 +24,7 @@ auto view(SimplexSlot<N>& slot) -> span<typename SimplexSlot<N>::ValueT>
 template <IndexT N>
 S<SimplexSlot<N>> SimplexSlot<N>::clone() const
 {
-    return std::make_shared<SimplexSlot<N>>(m_simplices);
+    return uipc::make_shared<SimplexSlot<N>>(m_simplices);
 }
 template <IndexT N>
 SizeT SimplexSlot<N>::get_use_count() const noexcept
@@ -41,7 +41,7 @@ S<ISimplexSlot> SimplexSlot<N>::do_clone() const
 template <IndexT N>
 void SimplexSlot<N>::do_make_owned()
 {
-    m_simplices = std::make_shared<Simplices<N>>(*m_simplices);
+    m_simplices = uipc::make_shared<Simplices<N>>(*m_simplices);
 }
 
 template <IndexT N>

--- a/src/uipc/geometry/details/simplices.inl
+++ b/src/uipc/geometry/details/simplices.inl
@@ -69,6 +69,6 @@ Json Simplices<N>::do_to_json(SizeT i) const
 template <IndexT N>
 S<ITopoElements> Simplices<N>::do_clone() const
 {
-    return std::make_shared<Simplices<N>>(*this);
+    return uipc::make_shared<Simplices<N>>(*this);
 }
 }  // namespace uipc::geometry

--- a/src/uipc/geometry/simplex_slot.cpp
+++ b/src/uipc/geometry/simplex_slot.cpp
@@ -104,7 +104,7 @@ UIPC_CORE_API span<IndexT> view(VertexSlot& slot)
 
 S<VertexSlot> VertexSlot::clone() const
 {
-    return std::make_shared<VertexSlot>(m_simplices);
+    return uipc::make_shared<VertexSlot>(m_simplices);
 }
 
 SizeT VertexSlot::get_use_count() const noexcept
@@ -119,7 +119,7 @@ S<ISimplexSlot> VertexSlot::do_clone() const
 
 void VertexSlot::do_make_owned()
 {
-    m_simplices = std::make_shared<Vertices>(*m_simplices);
+    m_simplices = uipc::make_shared<Vertices>(*m_simplices);
 }
 
 ISimplices& VertexSlot::get_simplices() noexcept

--- a/src/uipc/geometry/simplices.cpp
+++ b/src/uipc/geometry/simplices.cpp
@@ -70,7 +70,7 @@ void Vertices::do_clear()
 
 S<ITopoElements> Vertices::do_clone() const
 {
-    return std::make_shared<Vertices>(*this);
+    return uipc::make_shared<Vertices>(*this);
 }
 
 void Vertices::do_reserve(SizeT N)

--- a/src/uipc/util/io/scene_io.cpp
+++ b/src/uipc/util/io/scene_io.cpp
@@ -133,11 +133,6 @@ geometry::SimplicialComplex SceneIO::simplicial_surface() const
 
     auto simplicial_complex_has_surf = detail::collect_geometry_with_surf<-1>(geos);
 
-    if(simplicial_complex_has_surf.empty())
-    {
-        UIPC_WARN_WITH_LOCATION("No simplicial complex with surface found.");
-    }
-
     return extract_surface(simplicial_complex_has_surf);
 }
 
@@ -165,11 +160,6 @@ geometry::SimplicialComplex SceneIO::simplicial_surface(IndexT dim) const
             break;
         default:
             break;
-    }
-
-    if(simplicial_complex_has_surf.empty())
-    {
-        UIPC_WARN_WITH_LOCATION("No simplicial complex with surface found.");
     }
 
     return extract_surface(simplicial_complex_has_surf);

--- a/src/uipc/world/object_collection.cpp
+++ b/src/uipc/world/object_collection.cpp
@@ -11,7 +11,7 @@ T& remove_const(const T& t)
 S<Object> ObjectCollection::emplace(Object&& object)
 {
     IndexT id  = m_next_id++;
-    auto   ptr = std::make_shared<Object>(std::move(object));
+    auto   ptr = uipc::make_shared<Object>(std::move(object));
     m_objects.emplace(id, ptr);
     return ptr;
 }


### PR DESCRIPTION
 when create shared_ptr and passing module, programmer must use uipc::make_shared() instead of std::make_shared() to sync the memory resource