### PR TITLE
fix(engine): SimSystemSlot guards and IPC iteration limit reporting

### DIFF
--- a/src/backends/common/details/sim_system_slot.inl
+++ b/src/backends/common/details/sim_system_slot.inl
@@ -1,4 +1,5 @@
 #include <uipc/common/demangle.h>
+#include <uipc/common/log.h>
 
 namespace uipc::backend
 {
@@ -48,6 +49,9 @@ template <typename T>
 T* SimSystemSlot<T>::view() const noexcept
 {
     lazy_init();
+    UIPC_ASSERT(m_sim_system,
+                "{} is not registered, system building fatal error.",
+                uipc::demangle<T>());
     return m_sim_system;
 }
 
@@ -60,7 +64,8 @@ T* SimSystemSlot<T>::operator->() const noexcept
 template <typename T>
 SimSystemSlot<T>::operator bool() const noexcept
 {
-    return view();
+    lazy_init();
+    return m_sim_system != nullptr;
 }
 
 template <typename T>

--- a/src/backends/cuda/engine/advance_ipc.cu
+++ b/src/backends/cuda/engine/advance_ipc.cu
@@ -215,9 +215,9 @@ void SimEngine::advance()
         }
     };
 
-    auto check_line_search_iter = [this]
+    auto check_line_search_iter = [this](SizeT line_search_iter_after_loop)
     {
-        if(m_line_search_iter >= m_line_searcher->max_iter())
+        if(line_search_iter_after_loop >= m_line_searcher->max_iter())
         {
             logger::warn("Line Search Exits with Max Iteration: {} (Frame={}, Newton={})",
                          m_line_searcher->max_iter(),
@@ -231,12 +231,13 @@ void SimEngine::advance()
         }
     };
 
-    auto check_newton_iter = [this]
+    auto check_newton_iter = [this](IndexT newton_iter_after_loop)
     {
-        if(m_newton_iter >= m_newton_max_iter->view()[0])
+        auto newton_max = m_newton_max_iter->view()[0];
+        if(newton_iter_after_loop >= newton_max)
         {
             logger::warn("Newton Iteration Exits with Max Iteration: {} (Frame={})",
-                         m_newton_max_iter->view()[0],
+                         newton_max,
                          m_current_frame);
 
             if(m_strict_mode->view()[0])
@@ -247,9 +248,9 @@ void SimEngine::advance()
         else
         {
             logger::info("Newton Iteration Converged with Iteration Count: {}, Bound: [{}, {}]",
-                         m_newton_iter,
+                         newton_iter_after_loop,
                          m_newton_min_iter->view()[0],
-                         m_newton_max_iter->view()[0]);
+                         newton_max);
         }
     };
 
@@ -315,10 +316,11 @@ void SimEngine::advance()
             // 4. Nonlinear-Newton Iteration
             m_newton_tolerance_manager->pre_newton(m_current_frame);
 
-            auto   newton_max_iter = m_newton_max_iter->view()[0];
-            auto   newton_min_iter = m_newton_min_iter->view()[0];
-            beta                   = 1.0;
-            for(IndexT newton_iter = 0; newton_iter < newton_max_iter; ++newton_iter)
+            auto newton_max_iter = m_newton_max_iter->view()[0];
+            auto newton_min_iter = m_newton_min_iter->view()[0];
+            beta                 = 1.0;
+            IndexT newton_iter   = 0;
+            for(; newton_iter < newton_max_iter; ++newton_iter)
             {
                 Timer timer{"Newton Iteration"};
                 m_newton_iter = newton_iter;
@@ -379,10 +381,9 @@ void SimEngine::advance()
                     alpha = cfl_condition(alpha);
 
                     // Line Search Iteration
-                    bool converged = convergence_check(newton_iter);
-                    for(SizeT line_search_iter = 0;
-                        line_search_iter < m_line_searcher->max_iter();
-                        ++line_search_iter)
+                    bool  converged        = convergence_check(newton_iter);
+                    SizeT line_search_iter = 0;
+                    for(; line_search_iter < m_line_searcher->max_iter(); ++line_search_iter)
                     {
                         Timer timer{"Line Search Iteration"};
                         m_line_search_iter = line_search_iter;
@@ -413,7 +414,7 @@ void SimEngine::advance()
                     }
 
                     // Check Line Search Iteration: report warnings or throw exceptions if needed
-                    check_line_search_iter();
+                    check_line_search_iter(line_search_iter);
 
                     bool terminated = converged && (newton_iter >= newton_min_iter);
                     if(terminated)
@@ -430,7 +431,7 @@ void SimEngine::advance()
 
             // Check Newton Iteration
             // report warnings or throw exceptions if needed
-            check_newton_iter();
+            check_newton_iter(newton_iter);
         }
 
         logger::info("<<< End Frame: {}", m_current_frame);

--- a/src/backends/cuda/finite_element/finite_element_method.cu
+++ b/src/backends/cuda/finite_element/finite_element_method.cu
@@ -243,36 +243,7 @@ void FiniteElementMethod::Impl::_classify_base_constitutions()
 
 void FiniteElementMethod::Impl::_init_diff_reporters()
 {
-    //if(kinetic_diff_parm_reporter)
-    //{
-    //    kinetic_diff_parm_reporter.view()->init();
-    //}
-
-    //auto constitution_diff_parm_reporter_view = constitution_diff_parm_reporters.view();
-    //auto extra_constitution_diff_parm_reporter_view =
-    //    extra_constitution_diff_parm_reporters.view();
-
-    //// 1. Connect the reporter to the related constitution
-    //for(auto& cdpr : constitution_diff_parm_reporter_view)
-    //{
-    //    cdpr->connect();
-    //}
-
-    //for(auto& ecdpr : extra_constitution_diff_parm_reporter_view)
-    //{
-    //    ecdpr->connect();
-    //}
-
-    //// 2. Init the reporter
-    //for(auto& cdpr : constitution_diff_parm_reporter_view)
-    //{
-    //    cdpr->init();
-    //}
-
-    //for(auto& ecdpr : extra_constitution_diff_parm_reporter_view)
-    //{
-    //    ecdpr->init();
-    //}
+    // TODO: Placeholder for diff sim system initialization
 }
 
 void FiniteElementMethod::Impl::_build_geo_infos(WorldVisitor& world)
@@ -337,7 +308,6 @@ void FiniteElementMethod::Impl::_build_geo_infos(WorldVisitor& world)
 
 
     // 3) setup vertex offsets and primitive offsets
-    // + 1 for total count
     {
         OffsetCountCollection<IndexT> vertex_offsets_counts;
         vertex_offsets_counts.resize(geo_infos.size());
@@ -362,8 +332,7 @@ void FiniteElementMethod::Impl::_build_geo_infos(WorldVisitor& world)
         vertex_offsets_counts.scan();
 
         // we don't calculate the primitive offset here
-        // the primitive offset is related to the dimension
-        // the primitive offset in every dim starts from 0
+        // the primitive offset is related to the dimension, every dim starts from 0
 
         span<const IndexT> vertex_offsets = vertex_offsets_counts.offsets();
 


### PR DESCRIPTION
﻿## Summary

Hardens `SimSystemSlot` usage and fixes incorrect max-iteration reporting in the IPC advance loop. Also removes dead commented code in the FEM build path.

## Changes

### `SimSystemSlot` (`sim_system_slot.inl`)
- `view()` now calls `lazy_init()` then `UIPC_ASSERT(m_sim_system, ...)` with demangled `T`, so obtaining a raw pointer always implies a registered system.
- `operator bool()` calls `lazy_init()` and returns `m_sim_system != nullptr` **without** calling `view()`, so empty slots remain testable with `if (slot)`.
- `operator->` delegates to `view()` (same assertion path).
- Include `<uipc/common/log.h>` for `UIPC_ASSERT`.

### IPC advance (`advance_ipc.cu`)
- **Newton:** Hoist `newton_iter` outside the `for` loop so that after the loop, `newton_iter == newton_max_iter` when the loop exits by exhaustion (no early `break`). Pass that value to `check_newton_iter` so max-Newton warnings/strict mode trigger correctly and the “converged” info log is not emitted when the limit was hit.
- **Line search:** Same pattern for `line_search_iter` and `check_line_search_iter`, so max line-search iterations are detected when the inner loop exhausts without `break`.

### FEM (`finite_element_method.cu`)
- Remove obsolete commented `_init_diff_reporters` stub (`kinetic_diff_parm_reporter.view()`).

## Breaking / behavior notes
- Calling `SimSystemSlot::view()` on an unset slot now fails the assertion (use `if (slot)` before `view()` or use `operator->` only when the slot is known registered).

## Testing
- `uipc_test_sim_case.exe` (Catch2): 81 passed, 1 skipped; all assertions passed.
