### PR TITLE
feat(assets): unify show() with asset selector and config GUI

### DIFF
--- a/python/src/uipc/assets/__init__.py
+++ b/python/src/uipc/assets/__init__.py
@@ -1,11 +1,17 @@
 """Download and load UIPC simulation assets from the HuggingFace dataset.
 
+Supports both remote assets (downloaded from HuggingFace) and local asset
+directories for development and testing.
+
 Usage::
 
-    from uipc.assets import list_assets, asset_path, load
+    from uipc.assets import list_assets, asset_path, load, show
 
-    # See what's available
+    # See what's available (remote)
     print(list_assets())
+
+    # See what's available (local)
+    print(list_assets(local_dir='path/to/uipc-assets/assets'))
 
     # Get the local path (downloads on first call, cached afterwards)
     path = asset_path("cube_ground")
@@ -14,20 +20,28 @@ Usage::
     from uipc import Scene
     scene = Scene(Scene.default_config())
     load("cube_ground", scene)
+
+    # Interactive viewer with asset selector
+    show()                               # browse and pick any asset
+    show("cube_ground")                  # preload a scene (geometry only)
+    show("cube_ground", backend="cuda")  # preload and run simulation
+
+    # Work with a local assets directory
+    show(local_dir='path/to/uipc-assets/assets')
 """
 
 import importlib.util
 import pathlib
 
 from huggingface_hub import HfApi, RepoFolder, snapshot_download
-from uipc import Scene, SceneIO
+from uipc import Scene, SceneIO, Vector3, view
 from uipc.geometry import SimplicialComplex, SimplicialComplexIO
 
 REPO_ID = 'MuGdxy/uipc-assets'
 
 __all__ = [
     'REPO_ID', 'list_assets', 'asset_path', 'read_mesh',
-    'load', 'run', 'show', 'strip_constitutions',
+    'load', 'show', 'strip_constitutions',
 ]
 
 _CONSTITUTION_META_ATTRS = [
@@ -63,12 +77,36 @@ def strip_constitutions(scene: Scene) -> None:
                     meta.destroy(attr_name)
 
 
-def list_assets(*, revision: str = 'main') -> list[str]:
-    """List all available asset names in the HuggingFace dataset.
+def list_assets(
+    *,
+    revision: str = 'main',
+    local_dir: str | pathlib.Path | None = None,
+) -> list[str]:
+    """List all available asset names.
+
+    When *local_dir* is given, scans that directory for sub-directories
+    containing a ``scene.py`` file.  Otherwise queries the HuggingFace
+    dataset.
+
+    Args:
+        revision: Git revision (only used for remote assets).
+        local_dir: Path to a local assets directory (e.g.
+            ``'uipc-assets/assets'``).  Each immediate sub-directory that
+            contains a ``scene.py`` is treated as an asset.
 
     Returns:
         Sorted list of asset names (e.g. ``['cube_ground', 'fem_link_drop', ...]``).
     """
+    if local_dir is not None:
+        root = pathlib.Path(local_dir)
+        if not root.is_dir():
+            raise FileNotFoundError(f'Local assets directory not found: {root}')
+        return sorted(
+            d.name
+            for d in root.iterdir()
+            if d.is_dir() and (d / 'scene.py').exists()
+        )
+
     api = HfApi()
     entries = api.list_repo_tree(
         REPO_ID, repo_type='dataset', path_in_repo='assets', revision=revision
@@ -101,31 +139,43 @@ def read_mesh(io: SimplicialComplexIO, filepath: str | pathlib.Path) -> Simplici
 
 
 def asset_path(
-    name: str, *, revision: str = 'main', cache_dir: str | None = None
+    name: str,
+    *,
+    revision: str = 'main',
+    cache_dir: str | None = None,
+    local_dir: str | pathlib.Path | None = None,
 ) -> pathlib.Path:
-    """Download an asset by name from HuggingFace and return its local path.
+    """Return the local path to an asset directory.
 
-    The result is cached by ``huggingface_hub``; subsequent calls with the same
-    *name* and *revision* return instantly.
+    When *local_dir* is given, returns ``local_dir / name`` directly.
+    Otherwise downloads from HuggingFace (cached by ``huggingface_hub``).
 
     Args:
-        name: Asset name (e.g. ``'cube_ground'``).  Corresponds to
-              ``assets/<name>/`` in the dataset repo.
-        revision: Git revision (branch, tag, or commit hash).
-        cache_dir: Where to cache downloaded files.  ``None`` uses the
-                   default HuggingFace cache directory.
+        name: Asset name (e.g. ``'cube_ground'``).
+        revision: Git revision (only used for remote assets).
+        cache_dir: Where to cache downloaded files (remote only).
+        local_dir: Path to a local assets directory.  When set, no
+            network access is performed.
 
     Returns:
-        :class:`~pathlib.Path` to the downloaded asset directory.
+        :class:`~pathlib.Path` to the asset directory.
     """
-    local_dir = snapshot_download(
+    if local_dir is not None:
+        result = pathlib.Path(local_dir) / name
+        if not result.is_dir():
+            raise FileNotFoundError(
+                f'Asset \'{name}\' not found in local directory {local_dir}.'
+            )
+        return result
+
+    dl = snapshot_download(
         REPO_ID,
         allow_patterns=[f'assets/{name}/**', 'assets/_*.py'],
         revision=revision,
         cache_dir=cache_dir,
         repo_type='dataset',
     )
-    result = pathlib.Path(local_dir) / 'assets' / name
+    result = pathlib.Path(dl) / 'assets' / name
     if not result.is_dir():
         raise FileNotFoundError(
             f'Asset \'{name}\' not found in {REPO_ID}.  '
@@ -141,23 +191,26 @@ def load(
     geometry_only: bool = False,
     revision: str = 'main',
     cache_dir: str | None = None,
+    local_dir: str | pathlib.Path | None = None,
 ) -> None:
-    """Download an asset and apply it to a Scene.
+    """Download (or locate locally) an asset and apply it to a Scene.
 
-    Downloads ``assets/<name>/`` from the HuggingFace dataset, imports
-    its ``scene.py``, and calls ``build_scene(scene)``.  Each asset's
-    ``build_scene`` may modify ``scene.config()`` to set parameters
-    like ``dt`` or ``contact/d_hat``.
+    Imports the asset's ``scene.py`` and calls ``build_scene(scene)``.
+    Each asset's ``build_scene`` may modify ``scene.config()`` to set
+    parameters like ``dt`` or ``contact/d_hat``.
 
     Args:
         name: Asset name (e.g. ``'cube_ground'``).
         scene: A :class:`uipc.Scene` instance to populate.
         geometry_only: If ``True``, strip all constitution / constraint /
             contact metadata after building, leaving only raw geometry.
-        revision: Git revision (branch, tag, or commit hash).
-        cache_dir: Where to cache downloaded files.
+        revision: Git revision (only used for remote assets).
+        cache_dir: Where to cache downloaded files (remote only).
+        local_dir: Path to a local assets directory.  When set, no
+            network access is performed.
     """
-    path = asset_path(name, revision=revision, cache_dir=cache_dir)
+    path = asset_path(name, revision=revision, cache_dir=cache_dir,
+                      local_dir=local_dir)
     scene_file = path / 'scene.py'
     if not scene_file.exists():
         raise FileNotFoundError(
@@ -178,133 +231,435 @@ def load(
         strip_constitutions(scene)
 
 
-def run(
-    name: str,
-    backend: str = 'cuda',
+def _show_scene_config(imgui, cfg) -> None:
+    """Render all scene config attributes as ImGui controls."""
+
+    def _float(key: str, label: str, fmt: str = '%.6f'):
+        attr = cfg.find(key)
+        if attr is None:
+            return
+        val = float(view(attr)[0])
+        changed, new_val = imgui.InputFloat(label, val, 0.0, 0.0, fmt)
+        if changed:
+            view(attr)[0] = new_val
+
+    def _int(key: str, label: str, step: int = 1, step_fast: int = 10):
+        attr = cfg.find(key)
+        if attr is None:
+            return
+        val = int(view(attr)[0])
+        changed, new_val = imgui.InputInt(label, val, step, step_fast)
+        if changed:
+            view(attr)[0] = new_val
+
+    def _bool(key: str, label: str):
+        attr = cfg.find(key)
+        if attr is None:
+            return
+        val = bool(int(view(attr)[0]))
+        changed, new_val = imgui.Checkbox(label, val)
+        if changed:
+            view(attr)[0] = int(new_val)
+
+    def _vec3(key: str, label: str):
+        attr = cfg.find(key)
+        if attr is None:
+            return
+        g = view(attr)[0]
+        gv = [float(g[0][0]), float(g[1][0]), float(g[2][0])]
+        changed, new_g = imgui.DragFloat3(label, gv, 0.1, -100.0, 100.0, '%.2f')
+        if changed:
+            view(attr)[0] = Vector3.Values(new_g)
+
+    def _str(key: str, label: str):
+        attr = cfg.find(key)
+        if attr is None:
+            return
+        val = str(view(attr)[0])
+        imgui.InputText(label, val, imgui.ImGuiInputTextFlags_ReadOnly)
+
+    # ── Time & Physics ────────────────────────────────────────
+    if imgui.TreeNode('Time & Physics'):
+        _float('dt', 'dt')
+        _vec3('gravity', 'gravity')
+        imgui.TreePop()
+
+    # ── Contact ───────────────────────────────────────────────
+    if imgui.TreeNode('Contact'):
+        _bool('contact/enable', 'enable')
+        _bool('contact/friction/enable', 'friction')
+        _str('contact/constitution', 'constitution')
+        _float('contact/d_hat', 'd_hat', '%.6e')
+        _float('contact/eps_velocity', 'eps_velocity', '%.6e')
+        _float('contact/adaptive/min_kappa', 'min_kappa', '%.6e')
+        _float('contact/adaptive/init_kappa', 'init_kappa', '%.6e')
+        _float('contact/adaptive/max_kappa', 'max_kappa', '%.6e')
+        imgui.TreePop()
+
+    # ── Newton Solver ─────────────────────────────────────────
+    if imgui.TreeNode('Newton Solver'):
+        _int('newton/max_iter', 'max_iter')
+        _int('newton/min_iter', 'min_iter')
+        _bool('newton/use_adaptive_tol', 'adaptive_tol')
+        _float('newton/velocity_tol', 'velocity_tol', '%.6e')
+        _float('newton/ccd_tol', 'ccd_tol', '%.4f')
+        _float('newton/transrate_tol', 'transrate_tol', '%.6e')
+        _bool('newton/semi_implicit/enable', 'semi_implicit')
+        _float('newton/semi_implicit/beta_tol', 'beta_tol', '%.6e')
+        imgui.TreePop()
+
+    # ── Linear System ─────────────────────────────────────────
+    if imgui.TreeNode('Linear System'):
+        _float('linear_system/tol_rate', 'tol_rate', '%.6e')
+        _str('linear_system/solver', 'solver')
+        _bool('linear_system/precond/mas/contact_aware', 'contact_aware')
+        imgui.TreePop()
+
+    # ── Line Search ───────────────────────────────────────────
+    if imgui.TreeNode('Line Search'):
+        _int('line_search/max_iter', 'max_iter')
+        _bool('line_search/report_energy', 'report_energy')
+        imgui.TreePop()
+
+    # ── Misc ──────────────────────────────────────────────────
+    if imgui.TreeNode('Misc'):
+        _str('integrator/type', 'integrator')
+        _bool('cfl/enable', 'CFL')
+        _str('collision_detection/method', 'collision method')
+        _bool('sanity_check/enable', 'sanity_check')
+        _str('sanity_check/mode', 'sanity_mode')
+        _bool('diff_sim/enable', 'diff_sim')
+        _bool('extras/strict_mode/enable', 'strict_mode')
+        _bool('extras/debug/dump_surface', 'dump_surface')
+        _bool('extras/debug/dump_linear_system', 'dump_linear_sys')
+        _bool('extras/debug/dump_linear_pcg', 'dump_linear_pcg')
+        imgui.TreePop()
+
+
+def _show_contact_tabular(imgui, ct) -> None:
+    """Render editable contact tabular as ImGui controls."""
+    n = ct.element_count()
+
+    # Build element name lookup: id → name.
+    de = ct.default_element()
+    elem_names = {de.id(): de.name() or 'default'}
+
+    imgui.TextUnformatted(f'Elements: {n}')
+
+    # Show element list with names.
+    if imgui.TreeNode('Elements'):
+        for i in range(n):
+            name = elem_names.get(i, f'element_{i}')
+            imgui.TextUnformatted(f'  [{i}] {name}')
+        imgui.TreePop()
+
+    # ── Default model (editable) ──────────────────────────────
+    def_name = elem_names.get(de.id(), 'default')
+    if imgui.TreeNode(f'Default model ({def_name})'):
+        dm = ct.default_model()
+        fr = dm.friction_rate()
+        res = dm.resistance()
+        ena = dm.is_enabled()
+
+        ch_f, new_fr = imgui.InputFloat('friction##def', fr, 0.0, 0.0, '%.4f')
+        ch_r, new_res = imgui.InputFloat('resistance##def', res, 0.0, 0.0, '%.2e')
+        ch_e, new_ena = imgui.Checkbox('enabled##def', ena)
+
+        if ch_f or ch_r or ch_e:
+            ct.default_model(
+                new_fr if ch_f else fr,
+                new_res if ch_r else res,
+                new_ena if ch_e else ena,
+            )
+        imgui.TreePop()
+
+    # ── Pairwise models (editable) ────────────────────────────
+    if n > 1 and imgui.TreeNode('Pairwise models'):
+        for i in range(n):
+            for j in range(i, n):
+                m = ct.at(i, j)
+                ni = elem_names.get(i, f'element_{i}')
+                nj = elem_names.get(j, f'element_{j}')
+                tag = f'##{i}_{j}'
+                header = f'{ni} <-> {nj}{tag}'
+                if imgui.TreeNode(header):
+                    fr = m.friction_rate()
+                    res = m.resistance()
+                    ena = m.is_enabled()
+
+                    ch_f, new_fr = imgui.InputFloat(
+                        f'friction{tag}', fr, 0.0, 0.0, '%.4f',
+                    )
+                    ch_r, new_res = imgui.InputFloat(
+                        f'resistance{tag}', res, 0.0, 0.0, '%.2e',
+                    )
+                    ch_e, new_ena = imgui.Checkbox(f'enabled{tag}', ena)
+
+                    if ch_f or ch_r or ch_e:
+                        from uipc.core import ContactElement
+                        L = ContactElement(i, '')
+                        R = ContactElement(j, '')
+                        ct.insert(
+                            L, R,
+                            new_fr if ch_f else fr,
+                            new_res if ch_r else res,
+                            new_ena if ch_e else ena,
+                        )
+                    imgui.TreePop()
+        imgui.TreePop()
+
+
+def show(
+    name: str | None = None,
+    backend: str = 'none',
     *,
     gui: bool = True,
     workspace: str | None = None,
     revision: str = 'main',
     cache_dir: str | None = None,
+    local_dir: str | pathlib.Path | None = None,
     distance_factor: float = 2.0,
 ) -> None:
-    """Download an asset, build its scene, and run the simulation.
+    """Display and optionally simulate a UIPC asset in a Polyscope window.
 
-    A convenience one-liner for running a simulation::
+    Opens an interactive viewer with an **Asset Selector** panel that lists
+    every available asset.  You can pick any scene and hot-load it without
+    restarting.  When *backend* is a real engine (e.g. ``'cuda'``), a
+    **Run / Pause** control is shown as well.
 
-        from uipc.assets import run
-        run('cube_ground')                    # CUDA backend with GUI
-        run('cube_ground', gui=False)         # headless
-        run('cube_ground', 'none')            # None backend (sanity check only)
-        run('cube_ground', workspace='out/')  # custom output directory
+    Supports both remote assets (from HuggingFace) and local asset
+    directories for development::
+
+        from uipc.assets import show
+
+        show()                               # browse remote assets
+        show('cube_ground')                  # preload one scene
+        show('cube_ground', backend='cuda')  # preload + live simulation
+        show(backend='cuda')                 # browse, simulate what you pick
+        show(local_dir='uipc-assets/assets') # browse local assets
 
     Args:
-        name: Asset name (e.g. ``'cube_ground'``).
-        backend: Engine backend name (default ``'cuda'``).
-        gui: If ``True`` (default), open a Polyscope window to visualize
-             the simulation in real time.
+        name: Optional asset name to preload (e.g. ``'cube_ground'``).
+            If ``None``, the viewer opens empty and you pick from the list.
+        backend: Engine backend (default ``'none'`` for geometry-only preview,
+            ``'cuda'`` for live simulation).
+        gui: If ``True`` (default), open a Polyscope window.
+            If ``False`` with a real backend, run headlessly.
         workspace: Directory for simulation output.  ``None`` uses a
-                   temporary directory.
-        revision: Git revision (branch, tag, or commit hash).
-        cache_dir: Where to cache downloaded files.
+            temporary directory.
+        revision: Git revision (only used for remote assets).
+        cache_dir: Where to cache downloaded files (remote only).
+        local_dir: Path to a local assets directory.  When set, assets
+            are loaded from disk without any network access.
         distance_factor: How far the camera sits relative to the bounding-box
-                         diagonal (default ``2.0``).  Only used when *gui* is True.
+            diagonal (default ``2.0``).
     """
     import tempfile
+    import threading
+
     from uipc import Engine, World
 
-    scene = Scene(Scene.default_config())
-    load(name, scene, revision=revision, cache_dir=cache_dir)
+    is_simulation = (backend != 'none')
 
-    if workspace is None:
-        workspace = tempfile.mkdtemp(prefix=f'uipc_{name}_')
+    # ── headless mode (gui=False with a real backend) ──────────────
+    if not gui:
+        if name is None:
+            raise ValueError(
+                'Headless mode (gui=False) requires a scene name.'
+            )
+        scene = Scene(Scene.default_config())
+        load(name, scene, revision=revision, cache_dir=cache_dir,
+             local_dir=local_dir)
+        ws = workspace or tempfile.mkdtemp(prefix=f'uipc_{name}_')
+        engine = Engine(backend, ws)
+        world = World(engine)
+        world.init(scene)
+        if not world.is_valid():
+            raise RuntimeError(
+                f"Scene '{name}' failed sanity check, world is not valid."
+            )
+        while world.is_valid():
+            world.advance()
+            world.sync()
+            world.retrieve()
+        return
 
-    engine = Engine(backend, workspace)
-    world = World(engine)
-    world.init(scene)
+    # ── GUI mode ───────────────────────────────────────────────────
+    import polyscope as ps
+    import polyscope.imgui as imgui
+    from uipc.gui import SceneGUI
 
-    if not world.is_valid():
-        raise RuntimeError(f"Scene '{name}' failed sanity check, world is not valid.")
+    # Mutable state shared with the ImGui callback.
+    state = {
+        'scene': None,
+        'engine': None,
+        'world': None,
+        'scene_gui': None,
+        'current_name': None,
+        'running': False,
+        'frame': 0,
+        'selected_idx': 0,
+        'asset_names': None,   # None = not yet fetched
+        'fetching': False,
+        'status': '',
+        'error': '',
+    }
 
-    if gui:
-        import polyscope as ps
-        import polyscope.imgui as imgui
-        from uipc.gui import SceneGUI
+    # ── helper: (re-)load a scene into Polyscope ──────────────────
+    def _load_scene(asset_name: str) -> None:
+        try:
+            ps.remove_all_structures()
 
-        ps.init()
-        scene_gui = SceneGUI(scene)
-        scene_gui.register()
-        scene_gui.set_edge_width(1.0)
-        _auto_camera(scene, distance_factor)
+            scene = Scene(Scene.default_config())
+            load(asset_name, scene, revision=revision, cache_dir=cache_dir,
+                 local_dir=local_dir)
 
-        state = {'running': False, 'frame': 0}
+            if is_simulation:
+                ws = workspace or tempfile.mkdtemp(
+                    prefix=f'uipc_{asset_name}_'
+                )
+                engine = Engine(backend, ws)
+            else:
+                engine = Engine('none')
+            world = World(engine)
+            world.init(scene)
 
-        def _callback():
-            changed, state['running'] = imgui.Checkbox(
+            scene_gui = SceneGUI(scene, surf_type='split')
+            scene_gui.register()
+            scene_gui.set_edge_width(1.0)
+            _auto_camera(scene, distance_factor)
+
+            state['scene'] = scene
+            state['engine'] = engine
+            state['world'] = world
+            state['scene_gui'] = scene_gui
+            state['current_name'] = asset_name
+            state['running'] = False
+            state['frame'] = 0
+            state['status'] = f'Loaded: {asset_name}'
+            state['error'] = ''
+        except Exception as exc:
+            state['error'] = str(exc)
+            state['status'] = f'Error loading {asset_name}'
+
+    # ── helper: fetch asset list in a background thread ───────────
+    def _fetch_assets() -> None:
+        try:
+            names = list_assets(revision=revision, local_dir=local_dir)
+            state['asset_names'] = names
+            # Pre-select the currently loaded scene, if any.
+            if state['current_name'] and state['current_name'] in names:
+                state['selected_idx'] = names.index(state['current_name'])
+        except Exception as exc:
+            state['asset_names'] = []
+            state['error'] = f'Failed to fetch asset list: {exc}'
+        finally:
+            state['fetching'] = False
+
+    # ── ImGui callback ────────────────────────────────────────────
+    def _callback() -> None:
+        # ---- Asset Selector section ----
+        imgui.TextUnformatted('Asset Selector')
+        imgui.Separator()
+
+        names = state['asset_names']
+
+        # Kick off the background fetch once.
+        if names is None and not state['fetching']:
+            state['fetching'] = True
+            threading.Thread(target=_fetch_assets, daemon=True).start()
+
+        if state['fetching']:
+            imgui.TextUnformatted('Fetching asset list...')
+        elif names is not None and len(names) > 0:
+            # Scrollable list of assets.
+            line_h = imgui.GetTextLineHeightWithSpacing()
+            list_h = min(len(names), 15) * line_h
+            if imgui.BeginListBox('##assets', (0.0, list_h)):
+                for i, n in enumerate(names):
+                    is_cur = (i == state['selected_idx'])
+                    if imgui.Selectable(n, selected=is_cur):
+                        state['selected_idx'] = i
+                imgui.EndListBox()
+
+            # Read-only text box showing the selected name (user can copy).
+            sel = names[state['selected_idx']]
+            imgui.InputText('##selected', sel,
+                            imgui.ImGuiInputTextFlags_ReadOnly)
+
+            if imgui.Button('Load'):
+                state['status'] = f'Loading {sel}...'
+                _load_scene(sel)
+        elif names is not None:
+            imgui.TextUnformatted('No assets found.')
+
+        # Status / error feedback.
+        if state['status']:
+            imgui.TextUnformatted(state['status'])
+        if state['error']:
+            imgui.TextColored((1.0, 0.4, 0.4, 1.0), state['error'])
+
+        # ---- Scene Parameters section ----
+        if state['scene'] is not None:
+            imgui.Separator()
+            if imgui.CollapsingHeader('Scene Config'):
+                scene = state['scene']
+                cfg = scene.config()
+                _show_scene_config(imgui, cfg)
+
+            if imgui.CollapsingHeader('Contact Tabular'):
+                scene = state['scene']
+                ct = scene.contact_tabular()
+                _show_contact_tabular(imgui, ct)
+
+            # Re-init world with updated parameters
+            if is_simulation and state['world'] is not None:
+                if imgui.Button('Re-init'):
+                    try:
+                        scene = state['scene']
+                        ws = workspace or tempfile.mkdtemp(
+                            prefix=f'uipc_{state["current_name"]}_'
+                        )
+                        engine = Engine(backend, ws)
+                        world = World(engine)
+                        world.init(scene)
+                        ps.remove_all_structures()
+                        scene_gui = SceneGUI(scene, surf_type='split')
+                        scene_gui.register()
+                        scene_gui.set_edge_width(1.0)
+                        state['engine'] = engine
+                        state['world'] = world
+                        state['scene_gui'] = scene_gui
+                        state['running'] = False
+                        state['frame'] = 0
+                        state['status'] = f'Re-init: {state["current_name"]}'
+                        state['error'] = ''
+                    except Exception as exc:
+                        state['error'] = str(exc)
+
+        # ---- Simulation controls (only for real backends) ----
+        if is_simulation and state['world'] is not None:
+            imgui.Separator()
+            _, state['running'] = imgui.Checkbox(
                 'Run', state['running']
             )
             imgui.SameLine()
             imgui.TextUnformatted(f"frame: {state['frame']}")
 
-            if state['running'] and world.is_valid():
-                world.advance()
-                world.sync()
-                world.retrieve()
-                scene_gui.update()
+            if state['running'] and state['world'].is_valid():
+                state['world'].advance()
+                state['world'].sync()
+                state['world'].retrieve()
+                state['scene_gui'].update()
                 state['frame'] += 1
 
-        ps.set_user_callback(_callback)
-        ps.show()
-    else:
-        while world.is_valid():
-            world.advance()
-            world.sync()
-            world.retrieve()
-
-
-def show(
-    name: str,
-    *,
-    revision: str = 'main',
-    cache_dir: str | None = None,
-    distance_factor: float = 2.0,
-) -> None:
-    """Download an asset, build its scene, and display it in a Polyscope window.
-
-    This is a convenience one-liner for quick visual inspection::
-
-        from uipc.assets import show
-        show('cube_ground')
-
-    The camera is automatically positioned based on the scene bounding box:
-    it looks at the center from a 45-degree elevation, pulled back by
-    *distance_factor* times the bounding-box diagonal length.
-
-    Args:
-        name: Asset name (e.g. ``'cube_ground'``).
-        revision: Git revision (branch, tag, or commit hash).
-        cache_dir: Where to cache downloaded files.
-        distance_factor: How far the camera sits relative to the bounding-box
-                         diagonal (default ``2.0``).
-    """
-    import numpy as np
-    import polyscope as ps
-    from uipc import Engine, World
-    from uipc.gui import SceneGUI
-
-    scene = Scene(Scene.default_config())
-    load(name, scene, revision=revision, cache_dir=cache_dir)
-
-    engine = Engine('none')
-    world = World(engine)
-    world.init(scene)
-
+    # ── Initialise Polyscope and (optionally) preload a scene ─────
     ps.init()
-    gui = SceneGUI(scene)
-    gui.register()
-    gui.set_edge_width(1.0)
 
-    _auto_camera(scene, distance_factor)
+    if name is not None:
+        _load_scene(name)
+
+    ps.set_user_callback(_callback)
     ps.show()
 
 

--- a/python/src/uipc/gui.py
+++ b/python/src/uipc/gui.py
@@ -179,24 +179,28 @@ class SceneGUI:
     def _set_ground(self, ground_name):
         objs = self.scene.objects().find(ground_name)
         if len(objs) == 0:
+            ps.set_ground_plane_mode("none")
             return
+
         ground_obj:core.Object = objs[0]
         ids = ground_obj.geometries().ids()
         if len(ids) == 0:
+            ps.set_ground_plane_mode("none")
             return
+
         id = ids[0]
         geo_slot, rest_geo_slot = self.scene.geometries().find(id)
         if geo_slot is None:
+            ps.set_ground_plane_mode("none")
             return
+
         P = geo_slot.geometry().instances().find('P')
         N = geo_slot.geometry().instances().find('N')
-        if P is None:
+        if P is None or N is None:
+            ps.set_ground_plane_mode("none")
             return
-        if N is None:
-            return
-        
+
         normal = N.view()[0]
-        
         normal = normal.flatten()
         if np.allclose(normal, [0, 1, 0]):
             ps.set_up_dir("y_up")
@@ -205,9 +209,11 @@ class SceneGUI:
         elif np.allclose(normal, [0, 0, 1]):
             ps.set_up_dir("z_up")
         else:
+            ps.set_ground_plane_mode("none")
             return
-        
+
         height = float(P.view()[0][1][0])
+        ps.set_ground_plane_mode("shadow_only")
         ps.set_ground_plane_height(height)
 
     def update(self):


### PR DESCRIPTION
﻿## Summary

Unify un() and show() into a single show() function with an interactive Polyscope GUI for browsing, inspecting, and simulating UIPC assets.

### New show() API

`python
from uipc.assets import show

show()                               # browse assets (geometry only)
show('cube_ground')                  # preload one scene
show('cube_ground', backend='cuda')  # preload + live simulation
show(backend='cuda')                 # browse, simulate what you pick
show(local_dir='uipc-assets/assets') # browse local assets (no network)
`

### GUI Panels

- **Asset Selector** 鈥?scrollable list of all assets with hot-reload, read-only text box for copying names
- **Scene Config** 鈥?all ~30 config parameters organized by category (Time & Physics, Contact, Newton Solver, Linear System, Line Search, Misc) with editable controls
- **Contact Tabular** 鈥?element list with names, editable default model (friction, resistance, enabled), editable pairwise models
- **Simulation Controls** 鈥?Run/Pause checkbox + frame counter (only when `backend != 'none'`)
- **Re-init** button to rebuild Engine/World with updated parameters

### Other changes

- `run()` is removed 鈥?`show()` with `backend` parameter replaces it
- `local_dir` parameter added to `list_assets()`, `asset_path()`, `load()`, `show()` for local development
- `SceneGUI` uses `surf_type='split'` for per-geometry rendering
- Ground plane mode properly toggled (`shadow_only` / `none`) when switching scenes
- `_set_ground()` in `gui.py` now explicitly disables ground on every failure path

### Breaking changes

- `run()` is removed from `uipc.assets` (use `show(name, backend='cuda')` instead)
