### PR TITLE
Fix default value type error: StrainLimitingBaraffWitkinShell

### DIFF
--- a/src/pybind/pyuipc/constitution/strain_limiting_baraff_witkin.cpp
+++ b/src/pybind/pyuipc/constitution/strain_limiting_baraff_witkin.cpp
@@ -35,7 +35,7 @@ Returns:
            Float thickness)
         { self.apply_to(sc, moduli, mass_density, thickness); },
         py::arg("sc"),
-        py::arg("moduli")       = ElasticModuli::youngs_poisson(1.0_MPa, 0.49),
+        py::arg("moduli")       = ElasticModuli2D::youngs_poisson(1.0_MPa, 0.49),
         py::arg("mass_density") = 2.0e2,
         py::arg("thickness")    = 0.001_m,
         R"(Apply StrainLimitingBaraffWitkinShell constitution to a simplicial complex.


### PR DESCRIPTION
## Summary

Fix the `TypeError` when calling `StrainLimitingBaraffWitkinShell.apply_to()` with default arguments from Python.

## Root Cause

In the pybind binding (`src/pybind/pyuipc/constitution/strain_limiting_baraff_witkin.cpp`), the default value for the `moduli` parameter was using `ElasticModuli::youngs_poisson(1.0_MPa, 0.49)` (3D elastic moduli type) instead of `ElasticModuli2D::youngs_poisson(1.0_MPa, 0.49)` (2D elastic moduli type).

Since `StrainLimitingBaraffWitkinShell` is a shell (2D) constitution, its `apply_to()` expects `ElasticModuli2D`, but the pybind default was providing an `ElasticModuli` (3D) object, causing a type mismatch error at runtime.

## Fix

Changed `ElasticModuli::youngs_poisson` → `ElasticModuli2D::youngs_poisson` in the pybind default argument, matching the C++ header declaration.

## Checklist

- [x] Bug fix: `ElasticModuli` → `ElasticModuli2D` in pybind default
- [x] Unit tests pass
- [x] Manual testing completed

Fixes #309