### PR TITLE
fix(cuda): correct revolute joint axis direction for right-handed rotation

### DIFF
--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -493,7 +493,7 @@ Edge             = ({}, {}))",
                                 inst_id(1),
                                 right_sc->instances().size());
 
-                    Vector3 UnitE = (P0 - P1).normalized();
+                    Vector3 UnitE = (P1 - P0).normalized();
                     // normal
                     Vector3 normal = toNormal(UnitE);
                     Vector3 vec    = normal.cross(UnitE).normalized();

--- a/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_force_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_force_constraint.cu
@@ -98,7 +98,7 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
                 P1               = mid + HalfAxis;
 
 
-                Vector3 UnitE = (P0 - P1).normalized();
+                Vector3 UnitE = (P1 - P0).normalized();
                 // normal
                 Vector3 normal = toNormal(UnitE);
                 Vector3 vec    = normal.cross(UnitE).normalized();


### PR DESCRIPTION
## Summary

- Fix revolute joint axis direction (`UnitE`) by reversing it from `(P0 - P1)` to `(P1 - P0)`, ensuring positive angles follow right-handed spiral rotation around the joint axis.
- Applied consistently in both the joint constitution and external force constraint.

