### PR TITLE
Raising an exception when python bindnig is not built.

### DIFF
--- a/python/src/pyuipc_loader/__init__.py
+++ b/python/src/pyuipc_loader/__init__.py
@@ -20,6 +20,10 @@ else:
 import pyuipc
 
 def init():
+    if pyuipc is None:
+        err_message = "Python binding is not built. \n           Please make a `Release` or `RelWithDebInfo` build with option `-DUIPC_BUILD_PYBIND=1` to enable python binding."
+        raise Exception(err_message)
+    
     module_path = pathlib.Path(pyuipc.__file__).absolute()
     module_dir = module_path.parent
 


### PR DESCRIPTION
Currently if python binding compile option -DUIPC_BUILD_PYBIND=1 is not used, exception like this is raised

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/name/.conda/envs/uipc/lib/python3.10/site-packages/pyuipc_loader/__init__.py", line 35, in <module>
    init()
  File "/home/name/.conda/envs/uipc/lib/python3.10/site-packages/pyuipc_loader/__init__.py", line 23, in init
    module_path = pathlib.Path(pyuipc.__file__).absolute()
  File "/home/name/.conda/envs/uipc/lib/python3.10/pathlib.py", line 960, in __new__
    self = cls._from_parts(args)
  File "/home/name/.conda/envs/uipc/lib/python3.10/pathlib.py", line 594, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/home/name/.conda/envs/uipc/lib/python3.10/pathlib.py", line 578, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

which can be confusing ( at least for me ). I wonder raising an exception manually is a better choice.