### PR TITLE
fix CUDA PMR Allocator Compilation Error

### DIFF
--- a/src/backends/cuda/linear_system/global_linear_system.cu
+++ b/src/backends/cuda/linear_system/global_linear_system.cu
@@ -243,7 +243,7 @@ bool GlobalLinearSystem::Impl::_update_subsystem_extent()
             triplet_count_changed |= subsystem_triplet_counts[triplet_i] != total_block_count;
             subsystem_triplet_counts[triplet_i] = total_block_count;
             off_diag_lr_triplet_counts[subsystem_info.local_index] =
-                ulonglong2{info.m_lr_block_count, info.m_rl_block_count};
+                SizeT2{info.m_lr_block_count, info.m_rl_block_count};
         }
     }
 

--- a/src/backends/cuda/linear_system/global_linear_system.h
+++ b/src/backends/cuda/linear_system/global_linear_system.h
@@ -9,6 +9,13 @@
 #include <utils/offset_count_collection.h>
 namespace uipc::backend::cuda
 {
+// Define a simple POD to avoid constructing CUDA's built-in vector type with pmr allocators in host code
+struct SizeT2
+{
+    SizeT x;
+    SizeT y;
+};
+
 class DiagLinearSubsystem;
 class OffDiagLinearSubsystem;
 class IterativeSolver;
@@ -260,16 +267,16 @@ class GlobalLinearSystem : public SimSystem
 
         Float reserve_ratio = 1.1;
 
-        vector<LinearSubsytemInfo> subsystem_infos;
+        std::vector<LinearSubsytemInfo> subsystem_infos;
 
         OffsetCountCollection<IndexT> diag_dof_offsets_counts;
         OffsetCountCollection<IndexT> subsystem_triplet_offsets_counts;
 
-        vector<ulonglong2> off_diag_lr_triplet_counts;
+        std::vector<SizeT2> off_diag_lr_triplet_counts;
 
 
-        vector<int> accuracy_statisfied_flags;
-        vector<int> no_precond_diag_subsystem_indices;
+        std::vector<int> accuracy_statisfied_flags;
+        std::vector<int> no_precond_diag_subsystem_indices;
 
         // Containers
         SimSystemSlotCollection<DiagLinearSubsystem>    diag_subsystems;


### PR DESCRIPTION
I'm encountering build errors with libupic. The core issue appears to be an incompatibility between std::pmr::polymorphic_allocator and the CUDA construction of ulonglong2. Specifically, the allocator is not compatible with how ulonglong2 is being created within the CUDA compilation process. It can be fixed with POD structs data type as shown in my PR.

```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.348
08\include\xpolymorphic_allocator.h(285): error : expected an expression [F:\libuipc\build\src\backends\cuda\cuda.vcxproj]
_Uty(::std:: forward<decltype(_Construct_args)>(_Construct_args)...); 
detected during instantiation of "void std::pmr::polymorphic_allocator<_Ty>::construct(_Uty *, _Types &&...)
 [with _Ty=uipc::backend::cuda::SizeT2, _Uty=uipc::backend::cuda::SizeT2, _Types=<>]" at line 619 of 
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\xmemory



C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\xpolymorphic_allocator.h(285): error : expected an expression [F:\libuipc\build\src\backends\cuda\cuda.vcxproj]
_Uty(::std:: forward<decltype(_Construct_args)>(_Construct_args)...);
detected during instantiation of "void std::pmr::polymorphic_allocator<_Ty>::construct(_Uty *, _Types &&...) [with _Ty=uipc::backend::cuda::Size T2, _Uty=uipc::backend::cuda::SizeT2, _Types=<>]" at line 619 of C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\xmemory

C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\xpolymorphic_allocator.h(285): error : expected a ")" [F:\libuipc\build\src\backends\cuda\cuda.vcxproj]
_Uty(::std:: forward<decltype(_Construct_args)>(_Construct_args)...);
detected during instantiation of "void std::pmr::polymorphic_allocator<_Ty>::construct(_Uty *, _Types &&...) [with _Ty=uipc::backend::cuda::Size T2, _Uty=uipc::backend::cuda::SizeT2, _Types=<>]" at line 619 of C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\xmemory
```