### PR TITLE
fix(cuda): initialize AL vertex-half-plane TOI buffer after resize

### DIFF
--- a/src/backends/cuda/collision_detection/filters/al_vertex_half_plane_trajectory_filter.cu
+++ b/src/backends/cuda/collision_detection/filters/al_vertex_half_plane_trajectory_filter.cu
@@ -51,6 +51,7 @@ void ALVertexHalfPlaneTrajectoryFilter::Impl::filter_toi(FilterTOIInfo& info)
 
     info.toi().fill(1.1f);
     tois.resize(info.surf_vertices().size() * info.plane_positions().size());
+    tois.fill(1.1f);
     PHs.resize(info.surf_vertices().size() * info.plane_positions().size());
 
     // TODO: just hard code the slackness for now


### PR DESCRIPTION
## Summary
- Initialize `tois` buffer with `1.1f` after `resize()` in `ALVertexHalfPlaneTrajectoryFilter::filter_toi()` to prevent uninitialized values (skipped by contact tabular check) from affecting TOI filtering in AL-IPC half-plane contact

## Test plan
- [ ] Run AL-IPC simulation with ground contact — verify no spurious TOI values

🤖 Generated with [Claude Code](https://claude.com/claude-code)