### PR TITLE
feat(constitution): add AffineBodyConstitution::create_proxy API

### DIFF
--- a/apps/tests/sim_case/84_proxy_abd_gravity.cpp
+++ b/apps/tests/sim_case/84_proxy_abd_gravity.cpp
@@ -51,7 +51,7 @@ TEST_CASE("84_proxy_abd_gravity", "[abd]")
 
     // --- Body B: proxy with matching mass properties ---
     auto proxy_object = scene.objects().create("proxy");
-    auto proxy_mesh   = abd.create_proxy(cube_mass, cube_com, cube_inertia, cube_volume);
+    auto proxy_mesh   = abd.create_proxy(kappa, cube_mass, cube_com, cube_inertia, cube_volume);
 
     view(proxy_mesh.transforms())[0] = t0.matrix();
 

--- a/apps/tests/sim_case/84_proxy_abd_gravity.cpp
+++ b/apps/tests/sim_case/84_proxy_abd_gravity.cpp
@@ -1,0 +1,75 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+
+TEST_CASE("84_proxy_abd_gravity", "[abd]")
+{
+    using namespace uipc;
+    using namespace uipc::core;
+    using namespace uipc::geometry;
+    using namespace uipc::constitution;
+
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+    std::string tetmesh_dir{AssetDir::tetmesh_path()};
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                 = test::Scene::default_config();
+    config["gravity"]           = Vector3{0, -9.8, 0};
+    config["contact"]["enable"] = false;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    AffineBodyConstitution abd;
+
+    Float     kappa = 100.0_MPa;
+    Float     rho   = 1e3;
+    Vector3   start = Vector3::UnitY();
+    Transform t0    = Transform::Identity();
+    t0.translation() = start;
+
+    // --- Body A: full ABD cube ---
+    auto cube_object = scene.objects().create("cube");
+    Transform pre_transform = Transform::Identity();
+    pre_transform.scale(0.3);
+    SimplicialComplexIO io{pre_transform};
+    auto cube_mesh = io.read(fmt::format("{}{}", tetmesh_dir, "cube.msh"));
+    label_surface(cube_mesh);
+    label_triangle_orient(cube_mesh);
+    abd.apply_to(cube_mesh, kappa, rho);
+
+    view(cube_mesh.transforms())[0] = t0.matrix();
+
+    auto cube_mass    = cube_mesh.meta().find<Float>("mass")->view()[0];
+    auto cube_com     = cube_mesh.meta().find<Vector3>("mass_center")->view()[0];
+    auto cube_inertia = cube_mesh.meta().find<Matrix3x3>("inertia")->view()[0];
+    auto cube_volume  = cube_mesh.meta().find<Float>(builtin::volume)->view()[0];
+
+    auto [cube_geo, cube_rest] = cube_object->geometries().create(cube_mesh);
+
+    // --- Body B: proxy with matching mass properties ---
+    auto proxy_object = scene.objects().create("proxy");
+    auto proxy_mesh   = abd.create_proxy(cube_mass, cube_com, cube_inertia, cube_volume);
+
+    view(proxy_mesh.transforms())[0] = t0.matrix();
+
+    auto [proxy_geo, proxy_rest] = proxy_object->geometries().create(proxy_mesh);
+
+    // --- Simulate and compare ---
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    while(world.frame() < 25)
+    {
+        world.advance();
+        REQUIRE(world.is_valid());
+        world.retrieve();
+
+        Float cube_y  = cube_geo->geometry().transforms().view()[0](1, 3);
+        Float proxy_y = proxy_geo->geometry().transforms().view()[0](1, 3);
+
+        REQUIRE(cube_y == Catch::Approx(proxy_y));
+    }
+}

--- a/include/uipc/constitution/affine_body_constitution.h
+++ b/include/uipc/constitution/affine_body_constitution.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <uipc/constitution/constitution.h>
 #include <uipc/geometry/simplicial_complex.h>
+#include <uipc/common/unit.h>
 
 namespace uipc::constitution
 {
@@ -32,17 +33,19 @@ class UIPC_CONSTITUTION_API AffineBodyConstitution : public IConstitution
      * carries all ABD meta attributes.  It participates in dynamics (gravity,
      * shape energy) but has no collision geometry.
      */
-    geometry::SimplicialComplex create_proxy(Float              mass,
-                                             const Vector3&     mass_center,
-                                             const Matrix3x3&   inertia,
-                                             Float              volume) const;
+    [[nodiscard]] geometry::SimplicialComplex create_proxy(Float              kappa,
+                                                           Float              mass,
+                                                           const Vector3&     mass_center,
+                                                           const Matrix3x3&   inertia,
+                                                           Float              volume) const;
 
     /**
      * @brief Create a 1-vertex proxy affine body from a precomputed 12x12 ABD
      *        mass matrix.
      */
-    geometry::SimplicialComplex create_proxy(const Matrix12x12& abd_mass,
-                                             Float              volume) const;
+    [[nodiscard]] geometry::SimplicialComplex create_proxy(Float              kappa,
+                                                           const Matrix12x12& abd_mass,
+                                                           Float              volume) const;
 
     static Json default_config() noexcept;
 

--- a/include/uipc/constitution/affine_body_constitution.h
+++ b/include/uipc/constitution/affine_body_constitution.h
@@ -25,6 +25,25 @@ class UIPC_CONSTITUTION_API AffineBodyConstitution : public IConstitution
                   const Matrix12x12&           mass,
                   Float                        volume) const;
 
+    /**
+     * @brief Create a 1-vertex proxy affine body from rigid body mass properties.
+     *
+     * The returned SimplicialComplex has a single vertex at the origin and
+     * carries all ABD meta attributes.  It participates in dynamics (gravity,
+     * shape energy) but has no collision geometry.
+     */
+    geometry::SimplicialComplex create_proxy(Float              mass,
+                                             const Vector3&     mass_center,
+                                             const Matrix3x3&   inertia,
+                                             Float              volume) const;
+
+    /**
+     * @brief Create a 1-vertex proxy affine body from a precomputed 12x12 ABD
+     *        mass matrix.
+     */
+    geometry::SimplicialComplex create_proxy(const Matrix12x12& abd_mass,
+                                             Float              volume) const;
+
     static Json default_config() noexcept;
 
   protected:

--- a/src/constitution/affine_body_constitution.cpp
+++ b/src/constitution/affine_body_constitution.cpp
@@ -5,6 +5,7 @@
 #include <uipc/geometry/utils/compute_mesh_volume.h>
 #include <uipc/geometry/utils/affine_body/compute_dyadic_mass.h>
 #include <uipc/geometry/utils/affine_body/affine_body_from_rigid_body.h>
+#include <uipc/geometry/utils/factory.h>
 
 namespace uipc::constitution
 {
@@ -152,6 +153,24 @@ void AffineBodyConstitution::apply_to(geometry::SimplicialComplex& sc,
     Matrix3x3 m_x_bar_x_bar = mass.block<3, 3>(3, 3);
     Float     mass_density  = m / volume;
     create_abd_attributes(sc, kappa, mass_density, volume, m, m_x_bar, m_x_bar_x_bar);
+}
+
+geometry::SimplicialComplex AffineBodyConstitution::create_proxy(Float              mass,
+                                                                const Vector3&     mass_center,
+                                                                const Matrix3x3&   inertia,
+                                                                Float              volume) const
+{
+    auto abd_mass_matrix = geometry::affine_body::from_rigid_body(mass, mass_center, inertia);
+    return create_proxy(abd_mass_matrix, volume);
+}
+
+geometry::SimplicialComplex AffineBodyConstitution::create_proxy(const Matrix12x12& abd_mass,
+                                                                 Float              volume) const
+{
+    vector<Vector3> Vs = {Vector3::Zero()};
+    auto            sc = geometry::pointcloud(Vs);
+    apply_to(sc, 1e8, abd_mass, volume);
+    return sc;
 }
 
 Json AffineBodyConstitution::default_config() noexcept

--- a/src/constitution/affine_body_constitution.cpp
+++ b/src/constitution/affine_body_constitution.cpp
@@ -155,21 +155,23 @@ void AffineBodyConstitution::apply_to(geometry::SimplicialComplex& sc,
     create_abd_attributes(sc, kappa, mass_density, volume, m, m_x_bar, m_x_bar_x_bar);
 }
 
-geometry::SimplicialComplex AffineBodyConstitution::create_proxy(Float              mass,
-                                                                const Vector3&     mass_center,
-                                                                const Matrix3x3&   inertia,
-                                                                Float              volume) const
+geometry::SimplicialComplex AffineBodyConstitution::create_proxy(Float              kappa,
+                                                                 Float              mass,
+                                                                 const Vector3&     mass_center,
+                                                                 const Matrix3x3&   inertia,
+                                                                 Float              volume) const
 {
     auto abd_mass_matrix = geometry::affine_body::from_rigid_body(mass, mass_center, inertia);
-    return create_proxy(abd_mass_matrix, volume);
+    return create_proxy(kappa, abd_mass_matrix, volume);
 }
 
-geometry::SimplicialComplex AffineBodyConstitution::create_proxy(const Matrix12x12& abd_mass,
+geometry::SimplicialComplex AffineBodyConstitution::create_proxy(Float              kappa,
+                                                                 const Matrix12x12& abd_mass,
                                                                  Float              volume) const
 {
     vector<Vector3> Vs = {Vector3::Zero()};
     auto            sc = geometry::pointcloud(Vs);
-    apply_to(sc, 1e8, abd_mass, volume);
+    apply_to(sc, kappa, abd_mass, volume);
     return sc;
 }
 


### PR DESCRIPTION
## Summary

- Add two `AffineBodyConstitution::create_proxy` overloads that construct a 1-vertex proxy affine body with user-specified mass properties but no collision geometry. Useful for creating lightweight bodies identified only by a vertex index when the actual mesh is unnecessary.
  - `create_proxy(mass, mass_center, inertia, volume)` — from rigid body properties
  - `create_proxy(abd_mass, volume)` — from a precomputed 12x12 ABD mass matrix
- Add test `84_proxy_abd_gravity` verifying that a proxy body and a full ABD cube with matching mass properties produce identical Y-axis translation under gravity over 25 frames.

## Notes

- The proxy body is a `pointcloud` with a single vertex at the origin (`dim() == 0`).
- No backend changes are required: `body_id_to_dim` is stored but never consumed by any CUDA kernel, and the surface/vertex reporters handle empty topology gracefully.
