### PR TITLE
fix(cuda): gate joint external loads with constraint flags

### DIFF
--- a/apps/tests/sim_case/81_abd_prismatic_joint_driving_and_external_force.cpp
+++ b/apps/tests/sim_case/81_abd_prismatic_joint_driving_and_external_force.cpp
@@ -1,0 +1,175 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+#include <uipc/constitution/affine_body_prismatic_joint.h>
+#include <uipc/constitution/affine_body_driving_prismatic_joint.h>
+#include <uipc/constitution/affine_body_prismatic_joint_external_force.h>
+
+TEST_CASE("81_abd_prismatic_joint_driving_and_external_force", "[abd][joint][driving][external_force]")
+{
+    using namespace uipc;
+    using namespace uipc::geometry;
+    using namespace uipc::core;
+    using namespace uipc::constitution;
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    uipc::logger::set_level(uipc::Logger::Level::warn);
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                            = test::Scene::default_config();
+    config["gravity"]                      = Vector3{0.0, -9.8, 0.0};
+    config["contact"]["enable"]            = true;
+    config["line_search"]["report_energy"] = true;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    scene.contact_tabular().default_model(0.5, 1.0_GPa);
+
+    Transform pre_transform = Transform::Identity();
+    pre_transform.scale(0.4);
+    SimplicialComplexIO io{pre_transform};
+
+    auto left_link  = scene.objects().create("left");
+    auto right_link = scene.objects().create("right");
+
+    AffineBodyConstitution abd;
+    SimplicialComplex      abd_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(abd_mesh, 100.0_MPa);
+    label_surface(abd_mesh);
+
+    // Left body: fixed
+    SimplicialComplex left_mesh = abd_mesh;
+    {
+        left_mesh.instances().resize(1);
+        Transform t0 = Transform::Identity();
+        t0.translate(Vector3::UnitX() * -0.6);
+        view(left_mesh.transforms())[0] = t0.matrix();
+
+        auto is_fixed = left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [left_geo_slot, left_rest_geo_slot] = left_link->geometries().create(left_mesh);
+
+    // Right body: free
+    SimplicialComplex right_mesh = abd_mesh;
+    {
+        right_mesh.instances().resize(1);
+        Transform t0 = Transform::Identity();
+        t0.translate(Vector3::UnitX() * 0.6);
+        view(right_mesh.transforms())[0] = t0.matrix();
+
+        auto is_fixed = right_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 0;
+    }
+    auto [right_geo_slot, right_rest_geo_slot] = right_link->geometries().create(right_mesh);
+
+    // Prismatic joint along a diagonal axis
+    vector<Vector2i> Es = {{0, 1}};
+    vector<Vector3>  Vs = {Vector3{0.0, 0.0, 0.0}, Vector3{0.0, 0.0, 1.0}};
+
+    auto joint_mesh = linemesh(Vs, Es);
+    label_surface(joint_mesh);
+
+    // 1) Base prismatic joint
+    AffineBodyPrismaticJoint         prismatic_joint;
+    vector<S<SimplicialComplexSlot>> l_geo_slots = {left_geo_slot};
+    vector<S<SimplicialComplexSlot>> r_geo_slots = {right_geo_slot};
+    prismatic_joint.apply_to(joint_mesh, span{l_geo_slots}, span{r_geo_slots}, 100.0);
+
+    // 2) Driving constitution (active during frames 1..100)
+    AffineBodyDrivingPrismaticJoint driving;
+    vector<Float>                   driving_strength = {100.0};
+    driving.apply_to(joint_mesh, span{driving_strength});
+
+    // 3) External force constitution (active during frames 101..200)
+    AffineBodyPrismaticJointExternalBodyForce ext_force;
+    ext_force.apply_to(joint_mesh, Float{0});
+
+    auto joint_object = scene.objects().create("prismatic_joint");
+    joint_object->geometries().create(joint_mesh);
+
+    constexpr IndexT kDrivingEndFrame = 100;
+
+    scene.animator().insert(
+        *joint_object,
+        [=](Animation::UpdateInfo& info)
+        {
+            for(auto& geo_slot : info.geo_slots())
+            {
+                if(!geo_slot)
+                    continue;
+
+                auto& geo = geo_slot->geometry();
+                auto* sc  = geo.as<SimplicialComplex>();
+                if(!sc)
+                    continue;
+
+                bool driving_phase = (info.frame() <= kDrivingEndFrame);
+
+                // --- driving attributes ---
+                auto driving_is_constrained =
+                    sc->edges().find<IndexT>("driving/is_constrained");
+                auto aim_distance = sc->edges().find<Float>("aim_distance");
+                auto distances    = sc->edges().find<Float>("distance");
+
+                if(driving_is_constrained)
+                {
+                    auto v = view(*driving_is_constrained);
+                    std::fill(v.begin(), v.end(), driving_phase ? 1 : 0);
+                }
+
+                if(driving_phase && aim_distance && distances)
+                {
+                    auto aim_view  = view(*aim_distance);
+                    auto dist_view = view(*distances);
+                    const Float velocity = (info.frame() <= 50) ? -10.0f : 10.0f;
+                    for(size_t i = 0; i < std::min(aim_view.size(), dist_view.size()); ++i)
+                        aim_view[i] = dist_view[i] + info.dt() * velocity;
+                }
+
+                // --- external force attributes ---
+                auto ext_force_is_constrained =
+                    sc->edges().find<IndexT>("external_force/is_constrained");
+                auto external_force = sc->edges().find<Float>("external_force");
+
+                if(ext_force_is_constrained)
+                {
+                    auto v = view(*ext_force_is_constrained);
+                    std::fill(v.begin(), v.end(), driving_phase ? 0 : 1);
+                }
+
+                if(!driving_phase && external_force)
+                {
+                    Float force_value = (info.frame() <= 150) ? -1000 : 1000.0;
+                    std::ranges::fill(view(*external_force), force_value);
+                    spdlog::info("Frame {} external_force: {:.2f}", info.frame(), force_value);
+                }
+
+                // --- logging ---
+                if(distances)
+                {
+                    auto dist_view = view(*distances);
+                    for(size_t i = 0; i < dist_view.size(); ++i)
+                        printf("Frame {%zu} distance: {%f}\n", info.frame(), dist_view[i]);
+                }
+            }
+        });
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+
+    while(world.frame() < 200)
+    {
+        world.advance();
+        REQUIRE(world.is_valid());
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+}

--- a/apps/tests/sim_case/82_abd_revolute_joint_driving_and_external_torque.cpp
+++ b/apps/tests/sim_case/82_abd_revolute_joint_driving_and_external_torque.cpp
@@ -1,0 +1,181 @@
+#include <app/app.h>
+#include <numbers>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+#include <uipc/constitution/affine_body_revolute_joint.h>
+#include <uipc/constitution/affine_body_driving_revolute_joint.h>
+#include <uipc/constitution/affine_body_revolute_joint_external_force.h>
+
+TEST_CASE("82_abd_revolute_joint_driving_and_external_torque", "[abd][joint][driving][external_force]")
+{
+    using namespace uipc;
+    using namespace uipc::geometry;
+    using namespace uipc::core;
+    using namespace uipc::constitution;
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    uipc::logger::set_level(uipc::Logger::Level::warn);
+    auto config                            = test::Scene::default_config();
+    config["gravity"]                      = Vector3{0.0, 0.0, 0.0};
+    config["contact"]["enable"]            = true;
+    config["line_search"]["report_energy"] = true;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    scene.contact_tabular().default_model(0.5, 1.0_GPa);
+
+    Transform pre_transform = Transform::Identity();
+    pre_transform.scale(0.4);
+    SimplicialComplexIO io{pre_transform};
+
+    auto left_link  = scene.objects().create("left");
+    auto right_link = scene.objects().create("right");
+
+    AffineBodyConstitution abd;
+    SimplicialComplex      abd_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(abd_mesh, 100.0_MPa);
+    label_surface(abd_mesh);
+
+    // Left body: fixed
+    SimplicialComplex left_mesh = abd_mesh;
+    {
+        left_mesh.instances().resize(1);
+        Transform t0 = Transform::Identity();
+        t0.translate(Vector3::UnitX() * -0.6);
+        view(left_mesh.transforms())[0] = t0.matrix();
+
+        auto is_fixed = left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [left_geo_slot, left_rest_geo_slot] = left_link->geometries().create(left_mesh);
+
+    // Right body: free
+    SimplicialComplex right_mesh = abd_mesh;
+    {
+        right_mesh.instances().resize(1);
+        Transform t0 = Transform::Identity();
+        t0.translate(Vector3::UnitX() * 0.6);
+        view(right_mesh.transforms())[0] = t0.matrix();
+
+        auto is_fixed = right_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 0;
+    }
+    auto [right_geo_slot, right_rest_geo_slot] = right_link->geometries().create(right_mesh);
+
+    // Revolute joint along Z axis
+    vector<Vector2i> Es = {{0, 1}};
+    vector<Vector3>  Vs = {Vector3{0.0, 0.0, -0.5}, Vector3{0.0, 0.0, 0.5}};
+
+    auto joint_mesh = linemesh(Vs, Es);
+    label_surface(joint_mesh);
+
+    // 1) Base revolute joint
+    AffineBodyRevoluteJoint          revolute_joint;
+    vector<S<SimplicialComplexSlot>> l_geo_slots = {left_geo_slot};
+    vector<S<SimplicialComplexSlot>> r_geo_slots = {right_geo_slot};
+    revolute_joint.apply_to(joint_mesh, span{l_geo_slots}, span{r_geo_slots}, 100.0);
+
+    // 2) Driving constitution (active during frames 1..100)
+    AffineBodyDrivingRevoluteJoint driving;
+    vector<Float>                  driving_strength = {100.0};
+    driving.apply_to(joint_mesh, span{driving_strength});
+
+    // 3) External torque constitution (active during frames 101..200)
+    AffineBodyRevoluteJointExternalBodyForce ext_torque;
+    ext_torque.apply_to(joint_mesh, Float{0});
+
+    auto joint_object = scene.objects().create("revolute_joint");
+    joint_object->geometries().create(joint_mesh);
+
+    auto to_degrees = [](auto radians)
+    { return radians * (180.0 / std::numbers::pi); };
+
+    constexpr IndexT kDrivingEndFrame = 100;
+
+    scene.animator().insert(
+        *joint_object,
+        [=](Animation::UpdateInfo& info)
+        {
+            for(auto& geo_slot : info.geo_slots())
+            {
+                if(!geo_slot)
+                    continue;
+
+                auto& geo = geo_slot->geometry();
+                auto* sc  = geo.as<SimplicialComplex>();
+                if(!sc)
+                    continue;
+
+                bool driving_phase = (info.frame() <= kDrivingEndFrame);
+
+                // --- driving attributes ---
+                auto driving_is_constrained =
+                    sc->edges().find<IndexT>("driving/is_constrained");
+                auto aim_angle = sc->edges().find<Float>("aim_angle");
+                auto angles    = sc->edges().find<Float>("angle");
+
+                if(driving_is_constrained)
+                {
+                    auto v = view(*driving_is_constrained);
+                    std::fill(v.begin(), v.end(), driving_phase ? 1 : 0);
+                }
+
+                if(driving_phase && aim_angle && angles)
+                {
+                    auto        aim_view   = view(*aim_angle);
+                    auto        angle_view = view(*angles);
+                    const Float velocity = (info.frame() <= 50) ? -5.0f : 5.0f;
+                    for(size_t i = 0; i < std::min(aim_view.size(), angle_view.size()); ++i)
+                        aim_view[i] = angle_view[i] + info.dt() * velocity;
+                }
+
+                // --- external torque attributes ---
+                auto torque_is_constrained =
+                    sc->edges().find<IndexT>("external_torque/is_constrained");
+                auto external_torque = sc->edges().find<Float>("external_torque");
+
+                if(torque_is_constrained)
+                {
+                    auto v = view(*torque_is_constrained);
+                    std::fill(v.begin(), v.end(), driving_phase ? 0 : 1);
+                }
+
+                if(!driving_phase && external_torque)
+                {
+                    Float torque_value = (info.frame() <= 150) ? -1000.0 : 1000.0;
+                    std::ranges::fill(view(*external_torque), torque_value);
+                    spdlog::info("Frame {} external_torque: {:.2f}", info.frame(), torque_value);
+                }
+
+                // --- logging ---
+                if(angles)
+                {
+                    auto angle_view = view(*angles);
+                    printf("Frame {%zu} angle: {%f} rad ({%f} deg)\n",
+                           info.frame(),
+                           angle_view[0],
+                           to_degrees(angle_view[0]));
+                }
+            }
+        });
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+
+    while(world.frame() < 200)
+    {
+        world.advance();
+        REQUIRE(world.is_valid());
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+}

--- a/src/backends/cuda/affine_body/affine_body_prismatic_joint_external_body_force.cu
+++ b/src/backends/cuda/affine_body/affine_body_prismatic_joint_external_body_force.cu
@@ -44,8 +44,12 @@ class AffineBodyPrismaticJointExternalBodyForce final : public AffineBodyExterna
                     body_ids = constraint->body_ids().viewer().name("body_ids"),
                     forces   = constraint->forces().viewer().name("forces"),
                     rest_tangents = constraint->rest_tangents().viewer().name("rest_tangents"),
+                    constrained_flags = constraint->constrained_flags().viewer().name("constrained_flags"),
                     qs = affine_body_dynamics->qs().cviewer().name("qs")] __device__(int i) mutable
                    {
+                       if(constrained_flags(i) == 0)
+                           return;
+
                        Vector2i bids = body_ids(i);
                        Float    f    = forces(i);
 
@@ -89,7 +93,7 @@ class AffineBodyPrismaticJointExternalForceTimeIntegrator : public TimeIntegrato
 
     void do_build(BuildInfo& info) override
     {
-        constraint          = require<AffineBodyPrismaticJointExternalBodyForceConstraint>();
+        constraint = require<AffineBodyPrismaticJointExternalBodyForceConstraint>();
         affine_body_dynamics = require<AffineBodyDynamics>();
     }
 
@@ -107,13 +111,18 @@ class AffineBodyPrismaticJointExternalForceTimeIntegrator : public TimeIntegrato
         ParallelFor()
             .file_line(__FILE__, __LINE__)
             .apply(N,
-                   [body_ids       = constraint->body_ids().cviewer().name("body_ids"),
+                   [body_ids = constraint->body_ids().cviewer().name("body_ids"),
                     rest_positions = constraint->rest_positions().cviewer().name("rest_positions"),
-                    rest_tangents  = constraint->rest_tangents().cviewer().name("rest_tangents"),
+                    rest_tangents = constraint->rest_tangents().cviewer().name("rest_tangents"),
                     init_distances = constraint->init_distances().cviewer().name("init_distances"),
                     current_distances = constraint->current_distances().viewer().name("current_distances"),
+                    constrained_flags =
+                        constraint->constrained_flags().cviewer().name("constrained_flags"),
                     qs = affine_body_dynamics->qs().cviewer().name("qs")] __device__(int I)
                    {
+                       if(constrained_flags(I) == 0)
+                           return;
+
                        Vector2i bids = body_ids(I);
 
                        Vector12 q_i = qs(bids(0));

--- a/src/backends/cuda/affine_body/affine_body_revolute_joint_external_body_force.cu
+++ b/src/backends/cuda/affine_body/affine_body_revolute_joint_external_body_force.cu
@@ -42,8 +42,12 @@ class AffineBodyRevoluteJointExternalBodyForce final : public AffineBodyExternal
                     body_ids = constraint->body_ids().viewer().name("body_ids"),
                     torques  = constraint->torques().viewer().name("torques"),
                     rest_positions = constraint->rest_positions().viewer().name("rest_positions"),
+                    constrained_flags = constraint->constrained_flags().viewer().name("constrained_flags"),
                     qs = affine_body_dynamics->qs().cviewer().name("qs")] __device__(int i) mutable
                    {
+                       if(constrained_flags(i) == 0)
+                           return;
+
                        Vector2i bids = body_ids(i);
                        Float    tau  = torques(i);
 
@@ -85,13 +89,13 @@ class AffineBodyRevoluteJointExternalBodyForce final : public AffineBodyExternal
                        Vector12 F_i = Vector12::Zero();
                        if(r_sq_i > eps)
                        {
-                           F_i.segment<3>(0) = -tau * e_world_i.cross(r_i) / r_sq_i;
+                           F_i.segment<3>(0) = tau * e_world_i.cross(r_i) / r_sq_i;
                        }
 
                        Vector12 F_j = Vector12::Zero();
                        if(r_sq_j > eps)
                        {
-                           F_j.segment<3>(0) = tau * e_world_j.cross(r_j) / r_sq_j;
+                           F_j.segment<3>(0) = -tau * e_world_j.cross(r_j) / r_sq_j;
                        }
 
                        eigen::atomic_add(external_forces(bids(0)), F_i);
@@ -133,46 +137,34 @@ class AffineBodyRevoluteJointExternalForceTimeIntegrator : public TimeIntegrator
             .file_line(__FILE__, __LINE__)
             .apply(N,
                    [body_ids = constraint->body_ids().cviewer().name("body_ids"),
-                    rest_positions = constraint->rest_positions().cviewer().name("rest_positions"),
+                    rest_axis = constraint->rest_axis().cviewer().name("rest_axis"),
+                    rest_normals = constraint->rest_normals().cviewer().name("rest_normals"),
                     init_angles = constraint->init_angles().cviewer().name("init_angles"),
                     current_angles = constraint->current_angles().viewer().name("current_angles"),
+                    constrained_flags =
+                        constraint->constrained_flags().cviewer().name("constrained_flags"),
                     qs = affine_body_dynamics->qs().cviewer().name("qs"),
                     PI = std::numbers::pi] __device__(int I)
                    {
+                       if(constrained_flags(I) == 0)
+                           return;
+
                        Vector2i bids = body_ids(I);
 
                        Vector12 q_i = qs(bids(0));
                        Vector12 q_j = qs(bids(1));
 
-                       const Vector12& X_bar = rest_positions(I);
-
-                       Vector3 x0_bar = X_bar.segment<3>(0);
-                       Vector3 x1_bar = X_bar.segment<3>(3);
-                       Vector3 x2_bar = X_bar.segment<3>(6);
-                       Vector3 x3_bar = X_bar.segment<3>(9);
-
-                       Vector3 h_bar_i = (x1_bar - x0_bar) * 0.5;
-                       Vector3 h_bar_j = (x3_bar - x2_bar) * 0.5;
-
-                       Vector3 e_bar_i = h_bar_i.normalized();
-                       Vector3 e_bar_j = h_bar_j.normalized();
-
-                       auto toNormal = [](const Vector3& W) -> Vector3
-                       {
-                           Vector3 ref = abs(W.dot(Vector3(1, 0, 0))) < 0.99 ?
-                                             Vector3(1, 0, 0) :
-                                             Vector3(0, 1, 0);
-                           Vector3 U   = ref.cross(W).normalized();
-                           return W.cross(U).normalized();
-                       };
-
-                       Vector3 n_bar_i = toNormal(e_bar_i);
-                       Vector3 v_bar_i = n_bar_i.cross(e_bar_i).normalized();
-                       Vector3 n_bar_j = toNormal(e_bar_j);
-                       Vector3 v_bar_j = n_bar_j.cross(e_bar_j).normalized();
+                       Vector6 axis_bar   = rest_axis(I);
+                       Vector6 normal_bar = rest_normals(I);
 
                        Vector12 F01_q;
-                       DRJ::F01_q<Float>(F01_q, v_bar_i, n_bar_i, q_i, v_bar_j, n_bar_j, q_j);
+                       DRJ::F01_q<Float>(F01_q,
+                                         axis_bar.segment<3>(0),
+                                         normal_bar.segment<3>(0),
+                                         q_i,
+                                         axis_bar.segment<3>(3),
+                                         normal_bar.segment<3>(3),
+                                         q_j);
 
                        Float curr_angle;
                        DRJ::currAngle<Float>(curr_angle, F01_q);

--- a/src/backends/cuda/affine_body/constraints/affine_body_prismatic_joint_external_body_force_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/affine_body_prismatic_joint_external_body_force_constraint.cu
@@ -28,6 +28,7 @@ static void collect_prismatic_data(InterAffineBodyAnimator::FilteredInfo& info,
                                    vector<Vector6>& h_rest_tangents,
                                    vector<Vector6>& h_rest_positions,
                                    vector<Float>&   h_init_distances,
+                                   vector<IndexT>&  h_is_constrained,
                                    bool             check_uid = false)
 {
     info.for_each(
@@ -71,8 +72,7 @@ static void collect_prismatic_data(InterAffineBodyAnimator::FilteredInfo& info,
 
             for(auto&& [i, e] : enumerate(Es))
             {
-                if(is_constrained_view[i] == 0)
-                    continue;
+                h_is_constrained.push_back(is_constrained_view[i]);
 
                 Vector2i geo_id  = geo_ids_view[i];
                 Vector2i inst_id = inst_ids_view[i];
@@ -119,6 +119,7 @@ void AffineBodyPrismaticJointExternalBodyForceConstraint::do_init(InterAffineBod
                            m_impl.h_rest_tangents,
                            m_impl.h_rest_positions,
                            m_impl.h_init_distances,
+                           m_impl.h_is_constrained,
                            true);
 
     SizeT N = m_impl.h_forces.size();
@@ -131,6 +132,7 @@ void AffineBodyPrismaticJointExternalBodyForceConstraint::do_init(InterAffineBod
         m_impl.rest_tangents.copy_from(m_impl.h_rest_tangents);
         m_impl.rest_positions.copy_from(m_impl.h_rest_positions);
         m_impl.init_distances.copy_from(m_impl.h_init_distances);
+        m_impl.is_constrained.copy_from(m_impl.h_is_constrained);
         m_impl.current_distances.resize(N, 0.0);
     }
 }
@@ -139,40 +141,37 @@ void AffineBodyPrismaticJointExternalBodyForceConstraint::do_step(InterAffineBod
 {
     auto geo_slots = world().scene().geometries();
 
-    m_impl.h_forces.clear();
-    m_impl.h_body_ids.clear();
-    m_impl.h_rest_tangents.clear();
-    m_impl.h_rest_positions.clear();
-    m_impl.h_init_distances.clear();
+    // Only update is_constrained and external_force (structural data unchanged from do_init)
+    SizeT offset = 0;
+    info.for_each(
+        geo_slots,
+        [&](const InterAffineBodyConstitutionManager::ForEachInfo& I, geometry::Geometry& geo)
+        {
+            auto sc = geo.as<geometry::SimplicialComplex>();
+            UIPC_ASSERT(sc, "AffineBodyPrismaticJointExternalBodyForceConstraint: geometry must be SimplicialComplex");
 
-    collect_prismatic_data(info,
-                           geo_slots,
-                           m_impl.h_forces,
-                           m_impl.h_body_ids,
-                           m_impl.h_rest_tangents,
-                           m_impl.h_rest_positions,
-                           m_impl.h_init_distances);
+            auto is_constrained = sc->edges().find<IndexT>("external_force/is_constrained");
+            UIPC_ASSERT(is_constrained, "AffineBodyPrismaticJointExternalBodyForceConstraint: Geometry must have 'external_force/is_constrained' attribute on `edges`");
+            auto is_constrained_view = is_constrained->view();
+
+            auto external_force = sc->edges().find<Float>("external_force");
+            UIPC_ASSERT(external_force, "AffineBodyPrismaticJointExternalBodyForceConstraint: Geometry must have 'external_force' attribute on `edges`");
+            auto external_force_view = external_force->view();
+
+            auto Es = sc->edges().topo().view();
+            for(auto&& [i, e] : enumerate(Es))
+            {
+                m_impl.h_is_constrained[offset] = is_constrained_view[i];
+                m_impl.h_forces[offset]         = external_force_view[i];
+                ++offset;
+            }
+        });
 
     SizeT N = m_impl.h_forces.size();
-    m_impl.h_current_distances.resize(N, 0.0);
-
     if(N > 0)
     {
+        m_impl.is_constrained.copy_from(m_impl.h_is_constrained);
         m_impl.forces.copy_from(m_impl.h_forces);
-        m_impl.body_ids.copy_from(m_impl.h_body_ids);
-        m_impl.rest_tangents.copy_from(m_impl.h_rest_tangents);
-        m_impl.rest_positions.copy_from(m_impl.h_rest_positions);
-        m_impl.init_distances.copy_from(m_impl.h_init_distances);
-        m_impl.current_distances.resize(N);
-    }
-    else
-    {
-        m_impl.forces.resize(0);
-        m_impl.body_ids.resize(0);
-        m_impl.rest_tangents.resize(0);
-        m_impl.rest_positions.resize(0);
-        m_impl.init_distances.resize(0);
-        m_impl.current_distances.resize(0);
     }
 }
 
@@ -203,10 +202,12 @@ void AffineBodyPrismaticJointExternalBodyForceConstraint::write_scene()
 
                        for(SizeT i = 0; i < is_constrained_view.size(); ++i)
                        {
-                           if(is_constrained_view[i] == 0)
-                               continue;
                            if(offset < m_impl.h_current_distances.size())
-                               distance_view[i] = m_impl.h_current_distances[offset++];
+                           {
+                               if(is_constrained_view[i] != 0)
+                                   distance_view[i] = m_impl.h_current_distances[offset];
+                               ++offset;
+                           }
                        }
                    });
 }
@@ -239,6 +240,11 @@ muda::CBufferView<Float> AffineBodyPrismaticJointExternalBodyForceConstraint::in
 muda::DeviceBuffer<Float>& AffineBodyPrismaticJointExternalBodyForceConstraint::current_distances() noexcept
 {
     return m_impl.current_distances;
+}
+
+muda::CBufferView<IndexT> AffineBodyPrismaticJointExternalBodyForceConstraint::constrained_flags() const noexcept
+{
+    return m_impl.is_constrained.view();
 }
 
 void AffineBodyPrismaticJointExternalBodyForceConstraint::do_report_extent(

--- a/src/backends/cuda/affine_body/constraints/affine_body_prismatic_joint_external_body_force_constraint.h
+++ b/src/backends/cuda/affine_body/constraints/affine_body_prismatic_joint_external_body_force_constraint.h
@@ -19,6 +19,7 @@ class AffineBodyPrismaticJointExternalBodyForceConstraint final : public InterAf
         vector<Vector6>  h_rest_positions;
         vector<Float>    h_init_distances;
         vector<Float>    h_current_distances;
+        vector<IndexT>   h_is_constrained;
 
         muda::DeviceBuffer<Float>    forces;
         muda::DeviceBuffer<Vector2i> body_ids;
@@ -26,6 +27,7 @@ class AffineBodyPrismaticJointExternalBodyForceConstraint final : public InterAf
         muda::DeviceBuffer<Vector6>  rest_positions;
         muda::DeviceBuffer<Float>    init_distances;
         muda::DeviceBuffer<Float>    current_distances;
+        muda::DeviceBuffer<IndexT>   is_constrained;
     };
 
     muda::CBufferView<Float>    forces() const noexcept;
@@ -34,6 +36,7 @@ class AffineBodyPrismaticJointExternalBodyForceConstraint final : public InterAf
     muda::CBufferView<Vector6>  rest_positions() const noexcept;
     muda::CBufferView<Float>    init_distances() const noexcept;
     muda::DeviceBuffer<Float>&  current_distances() noexcept;
+    muda::CBufferView<IndexT>   constrained_flags() const noexcept;
 
   private:
     virtual void do_build(BuildInfo& info) override;

--- a/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_body_force_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_body_force_constraint.cu
@@ -26,7 +26,10 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
                                vector<Float>&                         h_torques,
                                vector<Vector2i>& h_body_ids,
                                vector<Vector12>& h_rest_positions,
-                               vector<Float>&    h_init_angles)
+                               vector<Vector6>&  h_rest_axis,
+                               vector<Vector6>&  h_rest_normals,
+                               vector<Float>&    h_init_angles,
+                               vector<IndexT>&   h_is_constrained)
 {
     info.for_each(
         geo_slots,
@@ -56,10 +59,21 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
             auto Es = sc->edges().topo().view();
             auto Ps = sc->positions().view();
 
+            auto toNormal = [&](const Vector3& W) -> Vector3
+            {
+                Vector3 ref = abs(W.dot(Vector3(1, 0, 0))) < 0.99 ?
+                                  Vector3(1, 0, 0) :
+                                  Vector3(0, 1, 0);
+
+                Vector3 U = ref.cross(W).normalized();
+                Vector3 V = W.cross(U).normalized();
+
+                return V;
+            };
+
             for(auto&& [i, e] : enumerate(Es))
             {
-                if(is_constrained_view[i] == 0)
-                    continue;
+                h_is_constrained.push_back(is_constrained_view[i]);
 
                 Vector2i geo_id  = geo_ids_view[i];
                 Vector2i inst_id = inst_ids_view[i];
@@ -83,6 +97,13 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
                 P0               = mid - HalfAxis;
                 P1               = mid + HalfAxis;
 
+
+                Vector3 UnitE = (P0 - P1).normalized();
+                // normal
+                Vector3 normal = toNormal(UnitE);
+                Vector3 vec    = normal.cross(UnitE).normalized();
+
+
                 Transform LT{left_sc->transforms().view()[inst_id(0)]};
                 Transform RT{right_sc->transforms().view()[inst_id(1)]};
 
@@ -92,6 +113,16 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
                 rest_pos.segment<3>(6) = RT.inverse() * P0;
                 rest_pos.segment<3>(9) = RT.inverse() * P1;
                 h_rest_positions.push_back(rest_pos);
+
+                Vector6 rest_axis;
+                rest_axis.segment<3>(0) = LT.rotation().inverse() * vec;
+                rest_axis.segment<3>(3) = RT.rotation().inverse() * vec;
+                h_rest_axis.push_back(rest_axis);
+
+                Vector6 rest_normal;
+                rest_normal.segment<3>(0) = LT.rotation().inverse() * normal;
+                rest_normal.segment<3>(3) = RT.rotation().inverse() * normal;
+                h_rest_normals.push_back(rest_normal);
 
                 h_torques.push_back(external_torque_view[i]);
                 h_init_angles.push_back(init_angle ? init_angle->view()[i] : Float{0});
@@ -124,7 +155,10 @@ void AffineBodyRevoluteJointExternalBodyForceConstraint::do_init(InterAffineBody
                        m_impl.h_torques,
                        m_impl.h_body_ids,
                        m_impl.h_rest_positions,
-                       m_impl.h_init_angles);
+                       m_impl.h_rest_axis,
+                       m_impl.h_rest_normals,
+                       m_impl.h_init_angles,
+                       m_impl.h_is_constrained);
 
     SizeT N = m_impl.h_torques.size();
     m_impl.h_current_angles.resize(N, 0.0);
@@ -134,8 +168,11 @@ void AffineBodyRevoluteJointExternalBodyForceConstraint::do_init(InterAffineBody
         m_impl.torques.copy_from(m_impl.h_torques);
         m_impl.body_ids.copy_from(m_impl.h_body_ids);
         m_impl.rest_positions.copy_from(m_impl.h_rest_positions);
+        m_impl.rest_axis.copy_from(m_impl.h_rest_axis);
+        m_impl.rest_normals.copy_from(m_impl.h_rest_normals);
         m_impl.init_angles.copy_from(m_impl.h_init_angles);
-        m_impl.current_angles.resize(N, 0.0);
+        m_impl.is_constrained.copy_from(m_impl.h_is_constrained);
+        m_impl.current_angles.copy_from(m_impl.h_init_angles);
     }
 }
 
@@ -143,36 +180,37 @@ void AffineBodyRevoluteJointExternalBodyForceConstraint::do_step(InterAffineBody
 {
     auto geo_slots = world().scene().geometries();
 
-    m_impl.h_torques.clear();
-    m_impl.h_body_ids.clear();
-    m_impl.h_rest_positions.clear();
-    m_impl.h_init_angles.clear();
+    // Only update is_constrained and external_torque (structural data unchanged from do_init)
+    SizeT offset = 0;
+    info.for_each(
+        geo_slots,
+        [&](const InterAffineBodyConstitutionManager::ForEachInfo& I, geometry::Geometry& geo)
+        {
+            auto sc = geo.as<geometry::SimplicialComplex>();
+            UIPC_ASSERT(sc, "AffineBodyRevoluteJointExternalBodyForceConstraint: geometry must be SimplicialComplex");
 
-    collect_joint_data(info,
-                       geo_slots,
-                       m_impl.h_torques,
-                       m_impl.h_body_ids,
-                       m_impl.h_rest_positions,
-                       m_impl.h_init_angles);
+            auto is_constrained = sc->edges().find<IndexT>("external_torque/is_constrained");
+            UIPC_ASSERT(is_constrained, "AffineBodyRevoluteJointExternalBodyForceConstraint: Geometry must have 'external_torque/is_constrained' attribute on `edges`");
+            auto is_constrained_view = is_constrained->view();
+
+            auto external_torque = sc->edges().find<Float>("external_torque");
+            UIPC_ASSERT(external_torque, "AffineBodyRevoluteJointExternalBodyForceConstraint: Geometry must have 'external_torque' attribute on `edges`");
+            auto external_torque_view = external_torque->view();
+
+            auto Es = sc->edges().topo().view();
+            for(auto&& [i, e] : enumerate(Es))
+            {
+                m_impl.h_is_constrained[offset] = is_constrained_view[i];
+                m_impl.h_torques[offset]        = external_torque_view[i];
+                ++offset;
+            }
+        });
 
     SizeT N = m_impl.h_torques.size();
-    m_impl.h_current_angles.resize(N, 0.0);
-
     if(N > 0)
     {
+        m_impl.is_constrained.copy_from(m_impl.h_is_constrained);
         m_impl.torques.copy_from(m_impl.h_torques);
-        m_impl.body_ids.copy_from(m_impl.h_body_ids);
-        m_impl.rest_positions.copy_from(m_impl.h_rest_positions);
-        m_impl.init_angles.copy_from(m_impl.h_init_angles);
-        m_impl.current_angles.resize(N);
-    }
-    else
-    {
-        m_impl.torques.resize(0);
-        m_impl.body_ids.resize(0);
-        m_impl.rest_positions.resize(0);
-        m_impl.init_angles.resize(0);
-        m_impl.current_angles.resize(0);
     }
 }
 
@@ -203,10 +241,12 @@ void AffineBodyRevoluteJointExternalBodyForceConstraint::write_scene()
 
                        for(SizeT i = 0; i < is_constrained_view.size(); ++i)
                        {
-                           if(is_constrained_view[i] == 0)
-                               continue;
                            if(offset < m_impl.h_current_angles.size())
-                               angle_view[i] = m_impl.h_current_angles[offset++];
+                           {
+                               if(is_constrained_view[i] != 0)
+                                   angle_view[i] = m_impl.h_current_angles[offset];
+                               ++offset;
+                           }
                        }
                    });
 }
@@ -226,6 +266,17 @@ muda::CBufferView<Vector12> AffineBodyRevoluteJointExternalBodyForceConstraint::
     return m_impl.rest_positions.view();
 }
 
+muda::CBufferView<Vector6> AffineBodyRevoluteJointExternalBodyForceConstraint::rest_axis() const noexcept
+{
+    return m_impl.rest_axis.view();
+}
+
+muda::CBufferView<Vector6> AffineBodyRevoluteJointExternalBodyForceConstraint::rest_normals() const noexcept
+{
+    return m_impl.rest_normals.view();
+}
+
+
 muda::CBufferView<Float> AffineBodyRevoluteJointExternalBodyForceConstraint::init_angles() const noexcept
 {
     return m_impl.init_angles.view();
@@ -234,6 +285,11 @@ muda::CBufferView<Float> AffineBodyRevoluteJointExternalBodyForceConstraint::ini
 muda::DeviceBuffer<Float>& AffineBodyRevoluteJointExternalBodyForceConstraint::current_angles() noexcept
 {
     return m_impl.current_angles;
+}
+
+muda::CBufferView<IndexT> AffineBodyRevoluteJointExternalBodyForceConstraint::constrained_flags() const noexcept
+{
+    return m_impl.is_constrained.view();
 }
 
 void AffineBodyRevoluteJointExternalBodyForceConstraint::do_report_extent(

--- a/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_body_force_constraint.h
+++ b/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_body_force_constraint.h
@@ -13,24 +13,33 @@ class AffineBodyRevoluteJointExternalBodyForceConstraint final : public InterAff
     class Impl
     {
       public:
-        vector<Float>     h_torques;
-        vector<Vector2i>  h_body_ids;
-        vector<Vector12>  h_rest_positions;
-        vector<Float>     h_init_angles;
-        vector<Float>     h_current_angles;
+        vector<Float>    h_torques;
+        vector<Vector2i> h_body_ids;
+        vector<Vector12> h_rest_positions;
+        vector<Vector6>  h_rest_axis;
+        vector<Vector6>  h_rest_normals;
+        vector<Float>    h_init_angles;
+        vector<Float>    h_current_angles;
+        vector<IndexT>   h_is_constrained;
 
-        muda::DeviceBuffer<Float>     torques;
-        muda::DeviceBuffer<Vector2i>  body_ids;
-        muda::DeviceBuffer<Vector12>  rest_positions;
-        muda::DeviceBuffer<Float>     init_angles;
-        muda::DeviceBuffer<Float>     current_angles;
+        muda::DeviceBuffer<Float>    torques;
+        muda::DeviceBuffer<Vector2i> body_ids;
+        muda::DeviceBuffer<Vector12> rest_positions;
+        muda::DeviceBuffer<Vector6>  rest_axis;
+        muda::DeviceBuffer<Vector6>  rest_normals;
+        muda::DeviceBuffer<Float>    init_angles;
+        muda::DeviceBuffer<Float>    current_angles;
+        muda::DeviceBuffer<IndexT>   is_constrained;
     };
 
-    muda::CBufferView<Float>     torques() const noexcept;
-    muda::CBufferView<Vector2i>  body_ids() const noexcept;
-    muda::CBufferView<Vector12>  rest_positions() const noexcept;
-    muda::CBufferView<Float>     init_angles() const noexcept;
-    muda::DeviceBuffer<Float>&   current_angles() noexcept;
+    muda::CBufferView<Float>    torques() const noexcept;
+    muda::CBufferView<Vector2i> body_ids() const noexcept;
+    muda::CBufferView<Vector12> rest_positions() const noexcept;
+    muda::CBufferView<Vector6>  rest_axis() const noexcept;
+    muda::CBufferView<Vector6>  rest_normals() const noexcept;
+    muda::CBufferView<Float>    init_angles() const noexcept;
+    muda::DeviceBuffer<Float>&  current_angles() noexcept;
+    muda::CBufferView<IndexT>   constrained_flags() const noexcept;
 
   private:
     virtual void do_build(BuildInfo& info) override;


### PR DESCRIPTION
## Summary
- gate affine-body revolute/prismatic external body force application with explicit constraint-level enable flags
- update CUDA external-force constraints to respect these flags and avoid applying external loads when the corresponding constraint is disabled
- add/expand simulation tests for revolute/prismatic joint driving + external force/torque behavior

## Breaking changes
- none

## Related
- n/a

## Test plan
- [ ] build CUDA backend test targets
- [ ] run `uipc_test_sim_case` covering new revolute/prismatic external-load scenarios
