### PR TITLE
fix(pybind): accept numpy mass matrix in affine apply_to

### DIFF
--- a/src/pybind/pyuipc/constitution/affine_body_constitution.cpp
+++ b/src/pybind/pyuipc/constitution/affine_body_constitution.cpp
@@ -26,9 +26,8 @@ Returns:
 
     class_AffineBodyConstitution.def(
         "apply_to",
-        static_cast<void (AffineBodyConstitution::*)(
-            geometry::SimplicialComplex&, Float, Float) const>(
-            &AffineBodyConstitution::apply_to),
+        [](const AffineBodyConstitution& self, geometry::SimplicialComplex& sc, Float kappa, Float mass_density)
+        { self.apply_to(sc, kappa, mass_density); },
         py::arg("sc"),
         py::arg("kappa"),
         py::arg("mass_density") = 1000.0,
@@ -40,9 +39,12 @@ Args:
 
     class_AffineBodyConstitution.def(
         "apply_to",
-        static_cast<void (AffineBodyConstitution::*)(
-            geometry::SimplicialComplex&, Float, const Matrix12x12&, Float) const>(
-            &AffineBodyConstitution::apply_to),
+        [](const AffineBodyConstitution& self,
+           geometry::SimplicialComplex&  sc,
+           Float                         kappa,
+           py::array_t<Float>            mass,
+           Float                         volume)
+        { self.apply_to(sc, kappa, to_matrix<Matrix12x12>(mass), volume); },
         py::arg("sc"),
         py::arg("kappa"),
         py::arg("mass"),


### PR DESCRIPTION
## Summary
- update `AffineBodyConstitution.apply_to` pybind bindings to use lambda wrappers for both overloads
- change the explicit ABD-mass overload to accept `py::array_t<Float>` and convert with `to_matrix<Matrix12x12>`
- keep argument order and docs unchanged so Python API stays backward compatible except improved NumPy ergonomics

## Test plan
- [x] run `clang-format -i src/pybind/pyuipc/constitution/affine_body_constitution.cpp`
- [ ] build `pyuipc` locally (`cmake --build ... --target pyuipc`)
- [ ] verify post-build stub generation succeeds and signatures are correct
