### PR TITLE
feat(gui): unify scene panels and expose animator metadata

### DIFF
--- a/include/uipc/core/animator.h
+++ b/include/uipc/core/animator.h
@@ -22,6 +22,9 @@ class UIPC_CORE_API Animator
   public:
     void  substep(SizeT n) noexcept;
     SizeT substep() const noexcept;
+    SizeT animation_count() const noexcept;
+    bool  has_animation(IndexT id) const noexcept;
+    vector<IndexT> animation_ids() const;
 
     void insert(Object& obj, Animation::ActionOnUpdate&& on_update);
     void erase(IndexT id);

--- a/python/src/uipc/assets/__init__.py
+++ b/python/src/uipc/assets/__init__.py
@@ -34,7 +34,7 @@ import importlib.util
 import pathlib
 
 from huggingface_hub import HfApi, RepoFolder, snapshot_download
-from uipc import Scene, SceneIO, Vector3, view
+from uipc import Scene, SceneIO
 from uipc.geometry import SimplicialComplex, SimplicialComplexIO
 
 REPO_ID = 'MuGdxy/uipc-assets'
@@ -238,184 +238,6 @@ def load(
         strip_constitutions(scene)
 
 
-def _show_scene_config(imgui, cfg) -> None:
-    """Render all scene config attributes as ImGui controls."""
-
-    def _float(key: str, label: str, fmt: str = '%.6f'):
-        attr = cfg.find(key)
-        if attr is None:
-            return
-        val = float(view(attr)[0])
-        changed, new_val = imgui.InputFloat(label, val, 0.0, 0.0, fmt)
-        if changed:
-            view(attr)[0] = new_val
-
-    def _int(key: str, label: str, step: int = 1, step_fast: int = 10):
-        attr = cfg.find(key)
-        if attr is None:
-            return
-        val = int(view(attr)[0])
-        changed, new_val = imgui.InputInt(label, val, step, step_fast)
-        if changed:
-            view(attr)[0] = new_val
-
-    def _bool(key: str, label: str):
-        attr = cfg.find(key)
-        if attr is None:
-            return
-        val = bool(int(view(attr)[0]))
-        changed, new_val = imgui.Checkbox(label, val)
-        if changed:
-            view(attr)[0] = int(new_val)
-
-    def _vec3(key: str, label: str):
-        attr = cfg.find(key)
-        if attr is None:
-            return
-        g = view(attr)[0]
-        gv = [float(g[0][0]), float(g[1][0]), float(g[2][0])]
-        changed, new_g = imgui.DragFloat3(label, gv, 0.1, -100.0, 100.0, '%.2f')
-        if changed:
-            view(attr)[0] = Vector3.Values(new_g)
-
-    def _str(key: str, label: str):
-        attr = cfg.find(key)
-        if attr is None:
-            return
-        val = str(view(attr)[0])
-        imgui.InputText(label, val, imgui.ImGuiInputTextFlags_ReadOnly)
-
-    # ── Time & Physics ────────────────────────────────────────
-    if imgui.TreeNode('Time & Physics'):
-        _float('dt', 'dt')
-        _vec3('gravity', 'gravity')
-        imgui.TreePop()
-
-    # ── Contact ───────────────────────────────────────────────
-    if imgui.TreeNode('Contact'):
-        _bool('contact/enable', 'enable')
-        _bool('contact/friction/enable', 'friction')
-        _str('contact/constitution', 'constitution')
-        _float('contact/d_hat', 'd_hat', '%.6e')
-        _float('contact/eps_velocity', 'eps_velocity', '%.6e')
-        _float('contact/adaptive/min_kappa', 'min_kappa', '%.6e')
-        _float('contact/adaptive/init_kappa', 'init_kappa', '%.6e')
-        _float('contact/adaptive/max_kappa', 'max_kappa', '%.6e')
-        imgui.TreePop()
-
-    # ── Newton Solver ─────────────────────────────────────────
-    if imgui.TreeNode('Newton Solver'):
-        _int('newton/max_iter', 'max_iter')
-        _int('newton/min_iter', 'min_iter')
-        _bool('newton/use_adaptive_tol', 'adaptive_tol')
-        _float('newton/velocity_tol', 'velocity_tol', '%.6e')
-        _float('newton/ccd_tol', 'ccd_tol', '%.4f')
-        _float('newton/transrate_tol', 'transrate_tol', '%.6e')
-        _bool('newton/semi_implicit/enable', 'semi_implicit')
-        _float('newton/semi_implicit/beta_tol', 'beta_tol', '%.6e')
-        imgui.TreePop()
-
-    # ── Linear System ─────────────────────────────────────────
-    if imgui.TreeNode('Linear System'):
-        _float('linear_system/tol_rate', 'tol_rate', '%.6e')
-        _str('linear_system/solver', 'solver')
-        _bool('linear_system/precond/mas/contact_aware', 'contact_aware')
-        imgui.TreePop()
-
-    # ── Line Search ───────────────────────────────────────────
-    if imgui.TreeNode('Line Search'):
-        _int('line_search/max_iter', 'max_iter')
-        _bool('line_search/report_energy', 'report_energy')
-        imgui.TreePop()
-
-    # ── Misc ──────────────────────────────────────────────────
-    if imgui.TreeNode('Misc'):
-        _str('integrator/type', 'integrator')
-        _bool('cfl/enable', 'CFL')
-        _str('collision_detection/method', 'collision method')
-        _bool('sanity_check/enable', 'sanity_check')
-        _str('sanity_check/mode', 'sanity_mode')
-        _bool('diff_sim/enable', 'diff_sim')
-        _bool('extras/strict_mode/enable', 'strict_mode')
-        _bool('extras/debug/dump_surface', 'dump_surface')
-        _bool('extras/debug/dump_linear_system', 'dump_linear_sys')
-        _bool('extras/debug/dump_linear_pcg', 'dump_linear_pcg')
-        imgui.TreePop()
-
-
-def _show_contact_tabular(imgui, ct) -> None:
-    """Render editable contact tabular as ImGui controls."""
-    n = ct.element_count()
-
-    # Build element name lookup: id → name.
-    de = ct.default_element()
-    elem_names = {de.id(): de.name() or 'default'}
-
-    imgui.TextUnformatted(f'Elements: {n}')
-
-    # Show element list with names.
-    if imgui.TreeNode('Elements'):
-        for i in range(n):
-            name = elem_names.get(i, f'element_{i}')
-            imgui.TextUnformatted(f'  [{i}] {name}')
-        imgui.TreePop()
-
-    # ── Default model (editable) ──────────────────────────────
-    def_name = elem_names.get(de.id(), 'default')
-    if imgui.TreeNode(f'Default model ({def_name})'):
-        dm = ct.default_model()
-        fr = dm.friction_rate()
-        res = dm.resistance()
-        ena = dm.is_enabled()
-
-        ch_f, new_fr = imgui.InputFloat('friction##def', fr, 0.0, 0.0, '%.4f')
-        ch_r, new_res = imgui.InputFloat('resistance##def', res, 0.0, 0.0, '%.2e')
-        ch_e, new_ena = imgui.Checkbox('enabled##def', ena)
-
-        if ch_f or ch_r or ch_e:
-            ct.default_model(
-                new_fr if ch_f else fr,
-                new_res if ch_r else res,
-                new_ena if ch_e else ena,
-            )
-        imgui.TreePop()
-
-    # ── Pairwise models (editable) ────────────────────────────
-    if n > 1 and imgui.TreeNode('Pairwise models'):
-        for i in range(n):
-            for j in range(i, n):
-                m = ct.at(i, j)
-                ni = elem_names.get(i, f'element_{i}')
-                nj = elem_names.get(j, f'element_{j}')
-                tag = f'##{i}_{j}'
-                header = f'{ni} <-> {nj}{tag}'
-                if imgui.TreeNode(header):
-                    fr = m.friction_rate()
-                    res = m.resistance()
-                    ena = m.is_enabled()
-
-                    ch_f, new_fr = imgui.InputFloat(
-                        f'friction{tag}', fr, 0.0, 0.0, '%.4f',
-                    )
-                    ch_r, new_res = imgui.InputFloat(
-                        f'resistance{tag}', res, 0.0, 0.0, '%.2e',
-                    )
-                    ch_e, new_ena = imgui.Checkbox(f'enabled{tag}', ena)
-
-                    if ch_f or ch_r or ch_e:
-                        from uipc.core import ContactElement
-                        L = ContactElement(i, '')
-                        R = ContactElement(j, '')
-                        ct.insert(
-                            L, R,
-                            new_fr if ch_f else fr,
-                            new_res if ch_r else res,
-                            new_ena if ch_e else ena,
-                        )
-                    imgui.TreePop()
-        imgui.TreePop()
-
-
 def show(
     name: str | None = None,
     backend: str = 'none',
@@ -429,10 +251,12 @@ def show(
 ) -> None:
     """Display and optionally simulate a UIPC asset in a Polyscope window.
 
-    Opens an interactive viewer with an **Asset Selector** panel that lists
-    every available asset.  You can pick any scene and hot-load it without
-    restarting.  When *backend* is a real engine (e.g. ``'cuda'``), a
-    **Run / Pause** control is shown as well.
+    Opens an interactive viewer with a collapsable **Asset Selector** panel
+    that lists every available asset. You can pick any scene and hot-load it
+    without restarting. Once loaded, the GUI shows the source directory and
+    ``scene.py`` path for the current scene, and supports exporting the scene
+    snapshot from a native save dialog. When *backend* is a real engine
+    (e.g. ``'cuda'``), a **Run / Pause** control is shown as well.
 
     Supports both remote assets (from HuggingFace) and local asset
     directories for development::
@@ -513,6 +337,8 @@ def show(
         'selected_idx': 0,
         'asset_names': None,   # None = not yet fetched
         'fetching': False,
+        'source_dir': '',
+        'scene_file': '',
         'status': '',
         'error': '',
     }
@@ -523,6 +349,13 @@ def show(
             ps.remove_all_structures()
 
             scene = Scene(Scene.default_config())
+            source_dir = asset_path(
+                asset_name,
+                revision=revision,
+                cache_dir=cache_dir,
+                local_repo=local_repo,
+            )
+            scene_file = source_dir / 'scene.py'
             load(
                 asset_name,
                 scene,
@@ -553,6 +386,8 @@ def show(
             state['current_name'] = asset_name
             state['running'] = False
             state['frame'] = 0
+            state['source_dir'] = str(source_dir.resolve())
+            state['scene_file'] = str(scene_file.resolve())
             state['status'] = f'Loaded: {asset_name}'
             state['error'] = ''
         except Exception as exc:
@@ -576,12 +411,43 @@ def show(
         finally:
             state['fetching'] = False
 
+    def _pick_save_path(asset_name: str, source_dir: str) -> pathlib.Path | None:
+        """Open a native file-save dialog and return selected path."""
+        try:
+            import tkinter as tk
+            from tkinter import filedialog
+        except Exception as exc:
+            raise RuntimeError(
+                f'Native file dialog is unavailable: {exc}'
+            ) from exc
+
+        initial_dir = source_dir or str(pathlib.Path.cwd())
+        initial_file = f'{asset_name}.json'
+
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes('-topmost', True)
+        try:
+            chosen = filedialog.asksaveasfilename(
+                title='Save Scene',
+                defaultextension='.json',
+                filetypes=[
+                    ('JSON file', '*.json'),
+                    ('BSON file', '*.bson'),
+                    ('All files', '*.*'),
+                ],
+                initialdir=initial_dir,
+                initialfile=initial_file,
+            )
+        finally:
+            root.destroy()
+
+        if not chosen:
+            return None
+        return pathlib.Path(chosen)
+
     # ── ImGui callback ────────────────────────────────────────────
     def _callback() -> None:
-        # ---- Asset Selector section ----
-        imgui.TextUnformatted('Asset Selector')
-        imgui.Separator()
-
         names = state['asset_names']
 
         # Kick off the background fetch once.
@@ -589,29 +455,34 @@ def show(
             state['fetching'] = True
             threading.Thread(target=_fetch_assets, daemon=True).start()
 
-        if state['fetching']:
-            imgui.TextUnformatted('Fetching asset list...')
-        elif names is not None and len(names) > 0:
-            # Scrollable list of assets.
-            line_h = imgui.GetTextLineHeightWithSpacing()
-            list_h = min(len(names), 15) * line_h
-            if imgui.BeginListBox('##assets', (0.0, list_h)):
-                for i, n in enumerate(names):
-                    is_cur = (i == state['selected_idx'])
-                    if imgui.Selectable(n, selected=is_cur):
-                        state['selected_idx'] = i
-                imgui.EndListBox()
+        # ---- Asset Selector section ----
+        if imgui.CollapsingHeader('Asset Selector'):
+            if state['fetching']:
+                imgui.TextUnformatted('Fetching asset list...')
+            elif names is not None and len(names) > 0:
+                # Scrollable list of assets.
+                line_h = imgui.GetTextLineHeightWithSpacing()
+                list_h = min(len(names), 15) * line_h
+                if imgui.BeginListBox('##assets', (0.0, list_h)):
+                    for i, n in enumerate(names):
+                        is_cur = (i == state['selected_idx'])
+                        if imgui.Selectable(n, selected=is_cur):
+                            state['selected_idx'] = i
+                    imgui.EndListBox()
 
-            # Read-only text box showing the selected name (user can copy).
-            sel = names[state['selected_idx']]
-            imgui.InputText('##selected', sel,
-                            imgui.ImGuiInputTextFlags_ReadOnly)
+                # Read-only text box showing the selected name (user can copy).
+                sel = names[state['selected_idx']]
+                imgui.InputText(
+                    '##selected',
+                    sel,
+                    imgui.ImGuiInputTextFlags_ReadOnly,
+                )
 
-            if imgui.Button('Load'):
-                state['status'] = f'Loading {sel}...'
-                _load_scene(sel)
-        elif names is not None:
-            imgui.TextUnformatted('No assets found.')
+                if imgui.Button('Load'):
+                    state['status'] = f'Loading {sel}...'
+                    _load_scene(sel)
+            elif names is not None:
+                imgui.TextUnformatted('No assets found.')
 
         # Status / error feedback.
         if state['status']:
@@ -621,16 +492,30 @@ def show(
 
         # ---- Scene Parameters section ----
         if state['scene'] is not None:
-            imgui.Separator()
-            if imgui.CollapsingHeader('Scene Config'):
-                scene = state['scene']
-                cfg = scene.config()
-                _show_scene_config(imgui, cfg)
+            def _on_save_scene() -> None:
+                try:
+                    save_path = _pick_save_path(
+                        state['current_name'],
+                        state['source_dir'],
+                    )
+                    if save_path is not None:
+                        sio = SceneIO(state['scene'])
+                        sio.save(str(save_path))
+                        state['status'] = f'Saved scene: {save_path}'
+                        state['error'] = ''
+                    else:
+                        state['status'] = 'Save canceled.'
+                except Exception as exc:
+                    state['error'] = f'Failed to save scene: {exc}'
 
-            if imgui.CollapsingHeader('Contact Tabular'):
-                scene = state['scene']
-                ct = scene.contact_tabular()
-                _show_contact_tabular(imgui, ct)
+            imgui.Separator()
+            state['scene_gui'].show(
+                imgui,
+                current_name=state['current_name'],
+                source_dir=state['source_dir'],
+                scene_file=state['scene_file'],
+                on_save_scene=_on_save_scene,
+            )
 
             # Re-init world with updated parameters
             if is_simulation and state['world'] is not None:

--- a/python/src/uipc/gui.py
+++ b/python/src/uipc/gui.py
@@ -1,10 +1,10 @@
 import polyscope as ps
-from uipc import Scene, SceneIO
+from uipc import Scene, SceneIO, Vector3, view
 from uipc import builtin
 from uipc import core
 from uipc.backend import SceneVisitor
 from uipc.geometry import SimplicialComplexSlot, SimplicialComplex, extract_surface, apply_transform, merge
-from typing import Literal
+from typing import Callable, Literal
 import numpy as np
 
 # only export SceneGUI
@@ -221,3 +221,363 @@ class SceneGUI:
     
     def set_edge_width(self, width:float):
         self.gui.set_edge_width(width)
+    
+    def show(
+        self,
+        imgui,
+        *,
+        current_name: str | None = None,
+        source_dir: str = '',
+        scene_file: str = '',
+        on_save_scene: Callable[[], None] | None = None,
+    ) -> None:
+        """Render all scene-related information panels."""
+        imgui.TextUnformatted(f'Current Asset: {current_name or ""}')
+        imgui.InputText(
+            'Source Dir',
+            source_dir,
+            imgui.ImGuiInputTextFlags_ReadOnly,
+        )
+        imgui.InputText(
+            'Scene File',
+            scene_file,
+            imgui.ImGuiInputTextFlags_ReadOnly,
+        )
+
+        if on_save_scene is not None and imgui.Button('Save Scene'):
+            on_save_scene()
+
+        imgui.Separator()
+        
+        if imgui.CollapsingHeader('Scene Config'):
+            self._show_scene_config(imgui, self.scene.config())
+
+        if imgui.CollapsingHeader('Contact Tabular'):
+            self._show_contact_tabular(imgui, self.scene.contact_tabular())
+
+        if imgui.CollapsingHeader('Animator'):
+            self._show_animator_info(imgui)
+
+
+    def _show_scene_config(self, imgui, cfg) -> None:
+        """Render scene config by traversing config keys dynamically."""
+        def _try_vec3(raw) -> list[float] | None:
+            try:
+                return [float(raw[0][0]), float(raw[1][0]), float(raw[2][0])]
+            except Exception:
+                return None
+
+        def _show_scalar(path: str, label: str) -> None:
+            attr = cfg.find(path)
+            if attr is None:
+                imgui.TextUnformatted(f'{label}: <missing>')
+                return
+
+            widget_label = f'{label}##{path}'
+            slot = view(attr)
+            raw = slot[0]
+            try:
+                type_name = str(attr.type_name())
+            except Exception:
+                type_name = ''
+            t_upper = type_name.upper()
+
+            if 'STRING' in t_upper or isinstance(raw, str):
+                imgui.InputText(widget_label, raw, imgui.ImGuiInputTextFlags_ReadOnly)
+                return
+
+            if isinstance(raw, (bool, np.bool_)):
+                cur = bool(raw)
+                changed, new_val = imgui.Checkbox(widget_label, cur)
+                if changed:
+                    slot[0] = int(new_val)
+                return
+
+            if path.endswith('/enable') or path == 'enable':
+                try:
+                    cur = bool(int(raw))
+                    changed, new_val = imgui.Checkbox(widget_label, cur)
+                    if changed:
+                        slot[0] = int(new_val)
+                    return
+                except Exception:
+                    pass
+
+            if 'VECTOR3' in t_upper and 'VECTOR3I' not in t_upper:
+                vec3 = _try_vec3(raw)
+                if vec3 is None:
+                    imgui.InputText(
+                        widget_label,
+                        str(raw),
+                        imgui.ImGuiInputTextFlags_ReadOnly,
+                    )
+                    return
+                changed, new_g = imgui.DragFloat3(
+                    widget_label, vec3, 0.1, -100.0, 100.0, '%.2f'
+                )
+                if changed:
+                    slot[0] = Vector3.Values(new_g)
+                return
+
+            if (
+                'FLOAT' in t_upper
+                or ('VECTOR' in t_upper and 'VECTOR3I' not in t_upper and 'VECTOR2I' not in t_upper and 'VECTOR4I' not in t_upper)
+                or 'MATRIX' in t_upper
+                or isinstance(raw, (float, np.floating))
+            ):
+                if not np.isscalar(raw):
+                    imgui.InputText(
+                        widget_label,
+                        str(raw),
+                        imgui.ImGuiInputTextFlags_ReadOnly,
+                    )
+                    return
+                cur = float(raw)
+                changed, new_val = imgui.InputFloat(
+                    widget_label, cur, 0.0, 0.0, '%.6g'
+                )
+                if changed:
+                    slot[0] = new_val
+                return
+
+            if (
+                any(tok in t_upper for tok in ('I32', 'I64', 'U32', 'U64', 'VECTOR2I', 'VECTOR3I', 'VECTOR4I'))
+                or isinstance(raw, (int, np.integer))
+            ):
+                if not np.isscalar(raw):
+                    imgui.InputText(
+                        widget_label,
+                        str(raw),
+                        imgui.ImGuiInputTextFlags_ReadOnly,
+                    )
+                    return
+                cur = int(raw)
+                changed, new_val = imgui.InputInt(widget_label, cur, 1, 10)
+                if changed:
+                    slot[0] = new_val
+                return
+
+            val = str(raw)
+            imgui.InputText(widget_label, val, imgui.ImGuiInputTextFlags_ReadOnly)
+
+        def _build_tree(paths: list[str]) -> dict:
+            root: dict = {}
+            for path in paths:
+                node = root
+                parts = [p for p in path.split('/') if p]
+                for p in parts:
+                    node = node.setdefault(p, {})
+                node['__path__'] = path
+            return root
+
+        preferred_order = [
+            'dt',
+            'gravity',
+            'cfl/enable',
+            'integrator/type',
+            'newton/max_iter',
+            'newton/min_iter',
+            'newton/use_adaptive_tol',
+            'newton/velocity_tol',
+            'newton/ccd_tol',
+            'newton/transrate_tol',
+            'newton/semi_implicit/enable',
+            'newton/semi_implicit/beta_tol',
+            'linear_system/tol_rate',
+            'linear_system/solver',
+            'linear_system/precond/mas/contact_aware',
+            'line_search/max_iter',
+            'line_search/report_energy',
+            'contact/enable',
+            'contact/friction/enable',
+            'contact/constitution',
+            'contact/d_hat',
+            'contact/adaptive/min_kappa',
+            'contact/adaptive/init_kappa',
+            'contact/adaptive/max_kappa',
+            'contact/eps_velocity',
+            'collision_detection/method',
+            'sanity_check/enable',
+            'sanity_check/mode',
+            'diff_sim/enable',
+            'extras/debug/dump_surface',
+            'extras/debug/dump_linear_system',
+            'extras/debug/dump_linear_pcg',
+            'extras/strict_mode/enable',
+        ]
+        order_map = {k: i for i, k in enumerate(preferred_order)}
+        unknown_order = len(preferred_order) + 1
+
+        def _node_min_order(node: dict) -> int:
+            min_order = unknown_order
+            path = node.get('__path__')
+            if isinstance(path, str):
+                min_order = min(min_order, order_map.get(path, unknown_order))
+            for key, child in node.items():
+                if key == '__path__':
+                    continue
+                min_order = min(min_order, _node_min_order(child))
+            return min_order
+
+        def _render_tree(node: dict) -> None:
+            keys = [k for k in node.keys() if k != '__path__']
+            keys.sort(key=lambda k: (_node_min_order(node[k]), k))
+            for key in keys:
+                child = node[key]
+                has_children = any(k != '__path__' for k in child.keys())
+                if has_children:
+                    if imgui.TreeNode(key):
+                        if '__path__' in child:
+                            _show_scalar(child['__path__'], key)
+                        _render_tree(child)
+                        imgui.TreePop()
+                else:
+                    _show_scalar(child.get('__path__', key), key)
+
+        cfg_json = cfg.to_json()
+        if not isinstance(cfg_json, dict):
+            imgui.TextUnformatted('Config is unavailable.')
+            return
+
+        paths = [k for k in cfg_json.keys() if isinstance(k, str)]
+        paths.sort(key=lambda p: (order_map.get(p, unknown_order), p))
+        _render_tree(_build_tree(paths))
+
+    def _show_contact_tabular(self, imgui, ct) -> None:
+        """Render editable contact tabular as ImGui controls."""
+        n = ct.element_count()
+        de = ct.default_element()
+        elem_names = {de.id(): de.name() or 'default'}
+        flags = imgui.ImGuiTableFlags_Borders | imgui.ImGuiTableFlags_RowBg
+        imgui.TextUnformatted(f'Elements: {n}')
+
+        if imgui.BeginTable('contact_elements_table', 2, flags):
+            imgui.TableSetupColumn('ID')
+            imgui.TableSetupColumn('Name')
+            imgui.TableHeadersRow()
+            for i in range(n):
+                imgui.TableNextRow()
+                imgui.TableNextColumn()
+                imgui.TextUnformatted(str(i))
+                imgui.TableNextColumn()
+                imgui.TextUnformatted(elem_names.get(i, f'element_{i}'))
+            imgui.EndTable()
+
+        dm = ct.default_model()
+        fr = dm.friction_rate()
+        res = dm.resistance()
+        ena = dm.is_enabled()
+        if imgui.BeginTable('contact_default_table', 4, flags):
+            imgui.TableSetupColumn('Default')
+            imgui.TableSetupColumn('Friction')
+            imgui.TableSetupColumn('Resistance')
+            imgui.TableSetupColumn('Enabled')
+            imgui.TableHeadersRow()
+            imgui.TableNextRow()
+            imgui.TableNextColumn()
+            imgui.TextUnformatted(elem_names.get(de.id(), 'default'))
+            imgui.TableNextColumn()
+            ch_f, new_fr = imgui.InputFloat('##def_friction', fr, 0.0, 0.0, '%.4f')
+            imgui.TableNextColumn()
+            ch_r, new_res = imgui.InputFloat('##def_resistance', res, 0.0, 0.0, '%.2e')
+            imgui.TableNextColumn()
+            ch_e, new_ena = imgui.Checkbox('##def_enabled', ena)
+            if ch_f or ch_r or ch_e:
+                ct.default_model(
+                    new_fr if ch_f else fr,
+                    new_res if ch_r else res,
+                    new_ena if ch_e else ena,
+                )
+            imgui.EndTable()
+
+        if n > 1 and imgui.BeginTable('contact_pairwise_table', 5, flags):
+            imgui.TableSetupColumn('Left')
+            imgui.TableSetupColumn('Right')
+            imgui.TableSetupColumn('Friction')
+            imgui.TableSetupColumn('Resistance')
+            imgui.TableSetupColumn('Enabled')
+            imgui.TableHeadersRow()
+            for i in range(n):
+                for j in range(i, n):
+                    m = ct.at(i, j)
+                    ni = elem_names.get(i, f'element_{i}')
+                    nj = elem_names.get(j, f'element_{j}')
+                    tag = f'##{i}_{j}'
+                    fr = m.friction_rate()
+                    res = m.resistance()
+                    ena = m.is_enabled()
+
+                    imgui.TableNextRow()
+                    imgui.TableNextColumn()
+                    imgui.TextUnformatted(ni)
+                    imgui.TableNextColumn()
+                    imgui.TextUnformatted(nj)
+                    imgui.TableNextColumn()
+                    ch_f, new_fr = imgui.InputFloat(
+                        f'##friction{tag}', fr, 0.0, 0.0, '%.4f',
+                    )
+                    imgui.TableNextColumn()
+                    ch_r, new_res = imgui.InputFloat(
+                        f'##resistance{tag}', res, 0.0, 0.0, '%.2e',
+                    )
+                    imgui.TableNextColumn()
+                    ch_e, new_ena = imgui.Checkbox(f'##enabled{tag}', ena)
+
+                    if ch_f or ch_r or ch_e:
+                        from uipc.core import ContactElement
+                        L = ContactElement(i, '')
+                        R = ContactElement(j, '')
+                        ct.insert(
+                            L, R,
+                            new_fr if ch_f else fr,
+                            new_res if ch_r else res,
+                            new_ena if ch_e else ena,
+                        )
+            imgui.EndTable()
+
+    def _show_animator_info(self, imgui) -> None:
+        """Render read-only animator information in an ImGui panel."""
+
+        def _show_animator_objects_table(items: list[tuple[int, str]]) -> None:
+            imgui.TextUnformatted('animated_objects:')
+            if len(items) == 0:
+                imgui.TextUnformatted('  (none)')
+                return
+            flags = imgui.ImGuiTableFlags_Borders | imgui.ImGuiTableFlags_RowBg
+            if imgui.BeginTable('animator_objects_table', 2, flags):
+                imgui.TableSetupColumn('Object ID')
+                imgui.TableSetupColumn('Object Name')
+                imgui.TableHeadersRow()
+                for oid, name in items:
+                    imgui.TableNextRow()
+                    imgui.TableNextColumn()
+                    imgui.TextUnformatted(str(oid))
+                    imgui.TableNextColumn()
+                    imgui.TextUnformatted(name)
+                imgui.EndTable()
+
+        try:
+            animator = self.scene.animator()
+            imgui.TextUnformatted(f'substep: {int(animator.substep())}')
+            if hasattr(animator, 'animation_count'):
+                count = int(animator.animation_count())
+                imgui.TextUnformatted(f'animation_count: {count}')
+            if hasattr(animator, 'animation_ids'):
+                ids = [int(i) for i in animator.animation_ids()]
+                table_data: list[tuple[int, str]] = []
+                for oid in ids:
+                    obj = self.scene.objects().find(oid)
+                    if obj is None:
+                        table_data.append((oid, '<missing>'))
+                    else:
+                        table_data.append((oid, obj.name()))
+                _show_animator_objects_table(table_data)
+        except Exception as exc:
+            imgui.TextUnformatted(f'Animator unavailable: {exc}')
+            return
+
+        cfg = self.scene.config()
+        dt_attr = cfg.find('dt')
+        if dt_attr is not None:
+            dt = float(dt_attr.view()[0])
+            imgui.TextUnformatted(f'dt: {dt:.6g}')

--- a/src/core/core/animator.cpp
+++ b/src/core/core/animator.cpp
@@ -1,5 +1,6 @@
 #include <uipc/core/animator.h>
 #include <uipc/common/log.h>
+#include <algorithm>
 namespace uipc::core
 {
 void Animator::substep(SizeT n) noexcept
@@ -11,6 +12,28 @@ void Animator::substep(SizeT n) noexcept
 SizeT Animator::substep() const noexcept
 {
     return m_substep;
+}
+
+SizeT Animator::animation_count() const noexcept
+{
+    return m_animations.size();
+}
+
+bool Animator::has_animation(IndexT id) const noexcept
+{
+    return m_animations.find(id) != m_animations.end();
+}
+
+vector<IndexT> Animator::animation_ids() const
+{
+    vector<IndexT> ids;
+    ids.reserve(m_animations.size());
+    for(const auto& [id, _] : m_animations)
+    {
+        ids.push_back(id);
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
 }
 
 void Animator::insert(Object& obj, Animation::ActionOnUpdate&& on_update)

--- a/src/pybind/pyuipc/core/animator.cpp
+++ b/src/pybind/pyuipc/core/animator.cpp
@@ -1,5 +1,6 @@
 #include <pyuipc/core/animator.h>
 #include <uipc/core/animator.h>
+#include <pybind11/stl.h>
 
 namespace pyuipc::core
 {
@@ -120,5 +121,36 @@ Args:
         R"(Get the substep count.
 Returns:
     int: Number of substeps per frame.)");
+
+    class_Animator.def(
+        "animation_count",
+        &Animator::animation_count,
+        R"(Get the number of animated objects.
+Returns:
+    int: Number of objects that currently have animation callbacks.)");
+
+    class_Animator.def(
+        "has_animation",
+        &Animator::has_animation,
+        py::arg("object_id"),
+        R"(Check whether an object has a registered animation callback.
+Args:
+    object_id: Object id to query.
+Returns:
+    bool: True if the object is animated, False otherwise.)");
+
+    class_Animator.def(
+        "animation_ids",
+        &Animator::animation_ids,
+        R"(Get sorted object ids that have registered animation callbacks.
+Returns:
+    list[int]: Animated object ids.)");
+
+    class_Animator.def(
+        "__repr__",
+        [](const Animator& self) { return fmt::format("{}", self); },
+        R"(String representation of the animator.
+Returns:
+    str: Formatted animator summary.)");
 }
 }  // namespace pyuipc::core


### PR DESCRIPTION
## Summary
- Move scene-related displays into reusable `SceneGUI.show()` and keep panel order stable (`Scene Config`, `Contact Tabular`, `Animator`).
- Add dynamic scene-config traversal/editing with preferred ordering and type-aware widget dispatch from attribute metadata.
- Add animator metadata APIs in core/pybind (`animation_count`, `has_animation`, `animation_ids`) so GUI can render a read-only animator object table.

## Test plan
- [x] Syntax-check updated Python files.
- [x] Launch assets viewer and verify collapsible selector + scene save/source path display.
- [x] Verify scene panels render in target order and contact/animator tables display expected data.
- [x] Verify dynamic scene config fields are editable with correct widget types (e.g., `dt` as float).