### PR TITLE
fix(cuda): use aim geometry instead of rest geometry for stitch Dm/B initialization

### DIFF
--- a/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_edge_stitch.cu
+++ b/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_edge_stitch.cu
@@ -76,15 +76,6 @@ class SoftVertexEdgeStitch : public InterPrimitiveConstitution
                 Vector2i ids         = geo_ids->view()[0];
                 auto     l_slot      = info.geo_slot(ids[0]);
                 auto     r_slot      = info.geo_slot(ids[1]);
-                auto     l_rest_slot = info.rest_geo_slot(ids[0]);
-                auto     r_rest_slot = info.rest_geo_slot(ids[1]);
-                UIPC_ASSERT(l_rest_slot,
-                            "SoftVertexEdgeStitch requires rest geometry for slot id {}",
-                            ids[0]);
-                UIPC_ASSERT(r_rest_slot,
-                            "SoftVertexEdgeStitch requires rest geometry for slot id {}",
-                            ids[1]);
-
                 auto l_geo = l_slot->geometry().as<geometry::SimplicialComplex>();
                 UIPC_ASSERT(l_geo,
                             "SoftVertexEdgeStitch requires simplicial complex, but got {} ({})",
@@ -95,17 +86,6 @@ class SoftVertexEdgeStitch : public InterPrimitiveConstitution
                             "SoftVertexEdgeStitch requires simplicial complex, but got {} ({})",
                             r_slot->geometry().type(),
                             r_slot->id());
-                auto l_rest_geo =
-                    l_rest_slot->geometry().as<geometry::SimplicialComplex>();
-                UIPC_ASSERT(l_rest_geo,
-                            "SoftVertexEdgeStitch requires rest simplicial complex for id {}",
-                            ids[0]);
-                auto r_rest_geo =
-                    r_rest_slot->geometry().as<geometry::SimplicialComplex>();
-                UIPC_ASSERT(r_rest_geo,
-                            "SoftVertexEdgeStitch requires rest simplicial complex for id {}",
-                            ids[1]);
-
                 auto l_offset =
                     l_geo->meta().find<IndexT>(builtin::global_vertex_offset);
                 UIPC_ASSERT(l_offset,

--- a/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_edge_stitch.cu
+++ b/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_edge_stitch.cu
@@ -121,11 +121,11 @@ class SoftVertexEdgeStitch : public InterPrimitiveConstitution
                             r_slot->id());
                 IndexT r_offset_v = r_offset->view()[0];
 
-                auto rest0_pos    = l_rest_geo->positions().view();
-                auto rest1_pos    = r_rest_geo->positions().view();
+                auto aim0_pos     = l_geo->positions().view();
+                auto aim1_pos     = r_geo->positions().view();
 
-                Transform l_transform(l_rest_geo->transforms().view()[0]);
-                Transform r_transform(r_rest_geo->transforms().view()[0]);
+                Transform l_transform(l_geo->transforms().view()[0]);
+                Transform r_transform(r_geo->transforms().view()[0]);
 
                 auto topo_view    = topo->view();
                 auto mu_view      = mu_slot->view();
@@ -138,9 +138,9 @@ class SoftVertexEdgeStitch : public InterPrimitiveConstitution
                 {
                     const Vector3i& t = topo_view[i];
                     IndexT  v_id = t(0), e0 = t(1), e1 = t(2);
-                    Vector3 x0 = l_transform * rest0_pos[v_id];
-                    Vector3 x1 = r_transform * rest1_pos[e0];
-                    Vector3 x2 = r_transform * rest1_pos[e1];
+                    Vector3 x0 = l_transform * aim0_pos[v_id];
+                    Vector3 x1 = r_transform * aim1_pos[e0];
+                    Vector3 x2 = r_transform * aim1_pos[e1];
 
                     constexpr Float geo_degeneracy_tol = 1e-12;
 

--- a/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_triangle_stitch.cu
+++ b/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_triangle_stitch.cu
@@ -45,7 +45,6 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
         list<Float>     lambda_buffer;
         list<Matrix3x3> Dm_inv_buffer;
         list<Float>     rest_volume_buffer;
-
         auto geo_slots    = world().scene().geometries();
         using ForEachInfo = InterPrimitiveConstitutionManager::ForEachInfo;
         info.for_each(
@@ -107,11 +106,11 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
                             r_slot->id());
                 IndexT r_offset_v = r_offset->view()[0];
 
-                auto rest0_pos = l_rest_geo->positions().view();
-                auto rest1_pos = r_rest_geo->positions().view();
+                auto aim0_pos = l_geo->positions().view();
+                auto aim1_pos = r_geo->positions().view();
 
-                Transform l_transform(l_rest_geo->transforms().view()[0]);
-                Transform r_transform(r_rest_geo->transforms().view()[0]);
+                Transform l_transform(l_geo->transforms().view()[0]);
+                Transform r_transform(r_geo->transforms().view()[0]);
 
                 auto min_sep_slot = geo.instances().find<Float>("min_separate_distance");
                 UIPC_ASSERT(min_sep_slot, "SoftVertexTriangleStitch requires per-instance attribute `min_separate_distance`");
@@ -126,10 +125,10 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
                 {
                     const Vector4i& t = topo_view[i];
                     IndexT  v_id = t(0), tri0 = t(1), tri1 = t(2), tri2 = t(3);
-                    Vector3 x0 = l_transform * rest0_pos[v_id];
-                    Vector3 x1 = r_transform * rest1_pos[tri0];
-                    Vector3 x2 = r_transform * rest1_pos[tri1];
-                    Vector3 x3 = r_transform * rest1_pos[tri2];
+                    Vector3 x0 = l_transform * aim0_pos[v_id];
+                    Vector3 x1 = r_transform * aim1_pos[tri0];
+                    Vector3 x2 = r_transform * aim1_pos[tri1];
+                    Vector3 x3 = r_transform * aim1_pos[tri2];
 
                     Float   d  = min_sep_view[i];
                     Vector3 e1 = x2 - x1, e2 = x3 - x1;
@@ -145,6 +144,7 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
                     normal /= nrm;
 
                     Float signed_dist = normal.dot(x0 - x1);
+
                     if(std::abs(signed_dist) < d)
                     {
                         Float sign = (signed_dist >= 0) ? 1.0 : -1.0;
@@ -155,16 +155,26 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
                     Dm.col(0)      = x1 - x0;
                     Dm.col(1)      = x2 - x0;
                     Dm.col(2)      = x3 - x0;
+
+                    if(Dm.determinant() < 0)
+                    {
+                        std::swap(x1, x2);
+                        std::swap(tri0, tri1);
+                        Dm.col(0) = x1 - x0;
+                        Dm.col(1) = x2 - x0;
+                    }
+                    
                     Float rest_vol = (1.0 / 6.0) * std::abs(Dm.determinant());
 
-                    topo_buffer.push_back(Vector4i{t(0) + l_offset_v,
-                                                   t(1) + r_offset_v,
-                                                   t(2) + r_offset_v,
-                                                   t(3) + r_offset_v});
+                    topo_buffer.push_back(Vector4i{v_id + l_offset_v,
+                                                   tri0 + r_offset_v,
+                                                   tri1 + r_offset_v,
+                                                   tri2 + r_offset_v});
                     mu_buffer.push_back(mu_view[i]);
                     lambda_buffer.push_back(lambda_view[i]);
                     Dm_inv_buffer.push_back(Dm.inverse());
                     rest_volume_buffer.push_back(rest_vol);
+
                 }
             });
 
@@ -179,6 +189,7 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
         lambdas.copy_from(h_lambdas);
         Dm_invs.copy_from(h_Dm_invs);
         rest_volumes.copy_from(h_rest_volumes);
+
     }
 
     void do_report_energy_extent(EnergyExtentInfo& info) override

--- a/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_triangle_stitch.cu
+++ b/src/backends/cuda/inter_primitive_effect_system/constitutions/soft_vertex_triangle_stitch.cu
@@ -63,15 +63,6 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
                 Vector2i ids         = geo_ids->view()[0];
                 auto     l_slot      = info.geo_slot(ids[0]);
                 auto     r_slot      = info.geo_slot(ids[1]);
-                auto     l_rest_slot = info.rest_geo_slot(ids[0]);
-                auto     r_rest_slot = info.rest_geo_slot(ids[1]);
-                UIPC_ASSERT(l_rest_slot,
-                            "SoftVertexTriangleStitch requires rest geometry for slot id {}",
-                            ids[0]);
-                UIPC_ASSERT(r_rest_slot,
-                            "SoftVertexTriangleStitch requires rest geometry for slot id {}",
-                            ids[1]);
-
                 auto l_geo = l_slot->geometry().as<geometry::SimplicialComplex>();
                 UIPC_ASSERT(l_geo,
                             "SoftVertexTriangleStitch requires simplicial complex geometry, but got {} ({})",
@@ -82,17 +73,6 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
                             "SoftVertexTriangleStitch requires simplicial complex geometry, but got {} ({})",
                             r_slot->geometry().type(),
                             r_slot->id());
-                auto l_rest_geo =
-                    l_rest_slot->geometry().as<geometry::SimplicialComplex>();
-                UIPC_ASSERT(l_rest_geo,
-                            "SoftVertexTriangleStitch requires rest simplicial complex for id {}",
-                            ids[0]);
-                auto r_rest_geo =
-                    r_rest_slot->geometry().as<geometry::SimplicialComplex>();
-                UIPC_ASSERT(r_rest_geo,
-                            "SoftVertexTriangleStitch requires rest simplicial complex for id {}",
-                            ids[1]);
-
                 auto l_offset = l_geo->meta().find<IndexT>(builtin::global_vertex_offset);
                 UIPC_ASSERT(l_offset,
                             "SoftVertexTriangleStitch requires attribute `global_vertex_offset` on meta() of geometry {} ({})",
@@ -156,15 +136,17 @@ class SoftVertexTriangleStitch : public InterPrimitiveConstitution
                     Dm.col(1)      = x2 - x0;
                     Dm.col(2)      = x3 - x0;
 
-                    if(Dm.determinant() < 0)
+                    Float det = Dm.determinant();
+                    if(det < 0)
                     {
                         std::swap(x1, x2);
                         std::swap(tri0, tri1);
                         Dm.col(0) = x1 - x0;
                         Dm.col(1) = x2 - x0;
+                        det = -det;
                     }
                     
-                    Float rest_vol = (1.0 / 6.0) * std::abs(Dm.determinant());
+                    Float rest_vol = (1.0 / 6.0) * det;
 
                     topo_buffer.push_back(Vector4i{v_id + l_offset_v,
                                                    tri0 + r_offset_v,


### PR DESCRIPTION
## Summary

`SoftVertexTriangleStitch` and `SoftVertexEdgeStitch` computed `Dm_inv` / `inv_B` from **rest geometry** positions in `do_init()`, while the GPU kernels read current positions from the global `xs` array (which is initialized from **aim/init geometry**). When rest and init shapes differ (e.g. flat sewing pattern vs. draped garment), this mismatch caused the deformation gradient `F` to deviate from identity at frame 0, introducing spurious elastic energy.

### Changes

- **`soft_vertex_triangle_stitch.cu`**: Read positions and transforms from aim geometry (`l_geo` / `r_geo`) instead of rest geometry (`l_rest_geo` / `r_rest_geo`). Also handle negative `Dm` determinant by swapping triangle vertices and use the swapped local indices when building global topology.
- **`soft_vertex_edge_stitch.cu`**: Same fix — use aim geometry positions and transforms for `inv_B` computation.

### Verification

All 4 stitch-related sim case tests pass:
- `39_soft_vertex_stitch` (51 assertions)
- `67_soft_vertex_triangle_stitch` (52 assertions)
- `68_soft_vertex_edge_stitch` (52 assertions)
- `70_svts_degenerate_rest_shape` (33 assertions)
- Regression test (`fem_mas_soft_vertex_stitch_regression`) also passes.
