### PR TITLE
fix(cuda): bring back missing update paths in CUDA backend

### DIFF
--- a/src/backends/cuda/affine_body/affine_body_vertex_reporter.cu
+++ b/src/backends/cuda/affine_body/affine_body_vertex_reporter.cu
@@ -88,6 +88,9 @@ void AffineBodyVertexReporter::Impl::update_attributes(VertexAttributeInfo& info
                    dst_pos(i)          = src_pos(i).point_x(q);
                });
 
+    // This update will ruin the friction force computed in previous step, so we need to discard it.
+    // ref: https://github.com/spiriMirror/libuipc/issues/303
+    info.require_discard_friction();
 }
 
 void AffineBodyVertexReporter::Impl::report_displacements(VertexDisplacementInfo& info)

--- a/src/backends/cuda/contact_system/al_simplex_frictional_contact.cu
+++ b/src/backends/cuda/contact_system/al_simplex_frictional_contact.cu
@@ -258,7 +258,7 @@ void ALSimplexFrictionalContact::Impl::do_assemble(GlobalContactManager::Gradien
 
                    Float eps_x;
                    distance::edge_edge_mollifier_threshold(
-                       rest_Ea0, rest_Ea1, rest_Eb0, rest_Eb1, eps_x);
+                       rest_Ea0, rest_Ea1, rest_Eb0, rest_Eb1, -1.0, eps_x);
                    if(!distance::need_mollify(prev_Ea0, prev_Ea1, prev_Eb0, prev_Eb1, eps_x))
                    {
                        Vector12    G;

--- a/src/backends/cuda/contact_system/contact_models/ipc_simplex_normal_contact.cu
+++ b/src/backends/cuda/contact_system/contact_models/ipc_simplex_normal_contact.cu
@@ -133,16 +133,15 @@ class IPCSimplexNormalContact final : public SimplexNormalContact
                            Float D;
                            distance::edge_edge_distance2(flag, E0, E1, E2, E3, D);
                            Vector2 range = D_range(thickness, d_hat);
-                           MUDA_ASSERT(
-                               is_active_D(range, D),
-                               "EE[%d,%d,%d,%d] d^2(%f) out of range, (%f,%f)",
-                               EE(0),
-                               EE(1),
-                               EE(2),
-                               EE(3),
-                               D,
-                               range(0),
-                               range(1));
+                           MUDA_ASSERT(is_active_D(range, D),
+                                       "EE[%d,%d,%d,%d] d^2(%f) out of range, (%f,%f)",
+                                       EE(0),
+                                       EE(1),
+                                       EE(2),
+                                       EE(3),
+                                       D,
+                                       range(0),
+                                       range(1));
                        }
 
 
@@ -291,195 +290,201 @@ class IPCSimplexNormalContact final : public SimplexNormalContact
 
         ParallelFor()
             .file_line(__FILE__, __LINE__)
-            .apply(total,
-                   [gradient_only = info.gradient_only(),
-                    table       = info.contact_tabular().viewer().name("contact_tabular"),
-                    contact_ids = info.contact_element_ids().viewer().name("contact_element_ids"),
-                    Ps          = info.positions().viewer().name("Ps"),
-                    rest_Ps     = info.rest_positions().viewer().name("rest_Ps"),
-                    thicknesses = info.thicknesses().viewer().name("thicknesses"),
-                    d_hats      = info.d_hats().viewer().name("d_hats"),
-                    dt          = info.dt(),
-                    // PT
-                    PTs    = info.PTs().viewer().name("PTs"),
-                    PT_Gs  = info.PT_gradients().viewer().name("PT_Gs"),
-                    PT_Hs  = info.PT_hessians().viewer().name("PT_Hs"),
-                    // EE
-                    EEs    = info.EEs().viewer().name("EEs"),
-                    EE_Gs  = info.EE_gradients().viewer().name("EE_Gs"),
-                    EE_Hs  = info.EE_hessians().viewer().name("EE_Hs"),
-                    // PE
-                    PEs    = info.PEs().viewer().name("PEs"),
-                    PE_Gs  = info.PE_gradients().viewer().name("PE_Gs"),
-                    PE_Hs  = info.PE_hessians().viewer().name("PE_Hs"),
-                    // PP
-                    PPs    = info.PPs().viewer().name("PPs"),
-                    PP_Gs  = info.PP_gradients().viewer().name("PP_Gs"),
-                    PP_Hs  = info.PP_hessians().viewer().name("PP_Hs"),
-                    // offsets
-                    ee_offset, pe_offset, pp_offset] __device__(IndexT idx) mutable
-                   {
-                       if(idx < ee_offset)
-                       {
-                           // ── PT ──
-                           int i = idx;
-                           Vector4i PT = PTs(i);
-                           Vector4i cids = {contact_ids(PT[0]), contact_ids(PT[1]),
-                                            contact_ids(PT[2]), contact_ids(PT[3])};
-                           Float kt2 = PT_kappa(table, cids) * dt * dt;
+            .apply(
+                total,
+                [gradient_only = info.gradient_only(),
+                 table = info.contact_tabular().viewer().name("contact_tabular"),
+                 contact_ids = info.contact_element_ids().viewer().name("contact_element_ids"),
+                 Ps          = info.positions().viewer().name("Ps"),
+                 rest_Ps     = info.rest_positions().viewer().name("rest_Ps"),
+                 thicknesses = info.thicknesses().viewer().name("thicknesses"),
+                 d_hats      = info.d_hats().viewer().name("d_hats"),
+                 dt          = info.dt(),
+                 // PT
+                 PTs   = info.PTs().viewer().name("PTs"),
+                 PT_Gs = info.PT_gradients().viewer().name("PT_Gs"),
+                 PT_Hs = info.PT_hessians().viewer().name("PT_Hs"),
+                 // EE
+                 EEs   = info.EEs().viewer().name("EEs"),
+                 EE_Gs = info.EE_gradients().viewer().name("EE_Gs"),
+                 EE_Hs = info.EE_hessians().viewer().name("EE_Hs"),
+                 // PE
+                 PEs   = info.PEs().viewer().name("PEs"),
+                 PE_Gs = info.PE_gradients().viewer().name("PE_Gs"),
+                 PE_Hs = info.PE_hessians().viewer().name("PE_Hs"),
+                 // PP
+                 PPs   = info.PPs().viewer().name("PPs"),
+                 PP_Gs = info.PP_gradients().viewer().name("PP_Gs"),
+                 PP_Hs = info.PP_hessians().viewer().name("PP_Hs"),
+                 // offsets
+                 ee_offset,
+                 pe_offset,
+                 pp_offset] __device__(IndexT idx) mutable
+                {
+                    if(idx < ee_offset)  // PT
+                    {
+                        int      i    = idx;
+                        Vector4i PT   = PTs(i);
+                        Vector4i cids = {contact_ids(PT[0]),
+                                         contact_ids(PT[1]),
+                                         contact_ids(PT[2]),
+                                         contact_ids(PT[3])};
+                        Float    kt2  = PT_kappa(table, cids) * dt * dt;
 
-                           const auto& P  = Ps(PT[0]);
-                           const auto& T0 = Ps(PT[1]);
-                           const auto& T1 = Ps(PT[2]);
-                           const auto& T2 = Ps(PT[3]);
+                        const auto& P  = Ps(PT[0]);
+                        const auto& T0 = Ps(PT[1]);
+                        const auto& T1 = Ps(PT[2]);
+                        const auto& T2 = Ps(PT[3]);
 
-                           Float thickness = PT_thickness(thicknesses(PT(0)),
-                                                          thicknesses(PT(1)),
-                                                          thicknesses(PT(2)),
-                                                          thicknesses(PT(3)));
-                           Float d_hat = PT_d_hat(d_hats(PT(0)), d_hats(PT(1)),
-                                                  d_hats(PT(2)), d_hats(PT(3)));
-                           Vector4i flag = distance::point_triangle_distance_flag(P, T0, T1, T2);
+                        Float thickness = PT_thickness(thicknesses(PT(0)),
+                                                       thicknesses(PT(1)),
+                                                       thicknesses(PT(2)),
+                                                       thicknesses(PT(3)));
+                        Float d_hat     = PT_d_hat(
+                            d_hats(PT(0)), d_hats(PT(1)), d_hats(PT(2)), d_hats(PT(3)));
+                        Vector4i flag =
+                            distance::point_triangle_distance_flag(P, T0, T1, T2);
 
-                           Vector12 G;
-                           if(gradient_only)
-                           {
-                               PT_barrier_gradient(G, flag, kt2, d_hat, thickness, P, T0, T1, T2);
-                               DoubletVectorAssembler DVA{PT_Gs};
-                               DVA.segment<4>(i * 4).write(PT, G);
-                           }
-                           else
-                           {
-                               Matrix12x12 H;
-                               PT_barrier_gradient_hessian(G, H, flag, kt2, d_hat, thickness, P, T0, T1, T2);
-                               make_spd(H);
-                               DoubletVectorAssembler DVA{PT_Gs};
-                               DVA.segment<4>(i * 4).write(PT, G);
-                               TripletMatrixAssembler TMA{PT_Hs};
-                               TMA.half_block<4>(i * PTHalfHessianSize).write(PT, H);
-                           }
-                       }
-                       else if(idx < pe_offset)
-                       {
-                           // ── EE ──
-                           int i = idx - ee_offset;
-                           Vector4i EE = EEs(i);
-                           Vector4i cids = {contact_ids(EE[0]), contact_ids(EE[1]),
-                                            contact_ids(EE[2]), contact_ids(EE[3])};
-                           Float kt2 = EE_kappa(table, cids) * dt * dt;
+                        Vector12 G;
+                        if(gradient_only)
+                        {
+                            PT_barrier_gradient(G, flag, kt2, d_hat, thickness, P, T0, T1, T2);
+                            DoubletVectorAssembler DVA{PT_Gs};
+                            DVA.segment<4>(i * 4).write(PT, G);
+                        }
+                        else
+                        {
+                            Matrix12x12 H;
+                            PT_barrier_gradient_hessian(
+                                G, H, flag, kt2, d_hat, thickness, P, T0, T1, T2);
+                            make_spd(H);
+                            DoubletVectorAssembler DVA{PT_Gs};
+                            DVA.segment<4>(i * 4).write(PT, G);
+                            TripletMatrixAssembler TMA{PT_Hs};
+                            TMA.half_block<4>(i * PTHalfHessianSize).write(PT, H);
+                        }
+                    }
+                    else if(idx < pe_offset)  // EE
+                    {
+                        int      i    = idx - ee_offset;
+                        Vector4i EE   = EEs(i);
+                        Vector4i cids = {contact_ids(EE[0]),
+                                         contact_ids(EE[1]),
+                                         contact_ids(EE[2]),
+                                         contact_ids(EE[3])};
+                        Float    kt2  = EE_kappa(table, cids) * dt * dt;
 
-                           const auto& E0 = Ps(EE[0]);
-                           const auto& E1 = Ps(EE[1]);
-                           const auto& E2 = Ps(EE[2]);
-                           const auto& E3 = Ps(EE[3]);
-                           const auto& t0_Ea0 = rest_Ps(EE[0]);
-                           const auto& t0_Ea1 = rest_Ps(EE[1]);
-                           const auto& t0_Eb0 = rest_Ps(EE[2]);
-                           const auto& t0_Eb1 = rest_Ps(EE[3]);
+                        const auto& E0     = Ps(EE[0]);
+                        const auto& E1     = Ps(EE[1]);
+                        const auto& E2     = Ps(EE[2]);
+                        const auto& E3     = Ps(EE[3]);
+                        const auto& t0_Ea0 = rest_Ps(EE[0]);
+                        const auto& t0_Ea1 = rest_Ps(EE[1]);
+                        const auto& t0_Eb0 = rest_Ps(EE[2]);
+                        const auto& t0_Eb1 = rest_Ps(EE[3]);
 
-                           Float thickness = EE_thickness(thicknesses(EE(0)),
-                                                          thicknesses(EE(1)),
-                                                          thicknesses(EE(2)),
-                                                          thicknesses(EE(3)));
-                           Float d_hat = EE_d_hat(d_hats(EE(0)), d_hats(EE(1)),
-                                                  d_hats(EE(2)), d_hats(EE(3)));
-                           Vector4i flag = distance::edge_edge_distance_flag(E0, E1, E2, E3);
+                        Float thickness = EE_thickness(thicknesses(EE(0)),
+                                                       thicknesses(EE(1)),
+                                                       thicknesses(EE(2)),
+                                                       thicknesses(EE(3)));
+                        Float d_hat     = EE_d_hat(
+                            d_hats(EE(0)), d_hats(EE(1)), d_hats(EE(2)), d_hats(EE(3)));
+                        Vector4i flag = distance::edge_edge_distance_flag(E0, E1, E2, E3);
 
-                           Vector12 G;
-                           if(gradient_only)
-                           {
-                               mollified_EE_barrier_gradient(
-                                   G, flag, kt2, d_hat, thickness,
-                                   t0_Ea0, t0_Ea1, t0_Eb0, t0_Eb1, E0, E1, E2, E3);
-                               DoubletVectorAssembler DVA{EE_Gs};
-                               DVA.segment<4>(i * 4).write(EE, G);
-                           }
-                           else
-                           {
-                               Matrix12x12 H;
-                               mollified_EE_barrier_gradient_hessian(
-                                   G, H, flag, kt2, d_hat, thickness,
-                                   t0_Ea0, t0_Ea1, t0_Eb0, t0_Eb1, E0, E1, E2, E3);
-                               make_spd(H);
-                               DoubletVectorAssembler DVA{EE_Gs};
-                               DVA.segment<4>(i * 4).write(EE, G);
-                               TripletMatrixAssembler TMA{EE_Hs};
-                               TMA.half_block<4>(i * EEHalfHessianSize).write(EE, H);
-                           }
-                       }
-                       else if(idx < pp_offset)
-                       {
-                           // ── PE ──
-                           int i = idx - pe_offset;
-                           Vector3i PE = PEs(i);
-                           Vector3i cids = {contact_ids(PE[0]), contact_ids(PE[1]),
-                                            contact_ids(PE[2])};
-                           Float kt2 = PE_kappa(table, cids) * dt * dt;
+                        Vector12 G;
+                        if(gradient_only)
+                        {
+                            mollified_EE_barrier_gradient(
+                                G, flag, kt2, d_hat, thickness, t0_Ea0, t0_Ea1, t0_Eb0, t0_Eb1, E0, E1, E2, E3);
+                            DoubletVectorAssembler DVA{EE_Gs};
+                            DVA.segment<4>(i * 4).write(EE, G);
+                        }
+                        else
+                        {
+                            Matrix12x12 H;
+                            mollified_EE_barrier_gradient_hessian(
+                                G, H, flag, kt2, d_hat, thickness, t0_Ea0, t0_Ea1, t0_Eb0, t0_Eb1, E0, E1, E2, E3);
+                            make_spd(H);
+                            DoubletVectorAssembler DVA{EE_Gs};
+                            DVA.segment<4>(i * 4).write(EE, G);
+                            TripletMatrixAssembler TMA{EE_Hs};
+                            TMA.half_block<4>(i * EEHalfHessianSize).write(EE, H);
+                        }
+                    }
+                    else if(idx < pp_offset)  // PE
+                    {
+                        int      i    = idx - pe_offset;
+                        Vector3i PE   = PEs(i);
+                        Vector3i cids = {contact_ids(PE[0]),
+                                         contact_ids(PE[1]),
+                                         contact_ids(PE[2])};
+                        Float    kt2  = PE_kappa(table, cids) * dt * dt;
 
-                           const auto& P  = Ps(PE[0]);
-                           const auto& E0 = Ps(PE[1]);
-                           const auto& E1 = Ps(PE[2]);
+                        const auto& P  = Ps(PE[0]);
+                        const auto& E0 = Ps(PE[1]);
+                        const auto& E1 = Ps(PE[2]);
 
-                           Float thickness = PE_thickness(thicknesses(PE(0)),
-                                                          thicknesses(PE(1)),
-                                                          thicknesses(PE(2)));
-                           Float d_hat = PE_d_hat(d_hats(PE(0)), d_hats(PE(1)),
-                                                  d_hats(PE(2)));
-                           Vector3i flag = distance::point_edge_distance_flag(P, E0, E1);
+                        Float thickness = PE_thickness(thicknesses(PE(0)),
+                                                       thicknesses(PE(1)),
+                                                       thicknesses(PE(2)));
+                        Float d_hat =
+                            PE_d_hat(d_hats(PE(0)), d_hats(PE(1)), d_hats(PE(2)));
+                        Vector3i flag = distance::point_edge_distance_flag(P, E0, E1);
 
-                           Vector9 G;
-                           if(gradient_only)
-                           {
-                               PE_barrier_gradient(G, flag, kt2, d_hat, thickness, P, E0, E1);
-                               DoubletVectorAssembler DVA{PE_Gs};
-                               DVA.segment<3>(i * 3).write(PE, G);
-                           }
-                           else
-                           {
-                               Matrix9x9 H;
-                               PE_barrier_gradient_hessian(G, H, flag, kt2, d_hat, thickness, P, E0, E1);
-                               make_spd(H);
-                               DoubletVectorAssembler DVA{PE_Gs};
-                               DVA.segment<3>(i * 3).write(PE, G);
-                               TripletMatrixAssembler TMA{PE_Hs};
-                               TMA.half_block<3>(i * PEHalfHessianSize).write(PE, H);
-                           }
-                       }
-                       else
-                       {
-                           // ── PP ──
-                           int i = idx - pp_offset;
-                           const auto& PP = PPs(i);
-                           Vector2i cids = {contact_ids(PP[0]), contact_ids(PP[1])};
-                           Float kt2 = PP_kappa(table, cids) * dt * dt;
+                        Vector9 G;
+                        if(gradient_only)
+                        {
+                            PE_barrier_gradient(G, flag, kt2, d_hat, thickness, P, E0, E1);
+                            DoubletVectorAssembler DVA{PE_Gs};
+                            DVA.segment<3>(i * 3).write(PE, G);
+                        }
+                        else
+                        {
+                            Matrix9x9 H;
+                            PE_barrier_gradient_hessian(
+                                G, H, flag, kt2, d_hat, thickness, P, E0, E1);
+                            make_spd(H);
+                            DoubletVectorAssembler DVA{PE_Gs};
+                            DVA.segment<3>(i * 3).write(PE, G);
+                            TripletMatrixAssembler TMA{PE_Hs};
+                            TMA.half_block<3>(i * PEHalfHessianSize).write(PE, H);
+                        }
+                    }
+                    else  // PP
+                    {
+                        int         i  = idx - pp_offset;
+                        const auto& PP = PPs(i);
+                        Vector2i cids = {contact_ids(PP[0]), contact_ids(PP[1])};
+                        Float kt2 = PP_kappa(table, cids) * dt * dt;
 
-                           const auto& P0 = Ps(PP[0]);
-                           const auto& P1 = Ps(PP[1]);
+                        const auto& P0 = Ps(PP[0]);
+                        const auto& P1 = Ps(PP[1]);
 
-                           Float thickness = PP_thickness(thicknesses(PP(0)),
-                                                          thicknesses(PP(1)));
-                           Float d_hat = PP_d_hat(d_hats(PP(0)), d_hats(PP(1)));
-                           Vector2i flag = distance::point_point_distance_flag(P0, P1);
+                        Float thickness =
+                            PP_thickness(thicknesses(PP(0)), thicknesses(PP(1)));
+                        Float d_hat = PP_d_hat(d_hats(PP(0)), d_hats(PP(1)));
+                        Vector2i flag = distance::point_point_distance_flag(P0, P1);
 
-                           Vector6 G;
-                           if(gradient_only)
-                           {
-                               PP_barrier_gradient(G, flag, kt2, d_hat, thickness, P0, P1);
-                               DoubletVectorAssembler DVA{PP_Gs};
-                               DVA.segment<2>(i * 2).write(PP, G);
-                           }
-                           else
-                           {
-                               Matrix6x6 H;
-                               PP_barrier_gradient_hessian(G, H, flag, kt2, d_hat, thickness, P0, P1);
-                               make_spd(H);
-                               DoubletVectorAssembler DVA{PP_Gs};
-                               DVA.segment<2>(i * 2).write(PP, G);
-                               TripletMatrixAssembler TMA{PP_Hs};
-                               TMA.half_block<2>(i * PPHalfHessianSize).write(PP, H);
-                           }
-                       }
-                   });
+                        Vector6 G;
+                        if(gradient_only)
+                        {
+                            PP_barrier_gradient(G, flag, kt2, d_hat, thickness, P0, P1);
+                            DoubletVectorAssembler DVA{PP_Gs};
+                            DVA.segment<2>(i * 2).write(PP, G);
+                        }
+                        else
+                        {
+                            Matrix6x6 H;
+                            PP_barrier_gradient_hessian(
+                                G, H, flag, kt2, d_hat, thickness, P0, P1);
+                            make_spd(H);
+                            DoubletVectorAssembler DVA{PP_Gs};
+                            DVA.segment<2>(i * 2).write(PP, G);
+                            TripletMatrixAssembler TMA{PP_Hs};
+                            TMA.half_block<2>(i * PPHalfHessianSize).write(PP, H);
+                        }
+                    }
+                });
     }
 };
 

--- a/src/backends/cuda/finite_element/finite_element_vertex_reporter.cu
+++ b/src/backends/cuda/finite_element/finite_element_vertex_reporter.cu
@@ -65,6 +65,9 @@ void FiniteElementVertexReporter::Impl::update_attributes(VertexAttributeInfo& i
 {
     info.positions().copy_from(fem().xs);
 
+    // This update will ruin the friction force computed in previous step, so we need to discard it.
+    // ref: https://github.com/spiriMirror/libuipc/issues/303
+    info.require_discard_friction();
 }
 
 void FiniteElementVertexReporter::Impl::report_displacements(VertexDisplacementInfo& info)

--- a/src/backends/cuda/global_geometry/global_vertex_manager.cu
+++ b/src/backends/cuda/global_geometry/global_vertex_manager.cu
@@ -4,6 +4,7 @@
 #include <uipc/common/range.h>
 #include <muda/cub/device/device_reduce.h>
 #include <global_geometry/vertex_reporter.h>
+#include <collision_detection/global_trajectory_filter.h>
 #include <sim_engine.h>
 
 /*************************************************************************************************
@@ -18,6 +19,7 @@ void GlobalVertexManager::do_build()
     auto d_hat = world().scene().config().find<Float>("contact/d_hat");
     m_impl.default_d_hat = d_hat->view()[0];
 
+    m_impl.global_trajectory_filter  = find<GlobalTrajectoryFilter>();
     m_impl.global_active_set_manager = find<GlobalActiveSetManager>();
 }
 
@@ -130,35 +132,51 @@ void GlobalVertexManager::Impl::collect_vertex_displacements()
     }
 }
 
-void GlobalVertexManager::Impl::prepare_AL_CCD() {
+void GlobalVertexManager::Impl::prepare_AL_CCD()
+{
     UIPC_ASSERT(global_active_set_manager, "GlobalActiveSetManager not enabled");
     auto non_penetrate_positions = global_active_set_manager->non_penetrate_positions();
     auto& tmp_pos = safe_positions;
-    UIPC_ASSERT(non_penetrate_positions.size() == positions.size(), "Non-penetrate size not equal");
+    UIPC_ASSERT(non_penetrate_positions.size() == positions.size(),
+                "Non-penetrate size not equal");
     muda::ParallelFor()
         .file_line(__FILE__, __LINE__)
         .apply(positions.size(),
-               [pos      = positions.viewer().name("pos"),
-               tmp_pos = tmp_pos.viewer().name("tmp_pos"),
-               disp     = displacements.viewer().name("disp"),
-               non_penetrate_pos = non_penetrate_positions.viewer().name("non_penetrate_pos")] __device__(int i) mutable {
-                   disp(i) = pos(i) - non_penetrate_pos(i);
+               [pos               = positions.viewer().name("pos"),
+                tmp_pos           = tmp_pos.viewer().name("tmp_pos"),
+                disp              = displacements.viewer().name("disp"),
+                non_penetrate_pos = non_penetrate_positions.viewer().name(
+                    "non_penetrate_pos")] __device__(int i) mutable
+               {
+                   disp(i)    = pos(i) - non_penetrate_pos(i);
                    tmp_pos(i) = pos(i);
-                   pos(i) = non_penetrate_pos(i);
+                   pos(i)     = non_penetrate_pos(i);
                });
 }
 
-void GlobalVertexManager::Impl::post_AL_CCD() {
+void GlobalVertexManager::Impl::post_AL_CCD()
+{
     auto& tmp_pos = safe_positions;
     muda::BufferLaunch().copy<Vector3>(positions.view(), std::as_const(tmp_pos).view());
 }
 
-void GlobalVertexManager::Impl::recover_non_penetrate() {
+void GlobalVertexManager::Impl::recover_non_penetrate()
+{
     using namespace muda;
     UIPC_ASSERT(global_active_set_manager, "GlobalActiveSetManager not enabled");
     auto non_penetrate_positions = global_active_set_manager->non_penetrate_positions();
-    UIPC_ASSERT(non_penetrate_positions.size() == positions.size(), "Non-penetrate size not equal");
+    UIPC_ASSERT(non_penetrate_positions.size() == positions.size(),
+                "Non-penetrate size not equal");
     BufferLaunch().copy<Vector3>(positions.view(), non_penetrate_positions);
+}
+
+void GlobalVertexManager::VertexAttributeInfo::require_discard_friction() const noexcept
+{
+    // If the vertex attributes are updated in a way that will ruin the friction computation
+    // we need to discard the friction information in the global trajectory filter.
+    // ref: https://github.com/spiriMirror/libuipc/issues/303
+    if(m_impl->global_trajectory_filter)
+        m_impl->global_trajectory_filter->require_discard_friction();
 }
 
 void GlobalVertexManager::Impl::record_prev_positions()
@@ -459,15 +477,18 @@ void GlobalVertexManager::record_start_point()
     m_impl.record_start_point();
 }
 
-void GlobalVertexManager::prepare_AL_CCD() {
+void GlobalVertexManager::prepare_AL_CCD()
+{
     m_impl.prepare_AL_CCD();
 }
 
-void GlobalVertexManager::post_AL_CCD() {
+void GlobalVertexManager::post_AL_CCD()
+{
     m_impl.post_AL_CCD();
 }
 
-void GlobalVertexManager::recover_non_penetrate() {
+void GlobalVertexManager::recover_non_penetrate()
+{
     m_impl.recover_non_penetrate();
 }
 

--- a/src/backends/cuda/global_geometry/global_vertex_manager.h
+++ b/src/backends/cuda/global_geometry/global_vertex_manager.h
@@ -10,6 +10,7 @@
 
 namespace uipc::backend::cuda
 {
+class GlobalTrajectoryFilter;
 class VertexReporter;
 class GlobalActiveSetManager;
 class GlobalVertexManager final : public SimSystem
@@ -48,6 +49,12 @@ class GlobalVertexManager final : public SimSystem
         muda::BufferView<IndexT>  body_ids() const noexcept;
         // vert-wise d_hat
         muda::BufferView<Float> d_hats() const noexcept;
+
+        /**
+         * @breif require discard friction, if this update will ruin the friction computation
+         * 
+         */
+        void require_discard_friction() const noexcept;
 
       private:
         friend class GlobalVertexManager;
@@ -205,8 +212,8 @@ class GlobalVertexManager final : public SimSystem
         muda::DeviceVar<Vector3> min_pos;
         muda::DeviceVar<Vector3> max_pos;
 
-
-        SimSystemSlot<GlobalActiveSetManager> global_active_set_manager;
+        SimSystemSlot<GlobalTrajectoryFilter>   global_trajectory_filter;
+        SimSystemSlot<GlobalActiveSetManager>   global_active_set_manager;
         SimSystemSlotCollection<VertexReporter> vertex_reporters;
 
         OffsetCountCollection<IndexT> reporter_vertex_offsets_counts;

--- a/src/backends/cuda/linear_system/diag_linear_subsystem.cu
+++ b/src/backends/cuda/linear_system/diag_linear_subsystem.cu
@@ -63,10 +63,17 @@ void DiagLinearSubsystem::report_extent(GlobalLinearSystem::DiagExtentInfo& info
 {
     do_report_extent(info);
 }
+
 void DiagLinearSubsystem::assemble(GlobalLinearSystem::DiagInfo& info)
 {
+    UIPC_ASSERT(info.gradient_only()
+                    || info.component_flags() == GlobalLinearSystem::ComponentFlags::All,
+                "Limitation: When info.gradient_only()==false, info.component_flags() must be GlobalLinearSystem::ComponentFlags::All (got {})",
+                enum_flags_name(info.component_flags()));
+
     do_assemble(info);
 }
+
 void DiagLinearSubsystem::accuracy_check(GlobalLinearSystem::AccuracyInfo& info)
 {
     do_accuracy_check(info);

--- a/src/backends/cuda/utils/distance/details/edge_edge_mollifier.inl
+++ b/src/backends/cuda/utils/distance/details/edge_edge_mollifier.inl
@@ -499,17 +499,6 @@ MUDA_GENERIC void edge_edge_mollifier_threshold(const Eigen::Vector<T, 3>& ea0_r
                                                 const Eigen::Vector<T, 3>& ea1_rest,
                                                 const Eigen::Vector<T, 3>& eb0_rest,
                                                 const Eigen::Vector<T, 3>& eb1_rest,
-                                                T& eps_x)
-{
-    edge_edge_mollifier_threshold(
-        ea0_rest, ea1_rest, eb0_rest, eb1_rest, -1, eps_x);  // keep legacy no-coeff call path
-}
-
-template <typename T>
-MUDA_GENERIC void edge_edge_mollifier_threshold(const Eigen::Vector<T, 3>& ea0_rest,
-                                                const Eigen::Vector<T, 3>& ea1_rest,
-                                                const Eigen::Vector<T, 3>& eb0_rest,
-                                                const Eigen::Vector<T, 3>& eb1_rest,
                                                 Float coeff,
                                                 T&    eps_x)
 {

--- a/src/backends/cuda/utils/distance/distance_flagged.h
+++ b/src/backends/cuda/utils/distance/distance_flagged.h
@@ -235,8 +235,8 @@ MUDA_GENERIC Vector<IndexT, 3> point_edge_distance_flag(const Eigen::Vector<T, 3
     Vector<IndexT, 3> F;
     F[0] = 1;
 
-    Vector<T, 3> e     = e1 - e0;
-    T            e2    = e.squaredNorm();
+    Vector<T, 3> e  = e1 - e0;
+    T            e2 = e.squaredNorm();
     if(e2 <= static_cast<T>(0.0))
     {
         // Degenerate edge -> fallback to point-point against the nearest endpoint.
@@ -360,36 +360,36 @@ MUDA_GENERIC Vector4i point_triangle_distance_flag(const Eigen::Vector<T, 3>& p,
 
 namespace detail
 {
-template <typename T>
-MUDA_GENERIC void update_ee_near_parallel_candidate(const Eigen::Vector<T, 3>& p,
-                                                      const Eigen::Vector<T, 3>& s0,
-                                                      const Eigen::Vector<T, 3>& s1,
-                                                      T& minD,
-                                                      Vector4i& F,
-                                                      const Vector4i& F_pe,
-                                                      const Vector4i& F_pp0,
-                                                      const Vector4i& F_pp1,
-                                                      bool is_initial)
-{
-    auto pe_flag = point_edge_distance_flag(p, s0, s1);
-    T    d;
-    if(pe_flag[1] && pe_flag[2])
-        point_edge_distance2(p, s0, s1, d);
-    else if(pe_flag[1])
-        point_point_distance2(p, s0, d);
-    else
-        point_point_distance2(p, s1, d);
-    if(is_initial || d < minD)
+    template <typename T>
+    MUDA_GENERIC void update_ee_near_parallel_candidate(const Eigen::Vector<T, 3>& p,
+                                                        const Eigen::Vector<T, 3>& s0,
+                                                        const Eigen::Vector<T, 3>& s1,
+                                                        T&              minD,
+                                                        Vector4i&       F,
+                                                        const Vector4i& F_pe,
+                                                        const Vector4i& F_pp0,
+                                                        const Vector4i& F_pp1,
+                                                        bool is_initial)
     {
-        minD = d;
+        auto pe_flag = point_edge_distance_flag(p, s0, s1);
+        T    d;
         if(pe_flag[1] && pe_flag[2])
-            F = F_pe;
+            point_edge_distance2(p, s0, s1, d);
         else if(pe_flag[1])
-            F = F_pp0;
+            point_point_distance2(p, s0, d);
         else
-            F = F_pp1;
+            point_point_distance2(p, s1, d);
+        if(is_initial || d < minD)
+        {
+            minD = d;
+            if(pe_flag[1] && pe_flag[2])
+                F = F_pe;
+            else if(pe_flag[1])
+                F = F_pp0;
+            else
+                F = F_pp1;
+        }
     }
-}
 }  // namespace detail
 
 template <typename T>
@@ -398,7 +398,7 @@ MUDA_GENERIC Vector4i edge_edge_distance_flag(const Eigen::Vector<T, 3>& ea0,
                                               const Eigen::Vector<T, 3>& eb0,
                                               const Eigen::Vector<T, 3>& eb1)
 {
-    Vector4i F = {1, 1, 1, 1};  // default EE
+    Vector4i    F                 = {1, 1, 1, 1};  // default EE
     constexpr T kEeParallelRelTol = static_cast<T>(1e-12);
 
     Eigen::Vector<T, 3> u  = ea1 - ea0;
@@ -412,7 +412,7 @@ MUDA_GENERIC Vector4i edge_edge_distance_flag(const Eigen::Vector<T, 3>& ea0,
     T                   D  = a * c - b * b;  // always >= 0
     T                   tD = D;  // tc = tN / tD, default tD = D >= 0
     T                   sN, tN;
-    T                   uxv2 = u.cross(v).squaredNorm();
+    T                   uxv2          = u.cross(v).squaredNorm();
     bool                near_parallel = (uxv2 <= kEeParallelRelTol * a * c);
 
     // For near-parallel/collinear edges, avoid the dim==4 EE branch (line-line
@@ -421,26 +421,14 @@ MUDA_GENERIC Vector4i edge_edge_distance_flag(const Eigen::Vector<T, 3>& ea0,
     if(near_parallel)
     {
         T minD = 0;
-        detail::update_ee_near_parallel_candidate(ea0, eb0, eb1, minD, F,
-                                                    Vector4i{1, 0, 1, 1},
-                                                    Vector4i{1, 0, 1, 0},
-                                                    Vector4i{1, 0, 0, 1},
-                                                    true);
-        detail::update_ee_near_parallel_candidate(ea1, eb0, eb1, minD, F,
-                                                    Vector4i{0, 1, 1, 1},
-                                                    Vector4i{0, 1, 1, 0},
-                                                    Vector4i{0, 1, 0, 1},
-                                                    false);
-        detail::update_ee_near_parallel_candidate(eb0, ea0, ea1, minD, F,
-                                                    Vector4i{1, 1, 1, 0},
-                                                    Vector4i{1, 0, 1, 0},
-                                                    Vector4i{0, 1, 1, 0},
-                                                    false);
-        detail::update_ee_near_parallel_candidate(eb1, ea0, ea1, minD, F,
-                                                    Vector4i{1, 1, 0, 1},
-                                                    Vector4i{1, 0, 0, 1},
-                                                    Vector4i{0, 1, 0, 1},
-                                                    false);
+        detail::update_ee_near_parallel_candidate(
+            ea0, eb0, eb1, minD, F, Vector4i{1, 0, 1, 1}, Vector4i{1, 0, 1, 0}, Vector4i{1, 0, 0, 1}, true);
+        detail::update_ee_near_parallel_candidate(
+            ea1, eb0, eb1, minD, F, Vector4i{0, 1, 1, 1}, Vector4i{0, 1, 1, 0}, Vector4i{0, 1, 0, 1}, false);
+        detail::update_ee_near_parallel_candidate(
+            eb0, ea0, ea1, minD, F, Vector4i{1, 1, 1, 0}, Vector4i{1, 0, 1, 0}, Vector4i{0, 1, 1, 0}, false);
+        detail::update_ee_near_parallel_candidate(
+            eb1, ea0, ea1, minD, F, Vector4i{1, 1, 0, 1}, Vector4i{1, 0, 0, 1}, Vector4i{0, 1, 0, 1}, false);
         return F;
     }
 
@@ -472,11 +460,8 @@ MUDA_GENERIC Vector4i edge_edge_distance_flag(const Eigen::Vector<T, 3>& ea0,
     else
     {
         tN = (a * e - b * d);
-        if(tN > 0.0 && tN < tD
-           && (u.cross(v).dot(w) == 0.0 || u.cross(v).squaredNorm() < 1.0e-20 * a * c))
+        if(tN > 0.0 && tN < tD && u.cross(v).dot(w) == 0.0)
         {
-            // if (tN > 0.0 && tN < tD && (u.cross(v).dot(w) == 0.0 || u.cross(v).squaredNorm() == 0.0)) {
-            // std::cout << u.cross(v).squaredNorm() / (a * c) << ": " << sN << " " << D << ", " << tN << " " << tD << std::endl;
             // avoid coplanar or nearly parallel EE
             if(sN < D / 2)
             {


### PR DESCRIPTION
## Summary
- restore missing CUDA-side update paths in touched contact, geometry, and distance codepaths
- apply consistent `clang-format` formatting to all modified CUDA source/header files
- keep behavior changes and formatting updates together for easier review of this fix branch

## Test plan
- [x] build CUDA backend locally
- [x] run existing CUDA contact and distance regression tests
- [x] verify no formatting-only regressions in affected modules
