### PR TITLE
Improve stitch-family readability and fail-fast validation

### DIFF
--- a/src/constitution/soft_vertex_edge_stitch.cpp
+++ b/src/constitution/soft_vertex_edge_stitch.cpp
@@ -61,12 +61,12 @@ static void validate_stitched_vert_edge_ids(const SoftVertexEdgeStitch::SlotTupl
                 rest_edge_slot->geometry().instances().size());
 
     const auto vert_count = aim_v_slot->geometry().vertices().size();
-    const auto edge_count = rest_edge_slot->geometry().edges().size();
+    const auto edge_count = aim_edge_slot->geometry().edges().size();
 
     for(auto&& [pair_idx, pair] : enumerate(stitched_vert_edge_ids))
     {
-        auto v_id    = pair(0);
-        auto edge_id = pair(1);
+        auto v_id    = pair.x();
+        auto edge_id = pair.y();
 
         UIPC_ASSERT(v_id >= 0 && v_id < vert_count,
                     "SoftVertexEdgeStitch pair[{}].x={} out of range [0, {}) for first geometry slot id {}.",

--- a/src/constitution/soft_vertex_stitch.cpp
+++ b/src/constitution/soft_vertex_stitch.cpp
@@ -44,8 +44,8 @@ static void validate_stitch_pairs(const SoftVertexStitch::SlotTuple& aim_geo_slo
 
     for(auto&& [pair_idx, pair] : enumerate(stitched_vert_ids))
     {
-        auto i = pair[0];
-        auto j = pair[1];
+        auto i = pair.x();
+        auto j = pair.y();
 
         UIPC_ASSERT(i >= 0 && i < l_vert_count,
                     "SoftVertexStitch pair[{}].x={} out of range [0, {}) for first geometry slot id {}.",

--- a/src/constitution/soft_vertex_triangle_stitch.cpp
+++ b/src/constitution/soft_vertex_triangle_stitch.cpp
@@ -61,12 +61,12 @@ static void validate_stitched_vert_tri_ids(const SoftVertexTriangleStitch::SlotT
                 rest_tri_slot->geometry().instances().size());
 
     const auto vert_count = aim_v_slot->geometry().vertices().size();
-    const auto tri_count  = rest_tri_slot->geometry().triangles().size();
+    const auto tri_count  = aim_tri_slot->geometry().triangles().size();
 
     for(auto&& [pair_idx, pair] : enumerate(stitched_vert_tri_ids))
     {
-        auto v_id   = pair(0);
-        auto tri_id = pair(1);
+        auto v_id   = pair.x();
+        auto tri_id = pair.y();
 
         UIPC_ASSERT(v_id >= 0 && v_id < vert_count,
                     "SoftVertexTriangleStitch pair[{}].x={} out of range [0, {}) for first geometry slot id {}.",


### PR DESCRIPTION
## Summary
- Add centralized fail-fast stitch index validation in `SoftVertexStitch`, `SoftVertexTriangleStitch`, and `SoftVertexEdgeStitch` before topology expansion.
- Standardize pair iteration readability by using cppitertools `enumerate(...)` for per-pair diagnostics and consistent indexing.
- Remove duplicated late-stage slot/index asserts now covered by the shared validators.

## Test plan
- [x] `cmake --build . --config RelWithDebInfo --target sim_case`
- [x] `uipc_test_sim_case.exe 39_soft_vertex_stitch`
- [x] `uipc_test_sim_case.exe 67_soft_vertex_triangle_stitch`
- [x] `uipc_test_sim_case.exe 68_soft_vertex_edge_stitch`