### PR TITLE
refactor(constitution): redesign affine body joint API with create_geometry and local positions

### DIFF
--- a/apps/tests/sim_case/76_abd_bdf2_rebound_higher_than_bdf1.cpp
+++ b/apps/tests/sim_case/76_abd_bdf2_rebound_higher_than_bdf1.cpp
@@ -128,7 +128,7 @@ ReboundResult run_drop_case(const std::string& output_path, const std::string& i
 }
 }  // namespace
 
-TEST_CASE("79_abd_bdf2_rebound_higher_than_bdf1", "[abd][bdf]")
+TEST_CASE("76_abd_bdf2_rebound_higher_than_bdf1", "[abd][bdf]")
 {
     using namespace uipc;
 

--- a/apps/tests/sim_case/77_abd_fixed_joint.cpp
+++ b/apps/tests/sim_case/77_abd_fixed_joint.cpp
@@ -5,7 +5,7 @@
 #include <uipc/constitution/soft_transform_constraint.h>
 #include <numbers>
 
-TEST_CASE("79_abd_fixed_joint", "[abd][joint]")
+TEST_CASE("77_abd_fixed_joint", "[abd][joint]")
 {
     using namespace uipc;
     using namespace uipc::geometry;
@@ -60,11 +60,16 @@ TEST_CASE("79_abd_fixed_joint", "[abd][joint]")
     auto [right_geo_slot, _r] = right_object->geometries().create(right_mesh);
 
     // ---- Fixed joint ----
-    SimplicialComplex                joint_mesh;
     AffineBodyFixedJoint             fixed_joint;
-    vector<S<SimplicialComplexSlot>> l_geo_slots = {left_geo_slot};
-    vector<S<SimplicialComplexSlot>> r_geo_slots = {right_geo_slot};
-    fixed_joint.apply_to(joint_mesh, span{l_geo_slots}, span{r_geo_slots}, 100.0);
+    vector<S<SimplicialComplexSlot>> l_geo_slots    = {left_geo_slot};
+    vector<IndexT>                   l_instance_ids = {0};
+    vector<S<SimplicialComplexSlot>> r_geo_slots    = {right_geo_slot};
+    vector<IndexT>                   r_instance_ids = {0};
+    vector<Float>                    strength_ratios = {100.0};
+    auto joint_mesh = fixed_joint.create_geometry(
+        span{l_geo_slots}, span{l_instance_ids},
+        span{r_geo_slots}, span{r_instance_ids},
+        span{strength_ratios});
 
     auto joint_object = scene.objects().create("fixed_joint");
     joint_object->geometries().create(joint_mesh);
@@ -103,7 +108,7 @@ TEST_CASE("79_abd_fixed_joint", "[abd][joint]")
     SceneIO sio{scene};
     sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
 
-    while(world.frame() < 200)
+    while(world.frame() < 50)
     {
         world.advance();
         world.retrieve();

--- a/apps/tests/sim_case/78_abd_spherical_joint.cpp
+++ b/apps/tests/sim_case/78_abd_spherical_joint.cpp
@@ -5,7 +5,7 @@
 #include <uipc/constitution/soft_transform_constraint.h>
 #include <numbers>
 
-TEST_CASE("80_abd_spherical_joint", "[abd][joint]")
+TEST_CASE("78_abd_spherical_joint", "[abd][joint]")
 {
     using namespace uipc;
     using namespace uipc::geometry;
@@ -62,20 +62,20 @@ TEST_CASE("80_abd_spherical_joint", "[abd][joint]")
     auto [right_geo_slot, _r] = right_object->geometries().create(right_mesh);
 
     // ---- Spherical joint ----
-    // Anchor is specified in body1 (right body)'s local frame.
-    // The cube is scaled to 0.3, so half-extent is 0.15.
-    // r_local_pos = {-0.15, 0.15, -0.15}: the anchor point p of the right cube.
-    SimplicialComplex                joint_mesh;
+    // Right body center = {0.15, 0.2, 0.15}; anchor in right body local = {-0.15, 0.15, -0.15}
+    // World anchor = body_translation + local_anchor = {0, 0.35, 0}
     AffineBodySphericalJoint         spherical_joint;
+    vector<Vector3>                  positions      = {Vector3{0, 0.35, 0}};
     vector<S<SimplicialComplexSlot>> l_geo_slots    = {left_geo_slot};
     vector<IndexT>                   l_instance_ids = {0};
     vector<S<SimplicialComplexSlot>> r_geo_slots    = {right_geo_slot};
     vector<IndexT>                   r_instance_ids = {0};
-    vector<Vector3> r_local_pos     = {Vector3{-0.15, 0.15, -0.15}};
-    vector<Float>   strength_ratios = {100.0};
-    spherical_joint.apply_to(
-        joint_mesh, span{l_geo_slots}, span{r_geo_slots}, span{r_local_pos}, 100);
-
+    vector<Float>                    strength_ratios = {100.0};
+    auto joint_mesh = spherical_joint.create_geometry(
+        span{positions},
+        span{l_geo_slots}, span{l_instance_ids},
+        span{r_geo_slots}, span{r_instance_ids},
+        span{strength_ratios});
 
     auto joint_object = scene.objects().create("spherical_joint");
     joint_object->geometries().create(joint_mesh);
@@ -86,7 +86,7 @@ TEST_CASE("80_abd_spherical_joint", "[abd][joint]")
     SceneIO sio{scene};
     sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
 
-    while(world.frame() < 200)
+    while(world.frame() < 50)
     {
         world.advance();
         world.retrieve();

--- a/apps/tests/sim_case/79_abd_prismatic_joint_driving_and_external_force.cpp
+++ b/apps/tests/sim_case/79_abd_prismatic_joint_driving_and_external_force.cpp
@@ -5,7 +5,7 @@
 #include <uipc/constitution/affine_body_driving_prismatic_joint.h>
 #include <uipc/constitution/affine_body_prismatic_joint_external_force.h>
 
-TEST_CASE("81_abd_prismatic_joint_driving_and_external_force", "[abd][joint][driving][external_force]")
+TEST_CASE("79_abd_prismatic_joint_driving_and_external_force", "[abd][joint][driving][external_force]")
 {
     using namespace uipc;
     using namespace uipc::geometry;
@@ -164,7 +164,7 @@ TEST_CASE("81_abd_prismatic_joint_driving_and_external_force", "[abd][joint][dri
     SceneIO sio{scene};
     sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
 
-    while(world.frame() < 200)
+    while(world.frame() < 50)
     {
         world.advance();
         REQUIRE(world.is_valid());

--- a/apps/tests/sim_case/80_abd_revolute_joint_driving_and_external_torque.cpp
+++ b/apps/tests/sim_case/80_abd_revolute_joint_driving_and_external_torque.cpp
@@ -6,7 +6,7 @@
 #include <uipc/constitution/affine_body_driving_revolute_joint.h>
 #include <uipc/constitution/affine_body_revolute_joint_external_force.h>
 
-TEST_CASE("82_abd_revolute_joint_driving_and_external_torque", "[abd][joint][driving][external_force]")
+TEST_CASE("80_abd_revolute_joint_driving_and_external_torque", "[abd][joint][driving][external_force]")
 {
     using namespace uipc;
     using namespace uipc::geometry;
@@ -170,7 +170,7 @@ TEST_CASE("82_abd_revolute_joint_driving_and_external_torque", "[abd][joint][dri
     SceneIO sio{scene};
     sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
 
-    while(world.frame() < 200)
+    while(world.frame() < 50)
     {
         world.advance();
         REQUIRE(world.is_valid());

--- a/apps/tests/sim_case/82_discrete_shell_bending_strain_plastic_open_strip.cpp
+++ b/apps/tests/sim_case/82_discrete_shell_bending_strain_plastic_open_strip.cpp
@@ -4,7 +4,7 @@
 #include <uipc/constitution/strain_plastic_discrete_shell_bending.h>
 #include <uipc/constitution/soft_position_constraint.h>
 #include <algorithm>
-#include <filesystem>
+#include <cmath>
 #include <numbers>
 
 namespace
@@ -14,17 +14,8 @@ using namespace uipc::core;
 using namespace uipc::geometry;
 using namespace uipc::constitution;
 
-constexpr SizeT EndFrame     = 60;
-constexpr SizeT RecoverFrame = 40;
-constexpr std::size_t DumpMagic = 0xc2663291fdf3;
 constexpr SizeT SheetResolution = 21;
 constexpr Float SheetSize       = 1.0;
-
-struct SimulationResult
-{
-    vector<Vector3> final_positions;
-    bool            recover_result = false;
-};
 
 struct ClothPatch
 {
@@ -88,17 +79,38 @@ ClothPatch load_center_patch()
                       v01,
                       step};
 }
+}  // namespace
 
-S<geometry::GeometrySlot> build_scene(Scene& scene)
+TEST_CASE("82_discrete_shell_bending_strain_plastic_open_strip", "[fem][strain_plastic_dsb]")
 {
-    NeoHookeanShell             nhs;
-    StrainPlasticDiscreteShellBending pdsb;
-    SoftPositionConstraint      spc;
+    using namespace uipc;
+    using namespace uipc::core;
+    using namespace uipc::geometry;
+    using namespace uipc::constitution;
+
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                             = test::Scene::default_config();
+    config["gravity"]                       = Vector3{0, 0, 0};
+    config["contact"]["enable"]             = false;
+    config["line_search"]["max_iter"]       = 8;
+    config["linear_system"]["tol_rate"]     = 1e-3;
+    config["dt"]                            = 0.01;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
 
     auto object = scene.objects().create("strip");
-    auto patch  = load_center_patch();
 
-    auto moduli = ElasticModuli2D::youngs_poisson(10.0_MPa, 0.49);
+    NeoHookeanShell            nhs;
+    StrainPlasticDiscreteShellBending pdsb;
+    SoftPositionConstraint     spc;
+
+    auto patch = load_center_patch();
+    auto moduli         = ElasticModuli2D::youngs_poisson(10.0_MPa, 0.49);
     nhs.apply_to(patch.mesh, moduli);
     pdsb.apply_to(patch.mesh, 5.0_kPa, 0.02, 0.0);
     spc.apply_to(patch.mesh, 100.0);
@@ -122,102 +134,32 @@ S<geometry::GeometrySlot> build_scene(Scene& scene)
             std::ranges::fill(is_constrained_view, 1);
             std::copy(rest_positions.begin(), rest_positions.end(), aim_position_view.begin());
 
-            const Float normalized_frame =
-                static_cast<Float>(std::min<SizeT>(info.frame(), EndFrame)) / EndFrame;
-            const Float y = amplitude * std::sin(std::numbers::pi_v<Float> * normalized_frame);
+            const Float t = static_cast<Float>(std::min<SizeT>(info.frame(), 60)) / 60.0;
+            const Float y = amplitude * std::sin(std::numbers::pi_v<Float> * t);
             aim_position_view[moving_vertex] =
                 rest_positions[moving_vertex] + Vector3::UnitY() * y;
         });
-
-    return slot;
-}
-
-SimulationResult run_case(const std::filesystem::path& workspace,
-                          bool                        dump_frames,
-                          std::optional<SizeT>        recover_frame = std::nullopt)
-{
-    Engine engine{"cuda", workspace.string()};
-    World  world{engine};
-
-    auto config                             = test::Scene::default_config();
-    config["gravity"]                       = Vector3{0, 0, 0};
-    config["contact"]["enable"]             = false;
-    config["line_search"]["max_iter"]       = 8;
-    config["linear_system"]["tol_rate"]     = 1e-3;
-    config["dt"]                            = 0.01;
-    test::Scene::dump_config(config, workspace.string());
-
-    Scene           scene{config};
-    auto slot = build_scene(scene);
 
     world.init(scene);
     REQUIRE(world.is_valid());
 
     SceneIO sio{scene};
-    sio.write_surface(fmt::format("{}scene_surface{}.obj", workspace.string(), world.frame()));
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
 
-    SimulationResult result;
-    if(recover_frame)
-    {
-        result.recover_result = world.recover(*recover_frame);
-        if(!result.recover_result)
-            return result;
-
-        REQUIRE(world.frame() == *recover_frame);
-        world.retrieve();
-        sio.write_surface(fmt::format("{}scene_surface{}.obj", workspace.string(), world.frame()));
-    }
-
-    while(world.frame() < EndFrame)
+    while(world.frame() < 70)
     {
         world.advance();
         REQUIRE(world.is_valid());
+
         world.retrieve();
-        sio.write_surface(fmt::format("{}scene_surface{}.obj", workspace.string(), world.frame()));
-        if(dump_frames)
-            world.dump();
+        sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+        auto sc = slot->geometry().as<SimplicialComplex>();
+        const auto position_view = view(sc->positions());
+        REQUIRE(std::ranges::all_of(position_view,
+                                    [](const Vector3& p)
+                                    {
+                                        return std::isfinite(p.x()) && std::isfinite(p.y())
+                                               && std::isfinite(p.z());
+                                    }));
     }
-
-    auto sc = slot->geometry().as<SimplicialComplex>();
-    const auto position_view = view(sc->positions());
-    result.final_positions.assign(position_view.begin(), position_view.end());
-    return result;
-}
-
-void clear_dump_dir(const std::filesystem::path& workspace)
-{
-    std::filesystem::remove_all(workspace / "dump");
-}
-
-Float max_position_diff(span<const Vector3> a, span<const Vector3> b)
-{
-    REQUIRE(a.size() == b.size());
-
-    Float max_diff = 0.0;
-    for(SizeT i = 0; i < a.size(); ++i)
-    {
-        max_diff = std::max(max_diff, (a[i] - b[i]).norm());
-    }
-    return max_diff;
-}
-}  // namespace
-
-TEST_CASE("78_strain_plastic_discrete_shell_bending_recover", "[fem][strain_plastic_dsb][recover]")
-{
-    namespace fs = std::filesystem;
-
-    auto workspace = fs::path(AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE));
-    clear_dump_dir(workspace);
-
-    SECTION("recover_continues_from_dumped_state")
-    {
-        auto baseline = run_case(workspace, true);
-        auto resumed  = run_case(workspace, false, RecoverFrame);
-
-        REQUIRE(resumed.recover_result);
-        REQUIRE(baseline.final_positions.size() == resumed.final_positions.size());
-        CHECK(max_position_diff(baseline.final_positions, resumed.final_positions)
-              < 1e-6);
-    }
-
 }

--- a/apps/tests/sim_case/83_discrete_shell_bending_strain_plastic_residual.cpp
+++ b/apps/tests/sim_case/83_discrete_shell_bending_strain_plastic_residual.cpp
@@ -204,7 +204,7 @@ uipc::Float residual_hinge_angle(bool use_plastic)
 }
 }  // namespace
 
-TEST_CASE("77_discrete_shell_bending_strain_plastic_residual", "[fem][strain_plastic_dsb]")
+TEST_CASE("83_discrete_shell_bending_strain_plastic_residual", "[fem][strain_plastic_dsb]")
 {
     const auto elastic_angle = residual_hinge_angle(false);
     const auto plastic_angle = residual_hinge_angle(true);

--- a/apps/tests/sim_case/84_strain_plastic_discrete_shell_bending_recover.cpp
+++ b/apps/tests/sim_case/84_strain_plastic_discrete_shell_bending_recover.cpp
@@ -1,10 +1,10 @@
 #include <app/app.h>
 #include <uipc/uipc.h>
 #include <uipc/constitution/neo_hookean_shell.h>
-#include <uipc/constitution/stress_plastic_discrete_shell_bending.h>
+#include <uipc/constitution/strain_plastic_discrete_shell_bending.h>
 #include <uipc/constitution/soft_position_constraint.h>
 #include <algorithm>
-#include <cmath>
+#include <filesystem>
 #include <numbers>
 
 namespace
@@ -14,8 +14,17 @@ using namespace uipc::core;
 using namespace uipc::geometry;
 using namespace uipc::constitution;
 
+constexpr SizeT EndFrame     = 60;
+constexpr SizeT RecoverFrame = 40;
+constexpr std::size_t DumpMagic = 0xc2663291fdf3;
 constexpr SizeT SheetResolution = 21;
 constexpr Float SheetSize       = 1.0;
+
+struct SimulationResult
+{
+    vector<Vector3> final_positions;
+    bool            recover_result = false;
+};
 
 struct ClothPatch
 {
@@ -79,40 +88,19 @@ ClothPatch load_center_patch()
                       v01,
                       step};
 }
-}  // namespace
 
-TEST_CASE("81_stress_plastic_discrete_shell_bending_open_strip", "[fem][stress_plastic_dsb]")
+S<geometry::GeometrySlot> build_scene(Scene& scene)
 {
-    using namespace uipc;
-    using namespace uipc::core;
-    using namespace uipc::geometry;
-    using namespace uipc::constitution;
-
-    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
-
-    Engine engine{"cuda", output_path};
-    World  world{engine};
-
-    auto config                         = test::Scene::default_config();
-    config["gravity"]                   = Vector3{0, 0, 0};
-    config["contact"]["enable"]         = false;
-    config["line_search"]["max_iter"]   = 8;
-    config["linear_system"]["tol_rate"] = 1e-3;
-    config["dt"]                        = 0.01;
-    test::Scene::dump_config(config, output_path);
-
-    Scene scene{config};
+    NeoHookeanShell             nhs;
+    StrainPlasticDiscreteShellBending pdsb;
+    SoftPositionConstraint      spc;
 
     auto object = scene.objects().create("strip");
-
-    NeoHookeanShell                  nhs;
-    StressPlasticDiscreteShellBending spdsb;
-    SoftPositionConstraint           spc;
-
     auto patch  = load_center_patch();
+
     auto moduli = ElasticModuli2D::youngs_poisson(10.0_MPa, 0.49);
     nhs.apply_to(patch.mesh, moduli);
-    spdsb.apply_to(patch.mesh, 5.0_kPa, 1.2_kPa, 0.0);
+    pdsb.apply_to(patch.mesh, 5.0_kPa, 0.02, 0.0);
     spc.apply_to(patch.mesh, 100.0);
 
     auto [slot, rest_slot] = object->geometries().create(patch.mesh);
@@ -134,32 +122,102 @@ TEST_CASE("81_stress_plastic_discrete_shell_bending_open_strip", "[fem][stress_p
             std::ranges::fill(is_constrained_view, 1);
             std::copy(rest_positions.begin(), rest_positions.end(), aim_position_view.begin());
 
-            const Float t = static_cast<Float>(std::min<SizeT>(info.frame(), 60)) / 60.0;
-            const Float y = amplitude * std::sin(std::numbers::pi_v<Float> * t);
+            const Float normalized_frame =
+                static_cast<Float>(std::min<SizeT>(info.frame(), EndFrame)) / EndFrame;
+            const Float y = amplitude * std::sin(std::numbers::pi_v<Float> * normalized_frame);
             aim_position_view[moving_vertex] =
                 rest_positions[moving_vertex] + Vector3::UnitY() * y;
         });
+
+    return slot;
+}
+
+SimulationResult run_case(const std::filesystem::path& workspace,
+                          bool                        dump_frames,
+                          std::optional<SizeT>        recover_frame = std::nullopt)
+{
+    Engine engine{"cuda", workspace.string()};
+    World  world{engine};
+
+    auto config                             = test::Scene::default_config();
+    config["gravity"]                       = Vector3{0, 0, 0};
+    config["contact"]["enable"]             = false;
+    config["line_search"]["max_iter"]       = 8;
+    config["linear_system"]["tol_rate"]     = 1e-3;
+    config["dt"]                            = 0.01;
+    test::Scene::dump_config(config, workspace.string());
+
+    Scene           scene{config};
+    auto slot = build_scene(scene);
 
     world.init(scene);
     REQUIRE(world.is_valid());
 
     SceneIO sio{scene};
-    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", workspace.string(), world.frame()));
 
-    while(world.frame() < 70)
+    SimulationResult result;
+    if(recover_frame)
+    {
+        result.recover_result = world.recover(*recover_frame);
+        if(!result.recover_result)
+            return result;
+
+        REQUIRE(world.frame() == *recover_frame);
+        world.retrieve();
+        sio.write_surface(fmt::format("{}scene_surface{}.obj", workspace.string(), world.frame()));
+    }
+
+    while(world.frame() < EndFrame)
     {
         world.advance();
         REQUIRE(world.is_valid());
-
         world.retrieve();
-        sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
-        auto sc = slot->geometry().as<SimplicialComplex>();
-        const auto position_view = view(sc->positions());
-        REQUIRE(std::ranges::all_of(position_view,
-                                    [](const Vector3& p)
-                                    {
-                                        return std::isfinite(p.x()) && std::isfinite(p.y())
-                                               && std::isfinite(p.z());
-                                    }));
+        sio.write_surface(fmt::format("{}scene_surface{}.obj", workspace.string(), world.frame()));
+        if(dump_frames)
+            world.dump();
     }
+
+    auto sc = slot->geometry().as<SimplicialComplex>();
+    const auto position_view = view(sc->positions());
+    result.final_positions.assign(position_view.begin(), position_view.end());
+    return result;
+}
+
+void clear_dump_dir(const std::filesystem::path& workspace)
+{
+    std::filesystem::remove_all(workspace / "dump");
+}
+
+Float max_position_diff(span<const Vector3> a, span<const Vector3> b)
+{
+    REQUIRE(a.size() == b.size());
+
+    Float max_diff = 0.0;
+    for(SizeT i = 0; i < a.size(); ++i)
+    {
+        max_diff = std::max(max_diff, (a[i] - b[i]).norm());
+    }
+    return max_diff;
+}
+}  // namespace
+
+TEST_CASE("84_strain_plastic_discrete_shell_bending_recover", "[fem][strain_plastic_dsb][recover]")
+{
+    namespace fs = std::filesystem;
+
+    auto workspace = fs::path(AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE));
+    clear_dump_dir(workspace);
+
+    SECTION("recover_continues_from_dumped_state")
+    {
+        auto baseline = run_case(workspace, true);
+        auto resumed  = run_case(workspace, false, RecoverFrame);
+
+        REQUIRE(resumed.recover_result);
+        REQUIRE(baseline.final_positions.size() == resumed.final_positions.size());
+        CHECK(max_position_diff(baseline.final_positions, resumed.final_positions)
+              < 1e-6);
+    }
+
 }

--- a/apps/tests/sim_case/85_stress_plastic_discrete_shell_bending_open_strip.cpp
+++ b/apps/tests/sim_case/85_stress_plastic_discrete_shell_bending_open_strip.cpp
@@ -1,7 +1,7 @@
 #include <app/app.h>
 #include <uipc/uipc.h>
 #include <uipc/constitution/neo_hookean_shell.h>
-#include <uipc/constitution/strain_plastic_discrete_shell_bending.h>
+#include <uipc/constitution/stress_plastic_discrete_shell_bending.h>
 #include <uipc/constitution/soft_position_constraint.h>
 #include <algorithm>
 #include <cmath>
@@ -81,7 +81,7 @@ ClothPatch load_center_patch()
 }
 }  // namespace
 
-TEST_CASE("76_discrete_shell_bending_strain_plastic_open_strip", "[fem][strain_plastic_dsb]")
+TEST_CASE("85_stress_plastic_discrete_shell_bending_open_strip", "[fem][stress_plastic_dsb]")
 {
     using namespace uipc;
     using namespace uipc::core;
@@ -93,26 +93,26 @@ TEST_CASE("76_discrete_shell_bending_strain_plastic_open_strip", "[fem][strain_p
     Engine engine{"cuda", output_path};
     World  world{engine};
 
-    auto config                             = test::Scene::default_config();
-    config["gravity"]                       = Vector3{0, 0, 0};
-    config["contact"]["enable"]             = false;
-    config["line_search"]["max_iter"]       = 8;
-    config["linear_system"]["tol_rate"]     = 1e-3;
-    config["dt"]                            = 0.01;
+    auto config                         = test::Scene::default_config();
+    config["gravity"]                   = Vector3{0, 0, 0};
+    config["contact"]["enable"]         = false;
+    config["line_search"]["max_iter"]   = 8;
+    config["linear_system"]["tol_rate"] = 1e-3;
+    config["dt"]                        = 0.01;
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
 
     auto object = scene.objects().create("strip");
 
-    NeoHookeanShell            nhs;
-    StrainPlasticDiscreteShellBending pdsb;
-    SoftPositionConstraint     spc;
+    NeoHookeanShell                  nhs;
+    StressPlasticDiscreteShellBending spdsb;
+    SoftPositionConstraint           spc;
 
-    auto patch = load_center_patch();
-    auto moduli         = ElasticModuli2D::youngs_poisson(10.0_MPa, 0.49);
+    auto patch  = load_center_patch();
+    auto moduli = ElasticModuli2D::youngs_poisson(10.0_MPa, 0.49);
     nhs.apply_to(patch.mesh, moduli);
-    pdsb.apply_to(patch.mesh, 5.0_kPa, 0.02, 0.0);
+    spdsb.apply_to(patch.mesh, 5.0_kPa, 1.2_kPa, 0.0);
     spc.apply_to(patch.mesh, 100.0);
 
     auto [slot, rest_slot] = object->geometries().create(patch.mesh);

--- a/apps/tests/sim_case/86_discrete_shell_bending_stress_plastic_residual.cpp
+++ b/apps/tests/sim_case/86_discrete_shell_bending_stress_plastic_residual.cpp
@@ -205,7 +205,7 @@ uipc::Float residual_hinge_angle(bool use_stress_plastic)
 }
 }  // namespace
 
-TEST_CASE("82_discrete_shell_bending_stress_plastic_residual", "[fem][stress_plastic_dsb]")
+TEST_CASE("86_discrete_shell_bending_stress_plastic_residual", "[fem][stress_plastic_dsb]")
 {
     const auto elastic_angle        = residual_hinge_angle(false);
     const auto stress_plastic_angle = residual_hinge_angle(true);

--- a/apps/tests/sim_case/87_stress_plastic_discrete_shell_bending_recover.cpp
+++ b/apps/tests/sim_case/87_stress_plastic_discrete_shell_bending_recover.cpp
@@ -201,7 +201,7 @@ Float max_position_diff(span<const Vector3> a, span<const Vector3> b)
 }
 }  // namespace
 
-TEST_CASE("83_stress_plastic_discrete_shell_bending_recover", "[fem][stress_plastic_dsb][recover]")
+TEST_CASE("87_stress_plastic_discrete_shell_bending_recover", "[fem][stress_plastic_dsb][recover]")
 {
     namespace fs = std::filesystem;
 

--- a/apps/tests/sim_case/88_abd_revolute_joint_local.cpp
+++ b/apps/tests/sim_case/88_abd_revolute_joint_local.cpp
@@ -1,0 +1,149 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+#include <uipc/constitution/affine_body_revolute_joint.h>
+
+TEST_CASE("88_abd_revolute_joint_local", "[abd][joint][local]")
+{
+    using namespace uipc;
+    using namespace uipc::geometry;
+    using namespace uipc::core;
+    using namespace uipc::constitution;
+
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                            = test::Scene::default_config();
+    config["gravity"]                      = Vector3{0, 0, 0};
+    config["contact"]["enable"]            = false;
+    config["line_search"]["report_energy"] = true;
+    config["dt"]                           = 0.01;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    Transform pre_transform = Transform::Identity();
+    pre_transform.scale(0.3);
+    SimplicialComplexIO io{pre_transform};
+
+    AffineBodyConstitution abd;
+
+    // Aligned pair (z = -0.5)
+    // Bodies adjacent, axis endpoints coincide in world space at frame 0
+    auto al_left_obj = scene.objects().create("aligned_left");
+    SimplicialComplex al_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_left_mesh, 100.0_MPa);
+    label_surface(al_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{-0.15, 0.5, -0.5});
+        view(al_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = al_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [al_left_slot, _al] = al_left_obj->geometries().create(al_left_mesh);
+
+    auto al_right_obj = scene.objects().create("aligned_right");
+    SimplicialComplex al_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_right_mesh, 100.0_MPa);
+    label_surface(al_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0.15, 0.5, -0.5});
+        view(al_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = al_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [al_right_slot, _ar] = al_right_obj->geometries().create(al_right_mesh);
+
+    // Misaligned pair (z = +0.5)
+    // Left body at same layout, right body slightly offset
+    auto mis_left_obj = scene.objects().create("misaligned_left");
+    SimplicialComplex mis_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_left_mesh, 100.0_MPa);
+    label_surface(mis_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{-0.15, 0.5, 0.5});
+        view(mis_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = mis_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [mis_left_slot, _ml] = mis_left_obj->geometries().create(mis_left_mesh);
+
+    auto mis_right_obj = scene.objects().create("misaligned_right");
+    SimplicialComplex mis_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_right_mesh, 100.0_MPa);
+    label_surface(mis_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0.2, 0.5, 0.55});
+        view(mis_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = mis_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [mis_right_slot, _mr] = mis_right_obj->geometries().create(mis_right_mesh);
+
+    // Two revolute joints with identical local attachment points
+    AffineBodyRevoluteJoint revolute_joint;
+
+    vector<Vector3> l_pos0 = {Vector3{0.15, 0, -0.15}, Vector3{0.15, 0, -0.15}};
+    vector<Vector3> l_pos1 = {Vector3{0.15, 0,  0.15}, Vector3{0.15, 0,  0.15}};
+    vector<Vector3> r_pos0 = {Vector3{-0.15, 0, -0.15}, Vector3{-0.15, 0, -0.15}};
+    vector<Vector3> r_pos1 = {Vector3{-0.15, 0,  0.15}, Vector3{-0.15, 0,  0.15}};
+
+    vector<S<SimplicialComplexSlot>> l_geo_slots    = {al_left_slot, mis_left_slot};
+    vector<IndexT>                   l_instance_ids = {0, 0};
+    vector<S<SimplicialComplexSlot>> r_geo_slots    = {al_right_slot, mis_right_slot};
+    vector<IndexT>                   r_instance_ids = {0, 0};
+    vector<Float>                    strength_ratios = {100.0, 100.0};
+
+    auto joint_mesh = revolute_joint.create_geometry(
+        span{l_pos0}, span{l_pos1}, span{r_pos0}, span{r_pos1},
+        span{l_geo_slots}, span{l_instance_ids},
+        span{r_geo_slots}, span{r_instance_ids},
+        span{strength_ratios});
+
+    auto joint_object = scene.objects().create("revolute_joint");
+    joint_object->geometries().create(joint_mesh);
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+
+    while(world.frame() < 5)
+    {
+        world.advance();
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+
+    auto to_world = [](const Matrix4x4& T, const Vector3& p) -> Vector3
+    {
+        return (T * Vector4{p.x(), p.y(), p.z(), 1.0}).head<3>();
+    };
+
+    auto al_left_t   = view(al_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto al_right_t  = view(al_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_left_t  = view(mis_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_right_t = view(mis_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+
+    Vector3 lp0{0.15, 0, -0.15};
+    Vector3 lp1{0.15, 0,  0.15};
+    Vector3 rp0{-0.15, 0, -0.15};
+    Vector3 rp1{-0.15, 0,  0.15};
+
+    REQUIRE(to_world(al_left_t, lp0).isApprox(to_world(al_right_t, rp0)));
+    REQUIRE(to_world(al_left_t, lp1).isApprox(to_world(al_right_t, rp1)));
+    REQUIRE(to_world(mis_left_t, lp0).isApprox(to_world(mis_right_t, rp0)));
+    REQUIRE(to_world(mis_left_t, lp1).isApprox(to_world(mis_right_t, rp1)));
+}

--- a/apps/tests/sim_case/89_abd_prismatic_joint_local.cpp
+++ b/apps/tests/sim_case/89_abd_prismatic_joint_local.cpp
@@ -1,0 +1,158 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+#include <uipc/constitution/affine_body_prismatic_joint.h>
+
+TEST_CASE("89_abd_prismatic_joint_local", "[abd][joint][local]")
+{
+    using namespace uipc;
+    using namespace uipc::geometry;
+    using namespace uipc::core;
+    using namespace uipc::constitution;
+
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                            = test::Scene::default_config();
+    config["gravity"]                      = Vector3{0, 0, 0};
+    config["contact"]["enable"]            = false;
+    config["line_search"]["report_energy"] = true;
+    config["dt"]                           = 0.01;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    Transform pre_transform = Transform::Identity();
+    pre_transform.scale(0.3);
+    SimplicialComplexIO io{pre_transform};
+
+    AffineBodyConstitution abd;
+
+    // Aligned pair (z = -0.5)
+    // Bodies adjacent, prismatic axis along X, both share the same axis line
+    auto al_left_obj = scene.objects().create("aligned_left");
+    SimplicialComplex al_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_left_mesh, 100.0_MPa);
+    label_surface(al_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{-0.15, 0.5, -0.5});
+        view(al_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = al_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [al_left_slot, _al] = al_left_obj->geometries().create(al_left_mesh);
+
+    auto al_right_obj = scene.objects().create("aligned_right");
+    SimplicialComplex al_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_right_mesh, 100.0_MPa);
+    label_surface(al_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0.15, 0.5, -0.5});
+        view(al_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = al_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [al_right_slot, _ar] = al_right_obj->geometries().create(al_right_mesh);
+
+    // Misaligned pair (z = +0.5)
+    // Left body at same layout, right body slightly offset
+    auto mis_left_obj = scene.objects().create("misaligned_left");
+    SimplicialComplex mis_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_left_mesh, 100.0_MPa);
+    label_surface(mis_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{-0.15, 0.5, 0.5});
+        view(mis_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = mis_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [mis_left_slot, _ml] = mis_left_obj->geometries().create(mis_left_mesh);
+
+    auto mis_right_obj = scene.objects().create("misaligned_right");
+    SimplicialComplex mis_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_right_mesh, 100.0_MPa);
+    label_surface(mis_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0.2, 0.55, 0.55});
+        view(mis_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = mis_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [mis_right_slot, _mr] = mis_right_obj->geometries().create(mis_right_mesh);
+
+    // Two prismatic joints with identical local attachment points
+    AffineBodyPrismaticJoint prismatic_joint;
+
+    vector<Vector3> l_pos0 = {Vector3{-0.15, 0, 0}, Vector3{-0.15, 0, 0}};
+    vector<Vector3> l_pos1 = {Vector3{ 0.15, 0, 0}, Vector3{ 0.15, 0, 0}};
+    vector<Vector3> r_pos0 = {Vector3{-0.15, 0, 0}, Vector3{-0.15, 0, 0}};
+    vector<Vector3> r_pos1 = {Vector3{ 0.15, 0, 0}, Vector3{ 0.15, 0, 0}};
+
+    vector<S<SimplicialComplexSlot>> l_geo_slots    = {al_left_slot, mis_left_slot};
+    vector<IndexT>                   l_instance_ids = {0, 0};
+    vector<S<SimplicialComplexSlot>> r_geo_slots    = {al_right_slot, mis_right_slot};
+    vector<IndexT>                   r_instance_ids = {0, 0};
+    vector<Float>                    strength_ratios = {100.0, 100.0};
+
+    auto joint_mesh = prismatic_joint.create_geometry(
+        span{l_pos0}, span{l_pos1}, span{r_pos0}, span{r_pos1},
+        span{l_geo_slots}, span{l_instance_ids},
+        span{r_geo_slots}, span{r_instance_ids},
+        span{strength_ratios});
+
+    auto joint_object = scene.objects().create("prismatic_joint");
+    joint_object->geometries().create(joint_mesh);
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+
+    while(world.frame() < 5)
+    {
+        world.advance();
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+
+    auto to_world = [](const Matrix4x4& T, const Vector3& p) -> Vector3
+    {
+        return (T * Vector4{p.x(), p.y(), p.z(), 1.0}).head<3>();
+    };
+
+    auto al_left_t   = view(al_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto al_right_t  = view(al_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_left_t  = view(mis_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_right_t = view(mis_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+
+    Vector3 lp0{-0.15, 0, 0};
+    Vector3 lp1{ 0.15, 0, 0};
+    Vector3 rp0{-0.15, 0, 0};
+    Vector3 rp1{ 0.15, 0, 0};
+
+    auto check_prismatic = [&](const Matrix4x4& lt, const Matrix4x4& rt)
+    {
+        Vector3 l_axis = (to_world(lt, lp1) - to_world(lt, lp0)).normalized();
+        Vector3 r_axis = (to_world(rt, rp1) - to_world(rt, rp0)).normalized();
+        REQUIRE(l_axis.cross(r_axis).isZero());
+
+        Vector3 offset = to_world(rt, rp0) - to_world(lt, lp0);
+        Vector3 perp   = offset - offset.dot(l_axis) * l_axis;
+        REQUIRE(perp.isZero());
+    };
+
+    check_prismatic(al_left_t, al_right_t);
+    check_prismatic(mis_left_t, mis_right_t);
+}

--- a/apps/tests/sim_case/90_abd_fixed_joint_local.cpp
+++ b/apps/tests/sim_case/90_abd_fixed_joint_local.cpp
@@ -1,0 +1,144 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+#include <uipc/constitution/affine_body_fixed_joint.h>
+
+TEST_CASE("90_abd_fixed_joint_local", "[abd][joint][local]")
+{
+    using namespace uipc;
+    using namespace uipc::geometry;
+    using namespace uipc::core;
+    using namespace uipc::constitution;
+
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                            = test::Scene::default_config();
+    config["gravity"]                      = Vector3{0, 0, 0};
+    config["contact"]["enable"]            = false;
+    config["line_search"]["report_energy"] = true;
+    config["dt"]                           = 0.01;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    Transform pre_transform = Transform::Identity();
+    pre_transform.scale(0.3);
+    SimplicialComplexIO io{pre_transform};
+
+    AffineBodyConstitution abd;
+
+    // Aligned pair (z = -0.5)
+    // Bodies adjacent, attachment points meet at (0, 0.5, -0.5)
+    auto al_left_obj = scene.objects().create("aligned_left");
+    SimplicialComplex al_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_left_mesh, 100.0_MPa);
+    label_surface(al_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{-0.15, 0.5, -0.5});
+        view(al_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = al_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [al_left_slot, _al] = al_left_obj->geometries().create(al_left_mesh);
+
+    auto al_right_obj = scene.objects().create("aligned_right");
+    SimplicialComplex al_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_right_mesh, 100.0_MPa);
+    label_surface(al_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0.15, 0.5, -0.5});
+        view(al_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = al_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [al_right_slot, _ar] = al_right_obj->geometries().create(al_right_mesh);
+
+    // Misaligned pair (z = +0.5)
+    // Left body at same layout, right body slightly offset
+    auto mis_left_obj = scene.objects().create("misaligned_left");
+    SimplicialComplex mis_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_left_mesh, 100.0_MPa);
+    label_surface(mis_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{-0.15, 0.5, 0.5});
+        view(mis_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = mis_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [mis_left_slot, _ml] = mis_left_obj->geometries().create(mis_left_mesh);
+
+    auto mis_right_obj = scene.objects().create("misaligned_right");
+    SimplicialComplex mis_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_right_mesh, 100.0_MPa);
+    label_surface(mis_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0.2, 0.6, 0.6});
+        view(mis_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = mis_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [mis_right_slot, _mr] = mis_right_obj->geometries().create(mis_right_mesh);
+
+    // Two fixed joints with identical local attachment points
+    AffineBodyFixedJoint fixed_joint;
+
+    vector<Vector3>                  l_positions     = {Vector3{0.15, 0, 0},
+                                                        Vector3{0.15, 0, 0}};
+    vector<Vector3>                  r_positions     = {Vector3{-0.15, 0, 0},
+                                                        Vector3{-0.15, 0, 0}};
+    vector<S<SimplicialComplexSlot>> l_geo_slots     = {al_left_slot, mis_left_slot};
+    vector<IndexT>                   l_instance_ids  = {0, 0};
+    vector<S<SimplicialComplexSlot>> r_geo_slots     = {al_right_slot, mis_right_slot};
+    vector<IndexT>                   r_instance_ids  = {0, 0};
+    vector<Float>                    strength_ratios = {100.0, 100.0};
+
+    auto joint_mesh = fixed_joint.create_geometry(
+        span{l_positions}, span{r_positions},
+        span{l_geo_slots}, span{l_instance_ids},
+        span{r_geo_slots}, span{r_instance_ids},
+        span{strength_ratios});
+
+    auto joint_object = scene.objects().create("fixed_joint");
+    joint_object->geometries().create(joint_mesh);
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+
+    while(world.frame() < 5)
+    {
+        world.advance();
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+
+    auto to_world = [](const Matrix4x4& T, const Vector3& p) -> Vector3
+    {
+        return (T * Vector4{p.x(), p.y(), p.z(), 1.0}).head<3>();
+    };
+
+    auto al_left_t   = view(al_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto al_right_t  = view(al_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_left_t  = view(mis_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_right_t = view(mis_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+
+    Vector3 lp{0.15, 0, 0};
+    Vector3 rp{-0.15, 0, 0};
+
+    REQUIRE(to_world(al_left_t, lp).isApprox(to_world(al_right_t, rp)));
+    REQUIRE(to_world(mis_left_t, lp).isApprox(to_world(mis_right_t, rp)));
+}

--- a/apps/tests/sim_case/91_abd_spherical_joint_local.cpp
+++ b/apps/tests/sim_case/91_abd_spherical_joint_local.cpp
@@ -1,0 +1,146 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+#include <uipc/constitution/affine_body_spherical_joint.h>
+
+TEST_CASE("91_abd_spherical_joint_local", "[abd][joint][local]")
+{
+    using namespace uipc;
+    using namespace uipc::geometry;
+    using namespace uipc::core;
+    using namespace uipc::constitution;
+
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                            = test::Scene::default_config();
+    config["gravity"]                      = Vector3{0, 0, 0};
+    config["contact"]["enable"]            = false;
+    config["line_search"]["report_energy"] = true;
+    config["dt"]                           = 0.01;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    Transform pre_transform = Transform::Identity();
+    pre_transform.scale(0.3);
+    SimplicialComplexIO io{pre_transform};
+
+    AffineBodyConstitution abd;
+
+    // Aligned pair (z = -0.5)
+    // Left body fixed, right body hangs below via spherical joint at touching face
+    auto al_left_obj = scene.objects().create("aligned_left");
+    SimplicialComplex al_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_left_mesh, 100.0_MPa);
+    label_surface(al_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0, 0.5, -0.5});
+        view(al_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = al_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [al_left_slot, _al] = al_left_obj->geometries().create(al_left_mesh);
+
+    auto al_right_obj = scene.objects().create("aligned_right");
+    SimplicialComplex al_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(al_right_mesh, 100.0_MPa);
+    label_surface(al_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0, 0.2, -0.5});
+        view(al_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = al_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [al_right_slot, _ar] = al_right_obj->geometries().create(al_right_mesh);
+
+    // Misaligned pair (z = +0.5)
+    // Left body at same layout, right body slightly offset
+    auto mis_left_obj = scene.objects().create("misaligned_left");
+    SimplicialComplex mis_left_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_left_mesh, 100.0_MPa);
+    label_surface(mis_left_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0, 0.5, 0.5});
+        view(mis_left_mesh.transforms())[0] = t.matrix();
+        auto is_fixed = mis_left_mesh.instances().find<IndexT>(builtin::is_fixed);
+        view(*is_fixed)[0] = 1;
+    }
+    auto [mis_left_slot, _ml] = mis_left_obj->geometries().create(mis_left_mesh);
+
+    auto mis_right_obj = scene.objects().create("misaligned_right");
+    SimplicialComplex mis_right_mesh =
+        io.read(fmt::format("{}cube.obj", AssetDir::trimesh_path()));
+    abd.apply_to(mis_right_mesh, 100.0_MPa);
+    label_surface(mis_right_mesh);
+    {
+        Transform t = Transform::Identity();
+        t.translate(Vector3{0, 0.15, 0.5});
+        view(mis_right_mesh.transforms())[0] = t.matrix();
+        auto is_dynamic = mis_right_mesh.instances().find<IndexT>(builtin::is_dynamic);
+        view(*is_dynamic)[0] = 0;
+    }
+    auto [mis_right_slot, _mr] = mis_right_obj->geometries().create(mis_right_mesh);
+
+    // Two spherical joints with identical local attachment points
+    // Left anchor at bottom face center, right anchor at top face center
+    // Aligned: left(0,0.5,-0.5)+(0,-0.15,0) = (0,0.35,-0.5)
+    //          right(0,0.2,-0.5)+(0,0.15,0)  = (0,0.35,-0.5) -> coincide
+    AffineBodySphericalJoint spherical_joint;
+
+    vector<Vector3> l_positions = {Vector3{0, -0.15, 0}, Vector3{0, -0.15, 0}};
+    vector<Vector3> r_positions = {Vector3{0,  0.15, 0}, Vector3{0,  0.15, 0}};
+
+    vector<S<SimplicialComplexSlot>> l_geo_slots    = {al_left_slot, mis_left_slot};
+    vector<IndexT>                   l_instance_ids = {0, 0};
+    vector<S<SimplicialComplexSlot>> r_geo_slots    = {al_right_slot, mis_right_slot};
+    vector<IndexT>                   r_instance_ids = {0, 0};
+    vector<Float>                    strength_ratios = {100.0, 100.0};
+
+    auto joint_mesh = spherical_joint.create_geometry(
+        span{l_positions}, span{r_positions},
+        span{l_geo_slots}, span{l_instance_ids},
+        span{r_geo_slots}, span{r_instance_ids},
+        span{strength_ratios});
+
+    auto joint_object = scene.objects().create("spherical_joint");
+    joint_object->geometries().create(joint_mesh);
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+
+    while(world.frame() < 5)
+    {
+        world.advance();
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+
+    auto to_world = [](const Matrix4x4& T, const Vector3& p) -> Vector3
+    {
+        return (T * Vector4{p.x(), p.y(), p.z(), 1.0}).head<3>();
+    };
+
+    auto al_left_t   = view(al_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto al_right_t  = view(al_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_left_t  = view(mis_left_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    auto mis_right_t = view(mis_right_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+
+    Vector3 lp{0, -0.15, 0};
+    Vector3 rp{0,  0.15, 0};
+
+    REQUIRE(to_world(al_left_t, lp).isApprox(to_world(al_right_t, rp)));
+    REQUIRE(to_world(mis_left_t, lp).isApprox(to_world(mis_right_t, rp)));
+}

--- a/docs/specification/constitutions/affine_body_driving_prismatic_joint.md
+++ b/docs/specification/constitutions/affine_body_driving_prismatic_joint.md
@@ -62,7 +62,9 @@ This constitution must be applied to a geometry that already has an [AffineBodyP
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on `edges`:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). The edge carries the same linking fields as [Affine Body Prismatic Joint](./affine_body_prismatic_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, base `strength_ratio` (if present), and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
+
+Driving-specific attributes on **edges**:
 
 - `driving/strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
 - `is_constrained`: enables (`1`) or disables (`0`) the driving effect

--- a/docs/specification/constitutions/affine_body_driving_revolute_joint.md
+++ b/docs/specification/constitutions/affine_body_driving_revolute_joint.md
@@ -66,7 +66,9 @@ This constitution must be applied to a geometry that already has an [AffineBodyR
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on `edges`:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). The edge carries the same linking fields as [Affine Body Revolute Joint](./affine_body_revolute_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, base `strength_ratio` (if present), and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
+
+Driving-specific attributes on **edges**:
 
 - `driving/strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
 - `is_constrained`: enables (`1`) or disables (`0`) the driving effect

--- a/docs/specification/constitutions/affine_body_fixed_joint.md
+++ b/docs/specification/constitutions/affine_body_fixed_joint.md
@@ -130,6 +130,14 @@ where $K$ is the stiffness constant of the joint, we choose $K=\gamma (m_i + m_j
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on `edges`:
+The joint geometry is a **0D simplicial complex**: **one vertex per joint** (no edges).
 
+On **vertices**:
+
+- `l_geo_id` (`IndexT`): scene geometry slot id for the left body $i$
+- `r_geo_id` (`IndexT`): scene geometry slot id for the right body $j$
+- `l_inst_id` (`IndexT`): instance index within the left geometry
+- `r_inst_id` (`IndexT`): instance index within the right geometry
 - `strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
+
+When the joint is created via Local `create_geometry`, optional **vertex** attributes (each `Vector3`) supply local attachment coordinates: `l_position` in the left body's local frame and `r_position` in the right body's local frame.

--- a/docs/specification/constitutions/affine_body_prismatic_joint.md
+++ b/docs/specification/constitutions/affine_body_prismatic_joint.md
@@ -72,7 +72,12 @@ where $K$ is the stiffness constant of the joint, we choose $K=\gamma (m_i + m_j
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on `edges`:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint):
 
+- `l_geo_id` (`IndexT`): scene geometry slot id for the left body $i$
+- `r_geo_id` (`IndexT`): scene geometry slot id for the right body $j$
+- `l_inst_id` (`IndexT`): instance index within the left geometry
+- `r_inst_id` (`IndexT`): instance index within the right geometry
 - `strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
 
+When the joint is created via Local `create_geometry`, optional **edge** attributes (each `Vector3`) supply local joint geometry: `l_position0`, `l_position1` (left body local frame), `r_position0`, `r_position1` (right body local frame).

--- a/docs/specification/constitutions/affine_body_prismatic_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_prismatic_joint_external_force.md
@@ -61,7 +61,9 @@ This constitution must be applied to a geometry that already has an [AffineBodyP
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on `edges`:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). The edge carries the same linking fields as [Affine Body Prismatic Joint](./affine_body_prismatic_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, `strength_ratio`, and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
+
+External-force attributes on **edges**:
 
 - `external_force`: $f$ in the formulae above, scalar force along the joint axis (one per edge)
 - `external_force/is_constrained`: enables (`1`) or disables (`0`) the external force

--- a/docs/specification/constitutions/affine_body_prismatic_joint_limit.md
+++ b/docs/specification/constitutions/affine_body_prismatic_joint_limit.md
@@ -97,7 +97,9 @@ This limit term is meaningful only on a geometry that already represents a
 
 ## Attributes
 
-On `edges`:
+The host geometry is **edge-based** (one edge per joint), with the same linking fields as [Affine Body Prismatic Joint](./affine_body_prismatic_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, `strength_ratio`, and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
+
+On **edges** (in addition to the base joint attributes above):
 
 - `limit/lower`: $l_{\text{user}}$ — relative lower bound (default `0.0`)
 - `limit/upper`: $u_{\text{user}}$ — relative upper bound (default `0.0`)

--- a/docs/specification/constitutions/affine_body_revolute_joint.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint.md
@@ -40,6 +40,12 @@ where $K$ is the stiffness constant of the joint, we choose $K=\gamma (m_i + m_j
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on `edges`:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint):
 
+- `l_geo_id` (`IndexT`): scene geometry slot id for the left body $i$
+- `r_geo_id` (`IndexT`): scene geometry slot id for the right body $j$
+- `l_inst_id` (`IndexT`): instance index within the left geometry
+- `r_inst_id` (`IndexT`): instance index within the right geometry
 - `strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
+
+When the joint is created via Local `create_geometry`, optional **edge** attributes (each `Vector3`) supply local joint geometry: `l_position0`, `l_position1` (left body local frame), `r_position0`, `r_position1` (right body local frame).

--- a/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
@@ -84,7 +84,9 @@ This constitution must be applied to a geometry that already has an [AffineBodyR
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on `edges`:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). The edge carries the same linking fields as [Affine Body Revolute Joint](./affine_body_revolute_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, `strength_ratio`, and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
+
+External-force attributes on **edges**:
 
 - `external_torque`: $\tau$ in the formulae above, scalar torque around the joint axis (one per edge)
 - `external_torque/is_constrained`: enables (`1`) or disables (`0`) the external torque

--- a/docs/specification/constitutions/affine_body_revolute_joint_limit.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint_limit.md
@@ -61,7 +61,7 @@ Here:
 - $\mathbf{q}_{ref}$ is the reference DOF captured at initialization.
 - $\theta^t$ is the accumulated revolute angle from the previous step.
 
-Note that $\mathbf{q}$ is the concatenation of the DOF of the two affine bodies connected by the prismatic joint.
+Note that $\mathbf{q}$ is the concatenation of the DOF of the two affine bodies connected by the revolute joint.
 
 $$
 \mathbf{q} =
@@ -106,7 +106,9 @@ This limit term is meaningful only on a geometry that already represents a
 
 ## Attributes
 
-On `edges`:
+The host geometry is **edge-based** (one edge per joint), with the same linking fields as [Affine Body Revolute Joint](./affine_body_revolute_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, `strength_ratio`, and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
+
+On **edges** (in addition to the base joint attributes above):
 
 - `limit/lower`: $l_{\text{user}}$ — relative lower bound (default `0.0`)
 - `limit/upper`: $u_{\text{user}}$ — relative upper bound (default `0.0`)

--- a/docs/specification/constitutions/affine_body_spherical_joint.md
+++ b/docs/specification/constitutions/affine_body_spherical_joint.md
@@ -16,19 +16,13 @@ Each body $k \in \{i,j\}$ carries the affine state $\mathbf{q}_k \in \mathbb{R}^
 
 ### Rest anchor and local coordinates
 
-At setup, the user specifies an attachment $\bar{\mathbf{p}}_j$ in body $j$'s (the **right** body's) rest local frame. The corresponding world anchor at rest is:
+At setup, a single world anchor $\mathbf{c}$ is shared by both bodies. When the joint is created via Local `create_geometry`, optional **vertex** attributes `l_position` (`Vector3`, left body local) and `r_position` (`Vector3`, right body local) define the attachment; with rest transforms $\mathbf{T}_i$, $\mathbf{T}_j$,
 
 $$
-\mathbf{c} = \mathbf{T}_j \bar{\mathbf{p}}_j
+\mathbf{c} = \mathbf{T}_i \bar{\mathbf{c}}_i = \mathbf{T}_j \bar{\mathbf{c}}_j,
 $$
 
-where $\mathbf{T}_j$ is that instance's rest transform. The same world point is expressed in each body's local frame:
-
-$$
-\bar{\mathbf{c}}_i = \mathbf{T}_i^{-1} \mathbf{c}, \qquad \bar{\mathbf{c}}_j = \mathbf{T}_j^{-1} \mathbf{c} = \bar{\mathbf{p}}_j
-$$
-
-These fixed $\bar{\mathbf{c}}_i$, $\bar{\mathbf{c}}_j$ are stored per joint and used in the constraint below.
+where $\bar{\mathbf{c}}_i$ and $\bar{\mathbf{c}}_j$ are taken from `l_position` and `r_position` respectively when those attributes are present. If they are omitted, the implementation derives $\bar{\mathbf{c}}_i$, $\bar{\mathbf{c}}_j$ from the joint-creation path (e.g. a shared world anchor and the bodies' rest transforms). The backend stores these fixed local anchors per joint and uses them in the constraint below.
 
 ### Translation constraint
 
@@ -80,16 +74,16 @@ Unlike the [Affine Body Fixed Joint](./affine_body_fixed_joint.md), there is **n
 
 ## Attributes and geometry
 
-The joint is stored as a 1D simplicial complex (one edge per joint).
+The joint is stored as a **0D simplicial complex**: **one vertex per joint** (no edges).
 
-On each **edge**:
+On each **vertex**:
 
-- `geo_ids`: `Vector2i` — scene geometry slot ids $(\text{left},\text{right})$ for bodies $i$ and $j$
-- `inst_ids`: `Vector2i` — instance indices within each geometry
+- `l_geo_id` (`IndexT`): scene geometry slot id for the left body $i$
+- `r_geo_id` (`IndexT`): scene geometry slot id for the right body $j$
+- `l_inst_id` (`IndexT`): instance index within the left geometry
+- `r_inst_id` (`IndexT`): instance index within the right geometry
 - `strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$
 
-On **vertices** (two per joint, for visualization and initialization):
-
-- `position` / builtin positions: vertex $2k$ is body $i$'s rest translation (edge endpoint for drawing); vertex $2k+1$ is the world-space anchor $\mathbf{c} = \mathbf{T}_j \bar{\mathbf{p}}_j$ at setup. The backend evaluates $\bar{\mathbf{c}}_i$, $\bar{\mathbf{c}}_j$ from the anchor vertex and the two rest transforms.
+When the joint is created via Local `create_geometry`, optional **vertex** attributes (each `Vector3`): `l_position` (left body's local frame) and `r_position` (right body's local frame).
 
 Constitution UID: $26$ (see [Constitutions index](./index.md)).

--- a/include/uipc/constitution/affine_body_fixed_joint.h
+++ b/include/uipc/constitution/affine_body_fixed_joint.h
@@ -13,17 +13,58 @@ class UIPC_CONSTITUTION_API AffineBodyFixedJoint final : public InterAffineBodyC
 
     virtual ~AffineBodyFixedJoint();
 
+    /**
+     * @brief Create fixed joint geometry with world-space positions derived from body transforms.
+     *
+     * Builds a vertex-based SimplicialComplex (1 vertex per joint).
+     * Writes vertices.position as midpoint of the two body translations.
+     * Does not write local position attributes.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
+     * @brief Create fixed joint geometry with local-space positions.
+     *
+     * Builds a vertex-based SimplicialComplex (1 vertex per joint).
+     * Writes local position attributes (position0, position1) on vertices.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<const Vector3>                      l_positions,
+        span<const Vector3>                      r_positions,
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
+     * @brief Bind affine body instances to existing fixed joint geometry (single-instance mode).
+     *
+     * Pure binding: writes constitution UID, geometry IDs, instance IDs, and
+     * strength ratios. Does NOT build geometry.
+     */
     void apply_to(geometry::SimplicialComplex&             sc,
                   span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
                   span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
                   Float strength_ratio = Float{100});
 
+    /**
+     * @brief Bind affine body instances to existing fixed joint geometry (multi-instance mode).
+     *
+     * Pure binding: writes constitution UID, geometry IDs, instance IDs, and
+     * strength ratios. Does NOT build geometry.
+     */
     void apply_to(geometry::SimplicialComplex&             sc,
                   span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
-                  span<IndexT>                             l_instance_id,
+                  span<IndexT>                             l_instance_ids,
                   span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                  span<IndexT>                             r_instance_id,
-                  span<Float>                              strength_ratio);
+                  span<IndexT>                             r_instance_ids,
+                  span<Float>                              strength_ratios);
 
   private:
     virtual U64 get_uid() const noexcept override;

--- a/include/uipc/constitution/affine_body_prismatic_joint.h
+++ b/include/uipc/constitution/affine_body_prismatic_joint.h
@@ -17,6 +17,40 @@ class UIPC_CONSTITUTION_API AffineBodyPrismaticJoint final : public InterAffineB
     virtual ~AffineBodyPrismaticJoint();
 
     /**
+     * @brief Create prismatic joint geometry with world-space endpoint positions.
+     *
+     * Builds a SimplicialComplex with 2*N vertices and N edges. Writes
+     * vertices.position from position0s/position1s. Does not write local
+     * position attributes.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<const Vector3>                      position0s,
+        span<const Vector3>                      position1s,
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
+     * @brief Create prismatic joint geometry with local-space endpoint positions.
+     *
+     * Builds a SimplicialComplex with N edges. Writes local position
+     * attributes (l_position0, l_position1, r_position0, r_position1)
+     * on edges. Does not write vertices.position.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<const Vector3>                      l_position0,
+        span<const Vector3>                      l_position1,
+        span<const Vector3>                      r_position0,
+        span<const Vector3>                      r_position1,
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
      * @brief Apply prismatic joint to edges connecting affine bodies (single-instance mode).
      * 
      * This method assumes each geometry has exactly one instance (instance 0).
@@ -40,17 +74,17 @@ class UIPC_CONSTITUTION_API AffineBodyPrismaticJoint final : public InterAffineB
      * 
      * @param edges The simplicial complex containing the edges representing the joints.
      * @param l_geo_slots Left geometry slots for each joint.
-     * @param l_instance_id Instance IDs for the left geometries (must be in range [0, instances().size())).
+     * @param l_instance_ids Instance IDs for the left geometries (must be in range [0, instances().size())).
      * @param r_geo_slots Right geometry slots for each joint.
-     * @param r_instance_id Instance IDs for the right geometries (must be in range [0, instances().size())).
-     * @param strength_ratio The strength ratio for each joint (one per edge).
+     * @param r_instance_ids Instance IDs for the right geometries (must be in range [0, instances().size())).
+     * @param strength_ratios The strength ratio for each joint (one per edge).
      */
     void apply_to(geometry::SimplicialComplex&             edges,
                   span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
-                  span<IndexT>                             l_instance_id,
+                  span<IndexT>                             l_instance_ids,
                   span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                  span<IndexT>                             r_instance_id,
-                  span<Float>                              strength_ratio);
+                  span<IndexT>                             r_instance_ids,
+                  span<Float>                              strength_ratios);
 
   private:
     virtual U64 get_uid() const noexcept override;

--- a/include/uipc/constitution/affine_body_revolute_joint.h
+++ b/include/uipc/constitution/affine_body_revolute_joint.h
@@ -17,6 +17,40 @@ class UIPC_CONSTITUTION_API AffineBodyRevoluteJoint final : public InterAffineBo
     virtual ~AffineBodyRevoluteJoint();
 
     /**
+     * @brief Create revolute joint geometry with world-space endpoint positions.
+     *
+     * Builds a SimplicialComplex with 2*N vertices and N edges. Writes
+     * vertices.position from position0s/position1s. Does not write local
+     * position attributes.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<const Vector3>                      position0s,
+        span<const Vector3>                      position1s,
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
+     * @brief Create revolute joint geometry with local-space endpoint positions.
+     *
+     * Builds a SimplicialComplex with N edges. Writes local position
+     * attributes (l_position0, l_position1, r_position0, r_position1)
+     * on edges. Does not write vertices.position.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<const Vector3>                      l_position0,
+        span<const Vector3>                      l_position1,
+        span<const Vector3>                      r_position0,
+        span<const Vector3>                      r_position1,
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
      * @brief Apply revolute joint to edges connecting affine bodies (single-instance mode).
      * 
      * This method assumes each geometry has exactly one instance (instance 0).
@@ -40,17 +74,17 @@ class UIPC_CONSTITUTION_API AffineBodyRevoluteJoint final : public InterAffineBo
      * 
      * @param edges The simplicial complex containing the edges representing the joints.
      * @param l_geo_slots Left geometry slots for each joint.
-     * @param l_instance_id Instance IDs for the left geometries (must be in range [0, instances().size())).
+     * @param l_instance_ids Instance IDs for the left geometries (must be in range [0, instances().size())).
      * @param r_geo_slots Right geometry slots for each joint.
-     * @param r_instance_id Instance IDs for the right geometries (must be in range [0, instances().size())).
-     * @param strength_ratio The strength ratio for each joint (one per edge).
+     * @param r_instance_ids Instance IDs for the right geometries (must be in range [0, instances().size())).
+     * @param strength_ratios The strength ratio for each joint (one per edge).
      */
     void apply_to(geometry::SimplicialComplex&             edges,
                   span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
-                  span<IndexT>                             l_instance_id,
+                  span<IndexT>                             l_instance_ids,
                   span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                  span<IndexT>                             r_instance_id,
-                  span<Float>                              strength_ratio);
+                  span<IndexT>                             r_instance_ids,
+                  span<Float>                              strength_ratios);
 
 
   private:

--- a/include/uipc/constitution/affine_body_spherical_joint.h
+++ b/include/uipc/constitution/affine_body_spherical_joint.h
@@ -13,20 +13,58 @@ class UIPC_CONSTITUTION_API AffineBodySphericalJoint final : public InterAffineB
 
     virtual ~AffineBodySphericalJoint();
 
-    // Simplified API: anchor at body1's (right body's) origin in local space
+    /**
+     * @brief Create spherical joint geometry with world-space anchor positions.
+     *
+     * Builds a vertex-based SimplicialComplex (1 vertex per joint).
+     * Writes vertices.position from positions. Does not write local
+     * position attributes.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<const Vector3>                      positions,
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
+     * @brief Create spherical joint geometry with local-space anchor positions.
+     *
+     * Builds a vertex-based SimplicialComplex (1 vertex per joint).
+     * Writes local position attributes (position0, position1) on vertices.
+     */
+    [[nodiscard]] geometry::SimplicialComplex create_geometry(
+        span<const Vector3>                      l_positions,
+        span<const Vector3>                      r_positions,
+        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+        span<IndexT>                             l_instance_ids,
+        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+        span<IndexT>                             r_instance_ids,
+        span<Float>                              strength_ratios);
+
+    /**
+     * @brief Bind affine body instances to existing spherical joint geometry (single-instance mode).
+     *
+     * Pure binding: writes constitution UID, geometry IDs, instance IDs, and
+     * strength ratios on vertices. Does NOT build geometry.
+     */
     void apply_to(geometry::SimplicialComplex&             sc,
                   span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
                   span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                  span<Vector3>                            r_local_pos,
                   Float strength_ratio = Float{100});
 
-    // Full API: anchor specified as r_local_pos in body1's (right body's) local frame
+    /**
+     * @brief Bind affine body instances to existing spherical joint geometry (multi-instance mode).
+     *
+     * Pure binding: writes constitution UID, geometry IDs, instance IDs, and
+     * strength ratios on vertices. Does NOT build geometry.
+     */
     void apply_to(geometry::SimplicialComplex&             sc,
                   span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
                   span<IndexT>                             l_instance_ids,
                   span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
                   span<IndexT>                             r_instance_ids,
-                  span<Vector3>                            r_local_pos,
                   span<Float>                              strength_ratios);
 
   private:

--- a/src/backends/cuda/affine_body/constitutions/affine_body_fixed_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_fixed_joint.cu
@@ -3,7 +3,6 @@
 #include <uipc/builtin/attribute_name.h>
 #include <utils/make_spd.h>
 #include <utils/matrix_assembler.h>
-#include <uipc/common/enumerate.h>
 
 namespace uipc::backend::cuda
 {
@@ -55,32 +54,51 @@ class AffineBodyFixedJoint final : public InterAffineBodyConstitution
             {
                 auto sc = geo.as<geometry::SimplicialComplex>();
 
-                auto geo_ids_view = sc->edges().find<Vector2i>("geo_ids")->view();
-                auto inst_ids_view = sc->edges().find<Vector2i>("inst_ids")->view();
+                auto l_geo_id = sc->vertices().find<IndexT>("l_geo_id");
+                auto l_geo_id_view = l_geo_id->view();
+                auto r_geo_id = sc->vertices().find<IndexT>("r_geo_id");
+                auto r_geo_id_view = r_geo_id->view();
+                auto l_inst_id = sc->vertices().find<IndexT>("l_inst_id");
+                auto l_inst_id_view = l_inst_id->view();
+                auto r_inst_id = sc->vertices().find<IndexT>("r_inst_id");
+                auto r_inst_id_view = r_inst_id->view();
                 auto strength_ratio_view =
-                    sc->edges().find<Float>("strength_ratio")->view();
+                    sc->vertices().find<Float>("strength_ratio")->view();
 
-                auto Es = sc->edges().topo().view();
+                auto pos0_attr = sc->vertices().find<Vector3>("l_position");
+                auto pos1_attr = sc->vertices().find<Vector3>("r_position");
+                const bool use_local_positions = pos0_attr && pos1_attr;
+
                 auto Ps = sc->positions().view();
-                for(auto&& [i, e] : enumerate(Es))
+                const SizeT n_joints = sc->vertices().size();
+                for(SizeT i = 0; i < n_joints; ++i)
                 {
-                    Vector2i geo_id  = geo_ids_view[i];
-                    Vector2i inst_id = inst_ids_view[i];
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    body_ids_list.push_back({info.body_id(geo_id(0), inst_id(0)),
-                                             info.body_id(geo_id(1), inst_id(1))});
+                    body_ids_list.push_back({info.body_id(l_gid, l_iid),
+                                             info.body_id(r_gid, r_iid)});
 
                     Transform LT{
-                        info.body_geo(geo_slots, geo_id(0))->transforms().view()[inst_id(0)]};
+                        info.body_geo(geo_slots, l_gid)->transforms().view()[l_iid]};
                     Transform RT{
-                        info.body_geo(geo_slots, geo_id(1))->transforms().view()[inst_id(1)]};
+                        info.body_geo(geo_slots, r_gid)->transforms().view()[r_iid]};
 
-                    Vector3 mid_point = (Ps[e[0]] + Ps[e[1]]) / 2.0;
-
-                    // rest_cs: midpoint in each body's local frame
+                    // rest_cs: matching attachment points in each body's local frame
                     Vector6 rest_c;
-                    rest_c.segment<3>(0) = LT.inverse() * mid_point;
-                    rest_c.segment<3>(3) = RT.inverse() * mid_point;
+                    if(use_local_positions)
+                    {
+                        rest_c.segment<3>(0) = pos0_attr->view()[i];
+                        rest_c.segment<3>(3) = pos1_attr->view()[i];
+                    }
+                    else
+                    {
+                        Vector3 mid_point = Ps[i];
+                        rest_c.segment<3>(0) = LT.inverse() * mid_point;
+                        rest_c.segment<3>(3) = RT.inverse() * mid_point;
+                    }
                     rest_c_list.push_back(rest_c);
 
                     // t, n, b: coordinate axes in body space

--- a/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
@@ -65,13 +65,21 @@ class AffineBodyPrismaticJoint final : public InterAffineBodyConstitution
 
                 auto sc = geo.as<geometry::SimplicialComplex>();
 
-                auto geo_ids = sc->edges().find<Vector2i>("geo_ids");
-                UIPC_ASSERT(geo_ids, "AffineBodyPrismaticJoint: Geometry must have 'geo_ids' attribute on `edges`");
-                auto geo_ids_view = geo_ids->view();
+                auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+                UIPC_ASSERT(l_geo_id, "AffineBodyPrismaticJoint: Geometry must have 'l_geo_id' attribute on `edges`");
+                auto l_geo_id_view = l_geo_id->view();
 
-                auto inst_ids = sc->edges().find<Vector2i>("inst_ids");
-                UIPC_ASSERT(inst_ids, "AffineBodyPrismaticJoint: Geometry must have 'inst_ids' attribute on `edges`");
-                auto inst_ids_view = inst_ids->view();
+                auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+                UIPC_ASSERT(r_geo_id, "AffineBodyPrismaticJoint: Geometry must have 'r_geo_id' attribute on `edges`");
+                auto r_geo_id_view = r_geo_id->view();
+
+                auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+                UIPC_ASSERT(l_inst_id, "AffineBodyPrismaticJoint: Geometry must have 'l_inst_id' attribute on `edges`");
+                auto l_inst_id_view = l_inst_id->view();
+
+                auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+                UIPC_ASSERT(r_inst_id, "AffineBodyPrismaticJoint: Geometry must have 'r_inst_id' attribute on `edges`");
+                auto r_inst_id_view = r_inst_id->view();
 
                 auto strength_ratio = sc->edges().find<Float>("strength_ratio");
                 UIPC_ASSERT(strength_ratio, "AffineBodyPrismaticJoint: Geometry must have 'strength_ratio' attribute on `edges`");
@@ -91,64 +99,84 @@ class AffineBodyPrismaticJoint final : public InterAffineBodyConstitution
 
                 auto Es = sc->edges().topo().view();
                 auto Ps = sc->positions().view();
+
+                auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+                auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+                auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+                auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+                bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
+
                 for(auto&& [i, e] : enumerate(Es))
                 {
-                    Vector3 P0 = Ps[e[0]];
-                    Vector3 P1 = Ps[e[1]];
-                    UIPC_ASSERT((P0 - P1).squaredNorm() > 0,
-                                "AffineBodyPrismaticJoint: Edge positions must not be too close");
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    Vector2i geo_id  = geo_ids_view[i];
-                    Vector2i inst_id = inst_ids_view[i];
-
-                    Vector2i body_ids = {info.body_id(geo_id(0), inst_id(0)),
-                                         info.body_id(geo_id(1), inst_id(1))};
+                    Vector2i body_ids = {info.body_id(l_gid, l_iid),
+                                         info.body_id(r_gid, r_iid)};
                     body_ids_list.push_back(body_ids);
 
-                    auto left_sc  = info.body_geo(geo_slots, geo_id(0));
-                    auto right_sc = info.body_geo(geo_slots, geo_id(1));
+                    auto left_sc  = info.body_geo(geo_slots, l_gid);
+                    auto right_sc = info.body_geo(geo_slots, r_gid);
 
-                    UIPC_ASSERT(inst_id(0) >= 0
-                                    && inst_id(0) < static_cast<IndexT>(
+                    UIPC_ASSERT(l_iid >= 0
+                                    && l_iid < static_cast<IndexT>(
                                            left_sc->instances().size()),
                                 "AffineBodyPrismaticJoint: Left instance ID {} is out of range [0, {})",
-                                inst_id(0),
+                                l_iid,
                                 left_sc->instances().size());
-                    UIPC_ASSERT(inst_id(1) >= 0
-                                    && inst_id(1) < static_cast<IndexT>(
+                    UIPC_ASSERT(r_iid >= 0
+                                    && r_iid < static_cast<IndexT>(
                                            right_sc->instances().size()),
                                 "AffineBodyPrismaticJoint: Right instance ID {} is out of range [0, {})",
-                                inst_id(1),
+                                r_iid,
                                 right_sc->instances().size());
 
-                    Transform LT{left_sc->transforms().view()[inst_id(0)]};
-                    Transform RT{right_sc->transforms().view()[inst_id(1)]};
+                    Transform LT{left_sc->transforms().view()[l_iid]};
+                    Transform RT{right_sc->transforms().view()[r_iid]};
 
-                    Vector3 tangent   = (P1 - P0).normalized();
+                    Vector3 tangent;
+                    Vector6 rest_position_c;
+                    if(use_local)
+                    {
+                        Vector3 lp0 = LT * l_pos0_attr->view()[i];
+                        Vector3 lp1 = LT * l_pos1_attr->view()[i];
+                        tangent = (lp1 - lp0).normalized();
+                        rest_position_c.segment<3>(0) = l_pos0_attr->view()[i];
+                        rest_position_c.segment<3>(3) = r_pos0_attr->view()[i];
+                    }
+                    else
+                    {
+                        Vector3 P0 = Ps[e[0]];
+                        Vector3 P1 = Ps[e[1]];
+                        UIPC_ASSERT((P0 - P1).squaredNorm() > 0,
+                                    "AffineBodyPrismaticJoint: Edge positions must not be too close");
+                        tangent = (P1 - P0).normalized();
+                        rest_position_c.segment<3>(0) = LT.inverse() * P0;
+                        rest_position_c.segment<3>(3) = RT.inverse() * P0;
+                    }
+
                     Vector3 normal    = Normal(tangent);
                     Vector3 bitangent = normal.cross(tangent).normalized();
-
-                    Vector6 rest_position_c;
-                    rest_position_c.segment<3>(0) = LT.inverse() * P0;  // ci_bar
-                    rest_position_c.segment<3>(3) = RT.inverse() * P0;  // cj_bar
                     rest_c_list.push_back(rest_position_c);
 
                     Matrix3x3 LT_rotation = LT.rotation();
                     Matrix3x3 RT_rotation = RT.rotation();
 
                     Vector6 rest_vec_t;
-                    rest_vec_t.segment<3>(0) = LT_rotation.inverse() * tangent;  // ti_bar
-                    rest_vec_t.segment<3>(3) = RT_rotation.inverse() * tangent;  // tj_bar
+                    rest_vec_t.segment<3>(0) = LT_rotation.inverse() * tangent;
+                    rest_vec_t.segment<3>(3) = RT_rotation.inverse() * tangent;
                     rest_t_list.push_back(rest_vec_t);
 
                     Vector6 rest_vec_n;
-                    rest_vec_n.segment<3>(0) = LT_rotation.inverse() * normal;  // ni_bar
-                    rest_vec_n.segment<3>(3) = RT_rotation.inverse() * normal;  // nj_bar
+                    rest_vec_n.segment<3>(0) = LT_rotation.inverse() * normal;
+                    rest_vec_n.segment<3>(3) = RT_rotation.inverse() * normal;
                     rest_n_list.push_back(rest_vec_n);
 
                     Vector6 rest_vec_b;
-                    rest_vec_b.segment<3>(0) = LT_rotation.inverse() * bitangent;  // bi_bar
-                    rest_vec_b.segment<3>(3) = RT_rotation.inverse() * bitangent;  // bj_bar
+                    rest_vec_b.segment<3>(0) = LT_rotation.inverse() * bitangent;
+                    rest_vec_b.segment<3>(3) = RT_rotation.inverse() * bitangent;
                     rest_b_list.push_back(rest_vec_b);
                 }
 
@@ -480,14 +508,22 @@ class AffineBodyDrivingPrismaticJoint : public InterAffineBodyConstraint
                 UIPC_ASSERT(h_geo_joint_offsets_counts.counts()[joint_offset] > 0,
                             "AffineBodyDrivingPrismaticJoint: Geometry must have at least one edge");
 
-                // get geo_ids and inst_ids
-                auto geo_ids = sc->edges().find<Vector2i>("geo_ids");
-                UIPC_ASSERT(geo_ids, "AffineBodyDrivingPrismaticJoint geometry must have 'geo_ids' attribute on `edges`");
-                auto geo_ids_view = geo_ids->view();
+                // get l_geo_id, r_geo_id, l_inst_id, r_inst_id
+                auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+                UIPC_ASSERT(l_geo_id, "AffineBodyDrivingPrismaticJoint: Geometry must have 'l_geo_id' attribute on `edges`");
+                auto l_geo_id_view = l_geo_id->view();
 
-                auto inst_ids = sc->edges().find<Vector2i>("inst_ids");
-                UIPC_ASSERT(inst_ids, "AffineBodyDrivingPrismaticJoint: Geometry must have 'inst_ids' attribute on `edges`");
-                auto inst_ids_view = inst_ids->view();
+                auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+                UIPC_ASSERT(r_geo_id, "AffineBodyDrivingPrismaticJoint: Geometry must have 'r_geo_id' attribute on `edges`");
+                auto r_geo_id_view = r_geo_id->view();
+
+                auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+                UIPC_ASSERT(l_inst_id, "AffineBodyDrivingPrismaticJoint: Geometry must have 'l_inst_id' attribute on `edges`");
+                auto l_inst_id_view = l_inst_id->view();
+
+                auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+                UIPC_ASSERT(r_inst_id, "AffineBodyDrivingPrismaticJoint: Geometry must have 'r_inst_id' attribute on `edges`");
+                auto r_inst_id_view = r_inst_id->view();
 
                 auto is_constrained = sc->edges().find<IndexT>("driving/is_constrained");
                 UIPC_ASSERT(is_constrained, "AffineBodyDrivingPrismaticJoint: Geometry must have 'driving/is_constrained' attribute on `edges`");
@@ -519,59 +555,77 @@ class AffineBodyDrivingPrismaticJoint : public InterAffineBodyConstraint
                 auto Es = sc->edges().topo().view();
                 auto Ps = sc->positions().view();
 
+                auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+                auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+                auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+                auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+                bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
+
                 for(auto&& [i, e] : enumerate(Es))
                 {
-                    Vector2i geo_id  = geo_ids_view[i];
-                    Vector2i inst_id = inst_ids_view[i];
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    Vector3 P0 = Ps[e[0]];
-                    Vector3 P1 = Ps[e[1]];
+                    Vector2i body_ids = {info.body_id(l_gid, l_iid),
+                                         info.body_id(r_gid, r_iid)};
+                    body_ids_list.push_back(body_ids);
 
-                    UIPC_ASSERT((P0 - P1).squaredNorm() > 0,
-                                R"(AffineBodyDrivingPrismaticJoint: Edge with zero length detected,
+                    auto left_sc  = info.body_geo(geo_slots, l_gid);
+                    auto right_sc = info.body_geo(geo_slots, r_gid);
+
+                    UIPC_ASSERT(l_iid >= 0
+                                    && l_iid < static_cast<IndexT>(
+                                           left_sc->instances().size()),
+                                "AffineBodyDrivingPrismaticJoint: Left instance ID {} is out of range [0, {})",
+                                l_iid,
+                                left_sc->instances().size());
+                    UIPC_ASSERT(r_iid >= 0
+                                    && r_iid < static_cast<IndexT>(
+                                           right_sc->instances().size()),
+                                "AffineBodyDrivingPrismaticJoint: Right instance ID {} is out of range [0, {})",
+                                r_iid,
+                                right_sc->instances().size());
+
+                    Transform LT{left_sc->transforms().view()[l_iid]};
+                    Transform RT{right_sc->transforms().view()[r_iid]};
+
+                    Vector3 tangent;
+                    Vector6 rest_position;
+                    if(use_local)
+                    {
+                        Vector3 lp0 = LT * l_pos0_attr->view()[i];
+                        Vector3 lp1 = LT * l_pos1_attr->view()[i];
+                        tangent = (lp1 - lp0).normalized();
+                        rest_position.segment<3>(0) = l_pos0_attr->view()[i];
+                        rest_position.segment<3>(3) = r_pos0_attr->view()[i];
+                    }
+                    else
+                    {
+                        Vector3 P0 = Ps[e[0]];
+                        Vector3 P1 = Ps[e[1]];
+
+                        UIPC_ASSERT((P0 - P1).squaredNorm() > 0,
+                                    R"(AffineBodyDrivingPrismaticJoint: Edge with zero length detected,
 Joint GeometryID = {},
 LinkGeoIDs       = ({}, {}),
 LinkInstIDs      = ({}, {}),
 Edge             = ({}, {}))",
-                                I.geo_info().geo_id,
-                                geo_id(0),
-                                geo_id(1),
-                                inst_id(0),
-                                inst_id(1),
-                                e(0),
-                                e(1));
+                                    I.geo_info().geo_id,
+                                    l_gid,
+                                    r_gid,
+                                    l_iid,
+                                    r_iid,
+                                    e(0),
+                                    e(1));
 
-                    Vector2i body_ids = {info.body_id(geo_id(0), inst_id(0)),
-                                         info.body_id(geo_id(1), inst_id(1))};
-                    body_ids_list.push_back(body_ids);
-
-                    auto left_sc  = info.body_geo(geo_slots, geo_id(0));
-                    auto right_sc = info.body_geo(geo_slots, geo_id(1));
-
-                    UIPC_ASSERT(inst_id(0) >= 0
-                                    && inst_id(0) < static_cast<IndexT>(
-                                           left_sc->instances().size()),
-                                "AffineBodyDrivingPrismaticJoint: Left instance ID {} is out of range [0, {})",
-                                inst_id(0),
-                                left_sc->instances().size());
-                    UIPC_ASSERT(inst_id(1) >= 0
-                                    && inst_id(1) < static_cast<IndexT>(
-                                           right_sc->instances().size()),
-                                "AffineBodyDrivingPrismaticJoint: Right instance ID {} is out of range [0, {})",
-                                inst_id(1),
-                                right_sc->instances().size());
-
-                    Vector3   tangent = (P1 - P0).normalized();
-                    Transform LT{left_sc->transforms().view()[inst_id(0)]};
-                    Transform RT{right_sc->transforms().view()[inst_id(1)]};
-
-                    // position
-                    Vector6 rest_position;
-                    rest_position.segment<3>(0) = LT.inverse() * P0;
-                    rest_position.segment<3>(3) = RT.inverse() * P0;
+                        tangent = (P1 - P0).normalized();
+                        rest_position.segment<3>(0) = LT.inverse() * P0;
+                        rest_position.segment<3>(3) = RT.inverse() * P0;
+                    }
                     rest_position_list.push_back(rest_position);
 
-                    // tangent
                     Vector6 rest_tangent;
                     rest_tangent.segment<3>(0) = LT.rotation().inverse() * tangent;
                     rest_tangent.segment<3>(3) = RT.rotation().inverse() * tangent;

--- a/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint_limit.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint_limit.cu
@@ -98,13 +98,18 @@ class AffineBodyPrismaticJointLimit final : public InterAffineBodyConstitution
                 auto sc = geo.as<geometry::SimplicialComplex>();
                 UIPC_ASSERT(sc, "AffineBodyPrismaticJointLimit geometry must be SimplicialComplex");
 
-                auto geo_ids_attr = sc->edges().find<Vector2i>("geo_ids");
-                UIPC_ASSERT(geo_ids_attr, "AffineBodyPrismaticJointLimit requires `geo_ids` attribute on edges");
-                auto geo_ids = geo_ids_attr->view();
-
-                auto inst_ids_attr = sc->edges().find<Vector2i>("inst_ids");
-                UIPC_ASSERT(inst_ids_attr, "AffineBodyPrismaticJointLimit requires `inst_ids` attribute on edges");
-                auto inst_ids = inst_ids_attr->view();
+                auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+                UIPC_ASSERT(l_geo_id, "AffineBodyPrismaticJointLimit requires `l_geo_id` attribute on edges");
+                auto l_geo_id_view = l_geo_id->view();
+                auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+                UIPC_ASSERT(r_geo_id, "AffineBodyPrismaticJointLimit requires `r_geo_id` attribute on edges");
+                auto r_geo_id_view = r_geo_id->view();
+                auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+                UIPC_ASSERT(l_inst_id, "AffineBodyPrismaticJointLimit requires `l_inst_id` attribute on edges");
+                auto l_inst_id_view = l_inst_id->view();
+                auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+                UIPC_ASSERT(r_inst_id, "AffineBodyPrismaticJointLimit requires `r_inst_id` attribute on edges");
+                auto r_inst_id_view = r_inst_id->view();
 
                 auto lower_attr = sc->edges().find<Float>("limit/lower");
                 UIPC_ASSERT(lower_attr, "AffineBodyPrismaticJointLimit requires `limit/lower` attribute on edges");
@@ -123,40 +128,66 @@ class AffineBodyPrismaticJointLimit final : public InterAffineBodyConstitution
                 auto init_dist_view = init_dist_attr->view();
 
                 auto edges = sc->edges().topo().view();
+
+                auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+                auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+                auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+                auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+                bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
+
                 for(auto&& [i, e] : enumerate(edges))
                 {
-                    Vector2i geo_id  = geo_ids[i];
-                    Vector2i inst_id = inst_ids[i];
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    auto* left_sc  = info.body_geo(geo_slots, geo_id[0]);
-                    auto* right_sc = info.body_geo(geo_slots, geo_id[1]);
+                    auto* left_sc  = info.body_geo(geo_slots, l_gid);
+                    auto* right_sc = info.body_geo(geo_slots, r_gid);
 
-                    UIPC_ASSERT(inst_id[0] >= 0
-                                    && inst_id[0] < static_cast<IndexT>(
+                    UIPC_ASSERT(l_iid >= 0
+                                    && l_iid < static_cast<IndexT>(
                                            left_sc->instances().size()),
                                 "AffineBodyPrismaticJointLimit: left instance ID {} out of range [0, {})",
-                                inst_id[0],
+                                l_iid,
                                 left_sc->instances().size());
-                    UIPC_ASSERT(inst_id[1] >= 0
-                                    && inst_id[1] < static_cast<IndexT>(
+                    UIPC_ASSERT(r_iid >= 0
+                                    && r_iid < static_cast<IndexT>(
                                            right_sc->instances().size()),
                                 "AffineBodyPrismaticJointLimit: right instance ID {} out of range [0, {})",
-                                inst_id[1],
+                                r_iid,
                                 right_sc->instances().size());
 
                     Vector2i bid = {
-                        info.body_id(geo_id[0], inst_id[0]),
-                        info.body_id(geo_id[1], inst_id[1]),
+                        info.body_id(l_gid, l_iid),
+                        info.body_id(r_gid, r_iid),
                     };
 
-                    auto [lb, rb] = get_prismatic_basis(
-                        left_sc, inst_id[0], right_sc, inst_id[1], sc, i);
+                    Vector6 lb, rb;
+                    if(use_local)
+                    {
+                        Transform LT{left_sc->transforms().view()[l_iid]};
+                        Transform RT{right_sc->transforms().view()[r_iid]};
+                        Vector3 l_t = (LT.rotation() * (l_pos1_attr->view()[i] - l_pos0_attr->view()[i])).normalized();
+                        Vector3 l_c = LT * l_pos0_attr->view()[i];
+                        Vector3 r_t = (RT.rotation() * (r_pos1_attr->view()[i] - r_pos0_attr->view()[i])).normalized();
+                        Vector3 r_c = RT * r_pos0_attr->view()[i];
+                        lb.segment<3>(0) = LT.inverse() * l_c;
+                        lb.segment<3>(3) = LT.rotation().inverse() * l_t;
+                        rb.segment<3>(0) = RT.inverse() * r_c;
+                        rb.segment<3>(3) = RT.rotation().inverse() * r_t;
+                    }
+                    else
+                    {
+                        std::tie(lb, rb) = get_prismatic_basis(
+                            left_sc, l_iid, right_sc, r_iid, sc, i);
+                    }
 
                     Vector24 ref;
                     ref.segment<12>(0) =
-                        transform_to_q(left_sc->transforms().view()[inst_id[0]]);
+                        transform_to_q(left_sc->transforms().view()[l_iid]);
                     ref.segment<12>(12) =
-                        transform_to_q(right_sc->transforms().view()[inst_id[1]]);
+                        transform_to_q(right_sc->transforms().view()[r_iid]);
 
                     h_body_ids.push_back(bid);
                     h_l_basis.push_back(lb);

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -59,13 +59,21 @@ class AffineBodyRevoluteJoint final : public InterAffineBodyConstitution
                 auto sc = geo.as<geometry::SimplicialComplex>();
                 UIPC_ASSERT(sc, "AffineBodyRevoluteJoint: Geometry must be a simplicial complex");
 
-                auto geo_ids = sc->edges().find<Vector2i>("geo_ids");
-                UIPC_ASSERT(geo_ids, "AffineBodyRevoluteJoint: Geometry must have 'geo_ids' attribute on `edges`");
-                auto geo_ids_view = geo_ids->view();
+                auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+                UIPC_ASSERT(l_geo_id, "AffineBodyRevoluteJoint: Geometry must have 'l_geo_id' attribute on `edges`");
+                auto l_geo_id_view = l_geo_id->view();
 
-                auto inst_ids = sc->edges().find<Vector2i>("inst_ids");
-                UIPC_ASSERT(inst_ids, "AffineBodyRevoluteJoint: Geometry must have 'inst_ids' attribute on `edges`");
-                auto inst_ids_view = inst_ids->view();
+                auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+                UIPC_ASSERT(r_geo_id, "AffineBodyRevoluteJoint: Geometry must have 'r_geo_id' attribute on `edges`");
+                auto r_geo_id_view = r_geo_id->view();
+
+                auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+                UIPC_ASSERT(l_inst_id, "AffineBodyRevoluteJoint: Geometry must have 'l_inst_id' attribute on `edges`");
+                auto l_inst_id_view = l_inst_id->view();
+
+                auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+                UIPC_ASSERT(r_inst_id, "AffineBodyRevoluteJoint: Geometry must have 'r_inst_id' attribute on `edges`");
+                auto r_inst_id_view = r_inst_id->view();
 
                 auto strength_ratio = sc->edges().find<Float>("strength_ratio");
                 UIPC_ASSERT(strength_ratio, "AffineBodyRevoluteJoint: Geometry must have 'strength_ratio' attribute on `edges`");
@@ -73,65 +81,81 @@ class AffineBodyRevoluteJoint final : public InterAffineBodyConstitution
 
                 auto Es = sc->edges().topo().view();
                 auto Ps = sc->positions().view();
+
+                auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+                auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+                auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+                auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+                bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
+
                 for(auto&& [i, e] : enumerate(Es))
                 {
-                    Vector2i geo_id  = geo_ids_view[i];
-                    Vector2i inst_id = inst_ids_view[i];
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    Vector3 P0  = Ps[e[0]];
-                    Vector3 P1  = Ps[e[1]];
-                    Vector3 mid = (P0 + P1) / 2;
-                    Vector3 Dir = (P1 - P0);
+                    Vector2i body_ids = {info.body_id(l_gid, l_iid),
+                                         info.body_id(r_gid, r_iid)};
+                    body_ids_list.push_back(body_ids);
 
-                    UIPC_ASSERT(Dir.norm() > 1e-12,
-                                R"(AffineBodyRevoluteJoint: Edge with zero length detected,
+                    auto left_sc  = info.body_geo(geo_slots, l_gid);
+                    auto right_sc = info.body_geo(geo_slots, r_gid);
+
+                    UIPC_ASSERT(l_iid >= 0
+                                    && l_iid < static_cast<IndexT>(
+                                           left_sc->instances().size()),
+                                "AffineBodyRevoluteJoint: Left instance ID {} is out of range [0, {})",
+                                l_iid,
+                                left_sc->instances().size());
+                    UIPC_ASSERT(r_iid >= 0
+                                    && r_iid < static_cast<IndexT>(
+                                           right_sc->instances().size()),
+                                "AffineBodyRevoluteJoint: Right instance ID {} is out of range [0, {})",
+                                r_iid,
+                                right_sc->instances().size());
+
+                    Transform LT{left_sc->transforms().view()[l_iid]};
+                    Transform RT{right_sc->transforms().view()[r_iid]};
+
+                    Vector12 rest_pos;
+                    if(use_local)
+                    {
+                        rest_pos.segment<3>(0) = l_pos0_attr->view()[i];
+                        rest_pos.segment<3>(3) = l_pos1_attr->view()[i];
+                        rest_pos.segment<3>(6) = r_pos0_attr->view()[i];
+                        rest_pos.segment<3>(9) = r_pos1_attr->view()[i];
+                    }
+                    else
+                    {
+                        Vector3 P0  = Ps[e[0]];
+                        Vector3 P1  = Ps[e[1]];
+                        Vector3 mid = (P0 + P1) / 2;
+                        Vector3 Dir = (P1 - P0);
+
+                        UIPC_ASSERT(Dir.norm() > 1e-12,
+                                    R"(AffineBodyRevoluteJoint: Edge with zero length detected,
 Joint GeometryID = {},
 LinkGeoIDs       = ({}, {}),
 LinkInstIDs      = ({}, {}),
 Edge             = ({}, {}))",
-                                joint_geo_id,
-                                geo_id(0),
-                                geo_id(1),
-                                inst_id(0),
-                                inst_id(1),
-                                e(0),
-                                e(1));
+                                    joint_geo_id,
+                                    l_gid,
+                                    r_gid,
+                                    l_iid,
+                                    r_iid,
+                                    e(0),
+                                    e(1));
 
-                    Vector3 HalfAxis = Dir.normalized() / 2;
+                        Vector3 HalfAxis = Dir.normalized() / 2;
+                        P0 = mid - HalfAxis;
+                        P1 = mid + HalfAxis;
 
-                    // Re-define P0 and P1 to be symmetric around the mid-point
-                    P0 = mid - HalfAxis;
-                    P1 = mid + HalfAxis;
-
-                    Vector2i body_ids = {info.body_id(geo_id(0), inst_id(0)),
-                                         info.body_id(geo_id(1), inst_id(1))};
-                    body_ids_list.push_back(body_ids);
-
-                    auto left_sc  = info.body_geo(geo_slots, geo_id(0));
-                    auto right_sc = info.body_geo(geo_slots, geo_id(1));
-
-                    UIPC_ASSERT(inst_id(0) >= 0
-                                    && inst_id(0) < static_cast<IndexT>(
-                                           left_sc->instances().size()),
-                                "AffineBodyRevoluteJoint: Left instance ID {} is out of range [0, {})",
-                                inst_id(0),
-                                left_sc->instances().size());
-                    UIPC_ASSERT(inst_id(1) >= 0
-                                    && inst_id(1) < static_cast<IndexT>(
-                                           right_sc->instances().size()),
-                                "AffineBodyRevoluteJoint: Right instance ID {} is out of range [0, {})",
-                                inst_id(1),
-                                right_sc->instances().size());
-
-                    Transform LT{left_sc->transforms().view()[inst_id(0)]};
-                    Transform RT{right_sc->transforms().view()[inst_id(1)]};
-
-                    Vector12 rest_pos;
-                    rest_pos.segment<3>(0) = LT.inverse() * P0;  // x0_bar
-                    rest_pos.segment<3>(3) = LT.inverse() * P1;  // x1_bar
-
-                    rest_pos.segment<3>(6) = RT.inverse() * P0;  // x2_bar
-                    rest_pos.segment<3>(9) = RT.inverse() * P1;  // x3_bar
+                        rest_pos.segment<3>(0) = LT.inverse() * P0;
+                        rest_pos.segment<3>(3) = LT.inverse() * P1;
+                        rest_pos.segment<3>(6) = RT.inverse() * P0;
+                        rest_pos.segment<3>(9) = RT.inverse() * P1;
+                    }
                     rest_positions_list.push_back(rest_pos);
                 }
 
@@ -393,14 +417,22 @@ class AffineBodyDrivingRevoluteJoint : public InterAffineBodyConstraint
                 UIPC_ASSERT(h_geo_joint_offsets_counts.counts()[joint_offset] > 0,
                             "AffineBodyDrivingRevoluteJoint: Geometry must have at least one edge");
 
-                // get geo_ids and inst_ids
-                auto geo_ids = sc->edges().find<Vector2i>("geo_ids");
-                UIPC_ASSERT(geo_ids, "AffineBodyDrivingRevoluteJoint geometry must have 'geo_ids' attribute on `edges`");
-                auto geo_ids_view = geo_ids->view();
+                // get l_geo_id, r_geo_id, l_inst_id, r_inst_id
+                auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+                UIPC_ASSERT(l_geo_id, "AffineBodyDrivingRevoluteJoint: Geometry must have 'l_geo_id' attribute on `edges`");
+                auto l_geo_id_view = l_geo_id->view();
 
-                auto inst_ids = sc->edges().find<Vector2i>("inst_ids");
-                UIPC_ASSERT(inst_ids, "AffineBodyDrivingRevoluteJoint: Geometry must have 'inst_ids' attribute on `edges`");
-                auto inst_ids_view = inst_ids->view();
+                auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+                UIPC_ASSERT(r_geo_id, "AffineBodyDrivingRevoluteJoint: Geometry must have 'r_geo_id' attribute on `edges`");
+                auto r_geo_id_view = r_geo_id->view();
+
+                auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+                UIPC_ASSERT(l_inst_id, "AffineBodyDrivingRevoluteJoint: Geometry must have 'l_inst_id' attribute on `edges`");
+                auto l_inst_id_view = l_inst_id->view();
+
+                auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+                UIPC_ASSERT(r_inst_id, "AffineBodyDrivingRevoluteJoint: Geometry must have 'r_inst_id' attribute on `edges`");
+                auto r_inst_id_view = r_inst_id->view();
 
                 auto is_constrained = sc->edges().find<IndexT>("driving/is_constrained");
                 UIPC_ASSERT(is_constrained, "AffineBodyDrivingRevoluteJoint: Geometry must have 'driving/is_constrained' attribute on `edges`");
@@ -432,6 +464,12 @@ class AffineBodyDrivingRevoluteJoint : public InterAffineBodyConstraint
                 auto Es = sc->edges().topo().view();
                 auto Ps = sc->positions().view();
 
+                auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+                auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+                auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+                auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+                bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
+
                 auto toNormal = [&](const Vector3& W) -> Vector3
                 {
                     Vector3 ref = abs(W.dot(Vector3(1, 0, 0))) < 0.99 ?
@@ -446,61 +484,70 @@ class AffineBodyDrivingRevoluteJoint : public InterAffineBodyConstraint
 
                 for(auto&& [i, e] : enumerate(Es))
                 {
-                    Vector2i geo_id  = geo_ids_view[i];
-                    Vector2i inst_id = inst_ids_view[i];
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    Vector3 P0  = Ps[e[0]];
-                    Vector3 P1  = Ps[e[1]];
-                    Vector3 mid = (P0 + P1) / 2;
-                    Vector3 Dir = (P1 - P0);
+                    Vector2i body_ids = {info.body_id(l_gid, l_iid),
+                                         info.body_id(r_gid, r_iid)};
+                    body_ids_list.push_back(body_ids);
 
-                    UIPC_ASSERT(Dir.squaredNorm() > 1e-24,
-                                R"(AffineBodyDrivingRevoluteJoint: Edge with zero length detected,
+                    auto left_sc  = info.body_geo(geo_slots, l_gid);
+                    auto right_sc = info.body_geo(geo_slots, r_gid);
+
+                    UIPC_ASSERT(l_iid >= 0
+                                    && l_iid < static_cast<IndexT>(
+                                           left_sc->instances().size()),
+                                "AffineBodyDrivingRevoluteJoint: Left instance ID {} is out of range [0, {})",
+                                l_iid,
+                                left_sc->instances().size());
+                    UIPC_ASSERT(r_iid >= 0
+                                    && r_iid < static_cast<IndexT>(
+                                           right_sc->instances().size()),
+                                "AffineBodyDrivingRevoluteJoint: Right instance ID {} is out of range [0, {})",
+                                r_iid,
+                                right_sc->instances().size());
+
+                    Transform LT{left_sc->transforms().view()[l_iid]};
+                    Transform RT{right_sc->transforms().view()[r_iid]};
+
+                    Vector3 UnitE;
+                    if(use_local)
+                    {
+                        Vector3 lp0 = LT * l_pos0_attr->view()[i];
+                        Vector3 lp1 = LT * l_pos1_attr->view()[i];
+                        UnitE = (lp1 - lp0).normalized();
+                    }
+                    else
+                    {
+                        Vector3 P0  = Ps[e[0]];
+                        Vector3 P1  = Ps[e[1]];
+                        Vector3 mid = (P0 + P1) / 2;
+                        Vector3 Dir = (P1 - P0);
+
+                        UIPC_ASSERT(Dir.squaredNorm() > 1e-24,
+                                    R"(AffineBodyDrivingRevoluteJoint: Edge with zero length detected,
 Joint GeometryID = {},
 LinkGeoIDs       = ({}, {}),
 LinkInstIDs      = ({}, {}),
 Edge             = ({}, {}))",
-                                I.geo_info().geo_id,
-                                geo_id(0),
-                                geo_id(1),
-                                inst_id(0),
-                                inst_id(1),
-                                e(0),
-                                e(1));
+                                    I.geo_info().geo_id,
+                                    l_gid,
+                                    r_gid,
+                                    l_iid,
+                                    r_iid,
+                                    e(0),
+                                    e(1));
 
-                    Vector3 HalfAxis = Dir.normalized() / 2;
+                        Vector3 HalfAxis = Dir.normalized() / 2;
+                        P0 = mid - HalfAxis;
+                        P1 = mid + HalfAxis;
+                        UnitE = (P1 - P0).normalized();
+                    }
 
-                    // Re-define P0 and P1 to be symmetric around the mid-point
-                    P0 = mid - HalfAxis;
-                    P1 = mid + HalfAxis;
-
-                    Vector2i body_ids = {info.body_id(geo_id(0), inst_id(0)),
-                                         info.body_id(geo_id(1), inst_id(1))};
-                    body_ids_list.push_back(body_ids);
-
-                    auto left_sc  = info.body_geo(geo_slots, geo_id(0));
-                    auto right_sc = info.body_geo(geo_slots, geo_id(1));
-
-                    UIPC_ASSERT(inst_id(0) >= 0
-                                    && inst_id(0) < static_cast<IndexT>(
-                                           left_sc->instances().size()),
-                                "AffineBodyDrivingRevoluteJoint: Left instance ID {} is out of range [0, {})",
-                                inst_id(0),
-                                left_sc->instances().size());
-                    UIPC_ASSERT(inst_id(1) >= 0
-                                    && inst_id(1) < static_cast<IndexT>(
-                                           right_sc->instances().size()),
-                                "AffineBodyDrivingRevoluteJoint: Right instance ID {} is out of range [0, {})",
-                                inst_id(1),
-                                right_sc->instances().size());
-
-                    Vector3 UnitE = (P1 - P0).normalized();
-                    // normal
                     Vector3 normal = toNormal(UnitE);
                     Vector3 vec    = normal.cross(UnitE).normalized();
-
-                    Transform LT{left_sc->transforms().view()[inst_id(0)]};
-                    Transform RT{right_sc->transforms().view()[inst_id(1)]};
 
                     // axis
                     Vector6 rest_axis;

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint_limit.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint_limit.cu
@@ -104,13 +104,18 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
                 auto sc = geo.as<geometry::SimplicialComplex>();
                 UIPC_ASSERT(sc, "AffineBodyRevoluteJointLimit geometry must be SimplicialComplex");
 
-                auto geo_ids_attr = sc->edges().find<Vector2i>("geo_ids");
-                UIPC_ASSERT(geo_ids_attr, "AffineBodyRevoluteJointLimit requires `geo_ids` attribute on edges");
-                auto geo_ids = geo_ids_attr->view();
-
-                auto inst_ids_attr = sc->edges().find<Vector2i>("inst_ids");
-                UIPC_ASSERT(inst_ids_attr, "AffineBodyRevoluteJointLimit requires `inst_ids` attribute on edges");
-                auto inst_ids = inst_ids_attr->view();
+                auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+                UIPC_ASSERT(l_geo_id, "AffineBodyRevoluteJointLimit requires `l_geo_id` attribute on edges");
+                auto l_geo_id_view = l_geo_id->view();
+                auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+                UIPC_ASSERT(r_geo_id, "AffineBodyRevoluteJointLimit requires `r_geo_id` attribute on edges");
+                auto r_geo_id_view = r_geo_id->view();
+                auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+                UIPC_ASSERT(l_inst_id, "AffineBodyRevoluteJointLimit requires `l_inst_id` attribute on edges");
+                auto l_inst_id_view = l_inst_id->view();
+                auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+                UIPC_ASSERT(r_inst_id, "AffineBodyRevoluteJointLimit requires `r_inst_id` attribute on edges");
+                auto r_inst_id_view = r_inst_id->view();
 
                 auto lower_attr = sc->edges().find<Float>("limit/lower");
                 UIPC_ASSERT(lower_attr, "AffineBodyRevoluteJointLimit requires `limit/lower` attribute on edges");
@@ -129,40 +134,70 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
                 auto init_angle_view = init_angle_attr->view();
 
                 auto edges = sc->edges().topo().view();
+
+                auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+                auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+                auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+                auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+                bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
+
                 for(auto&& [i, e] : enumerate(edges))
                 {
-                    Vector2i geo_id  = geo_ids[i];
-                    Vector2i inst_id = inst_ids[i];
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    auto* left_sc  = info.body_geo(geo_slots, geo_id[0]);
-                    auto* right_sc = info.body_geo(geo_slots, geo_id[1]);
+                    auto* left_sc  = info.body_geo(geo_slots, l_gid);
+                    auto* right_sc = info.body_geo(geo_slots, r_gid);
 
-                    UIPC_ASSERT(inst_id[0] >= 0
-                                    && inst_id[0] < static_cast<IndexT>(
+                    UIPC_ASSERT(l_iid >= 0
+                                    && l_iid < static_cast<IndexT>(
                                            left_sc->instances().size()),
                                 "AffineBodyRevoluteJointLimit: left instance ID {} out of range [0, {})",
-                                inst_id[0],
+                                l_iid,
                                 left_sc->instances().size());
-                    UIPC_ASSERT(inst_id[1] >= 0
-                                    && inst_id[1] < static_cast<IndexT>(
+                    UIPC_ASSERT(r_iid >= 0
+                                    && r_iid < static_cast<IndexT>(
                                            right_sc->instances().size()),
                                 "AffineBodyRevoluteJointLimit: right instance ID {} out of range [0, {})",
-                                inst_id[1],
+                                r_iid,
                                 right_sc->instances().size());
 
                     Vector2i bid = {
-                        info.body_id(geo_id[0], inst_id[0]),
-                        info.body_id(geo_id[1], inst_id[1]),
+                        info.body_id(l_gid, l_iid),
+                        info.body_id(r_gid, r_iid),
                     };
 
-                    auto [lb, rb] = get_revolute_basis(
-                        left_sc, inst_id[0], right_sc, inst_id[1], sc, i);
+                    Vector6 lb, rb;
+                    if(use_local)
+                    {
+                        Transform LT{left_sc->transforms().view()[l_iid]};
+                        Transform RT{right_sc->transforms().view()[r_iid]};
+                        Vector3 t = LT.rotation() * (l_pos1_attr->view()[i] - l_pos0_attr->view()[i]);
+                        UIPC_ASSERT(t.squaredNorm() > 0.0,
+                                    "AffineBodyRevoluteJointLimit: local attribute edge has zero length at index {}",
+                                    i);
+                        Vector3 n, b_vec;
+                        orthonormal_basis(t, n, b_vec);
+                        Matrix3x3 L_inv_rot = LT.rotation().inverse();
+                        Matrix3x3 R_inv_rot = RT.rotation().inverse();
+                        lb.segment<3>(0) = L_inv_rot * b_vec;
+                        lb.segment<3>(3) = L_inv_rot * n;
+                        rb.segment<3>(0) = R_inv_rot * b_vec;
+                        rb.segment<3>(3) = R_inv_rot * n;
+                    }
+                    else
+                    {
+                        std::tie(lb, rb) = get_revolute_basis(
+                            left_sc, l_iid, right_sc, r_iid, sc, i);
+                    }
 
                     Vector24 ref;
                     ref.segment<12>(0) =
-                        transform_to_q(left_sc->transforms().view()[inst_id[0]]);
+                        transform_to_q(left_sc->transforms().view()[l_iid]);
                     ref.segment<12>(12) =
-                        transform_to_q(right_sc->transforms().view()[inst_id[1]]);
+                        transform_to_q(right_sc->transforms().view()[r_iid]);
 
                     h_body_ids.push_back(bid);
                     h_l_basis.push_back(lb);

--- a/src/backends/cuda/affine_body/constitutions/affine_body_spherical_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_spherical_joint.cu
@@ -3,7 +3,6 @@
 #include <uipc/builtin/attribute_name.h>
 #include <utils/make_spd.h>
 #include <utils/matrix_assembler.h>
-#include <uipc/common/enumerate.h>
 
 namespace uipc::backend::cuda
 {
@@ -46,33 +45,50 @@ class AffineBodySphericalJoint final : public InterAffineBodyConstitution
             {
                 auto sc = geo.as<geometry::SimplicialComplex>();
 
-                auto geo_ids_view = sc->edges().find<Vector2i>("geo_ids")->view();
-                auto inst_ids_view = sc->edges().find<Vector2i>("inst_ids")->view();
+                auto l_geo_id = sc->vertices().find<IndexT>("l_geo_id");
+                auto l_geo_id_view = l_geo_id->view();
+                auto r_geo_id = sc->vertices().find<IndexT>("r_geo_id");
+                auto r_geo_id_view = r_geo_id->view();
+                auto l_inst_id = sc->vertices().find<IndexT>("l_inst_id");
+                auto l_inst_id_view = l_inst_id->view();
+                auto r_inst_id = sc->vertices().find<IndexT>("r_inst_id");
+                auto r_inst_id_view = r_inst_id->view();
                 auto strength_ratio_view =
-                    sc->edges().find<Float>("strength_ratio")->view();
+                    sc->vertices().find<Float>("strength_ratio")->view();
 
-                auto Es = sc->edges().topo().view();
+                auto pos0_attr = sc->vertices().find<Vector3>("l_position");
+                auto pos1_attr = sc->vertices().find<Vector3>("r_position");
+                const bool use_local_positions = pos0_attr && pos1_attr;
+
                 auto Ps = sc->positions().view();
-                for(auto&& [i, e] : enumerate(Es))
+                const SizeT n_joints = sc->vertices().size();
+                for(SizeT i = 0; i < n_joints; ++i)
                 {
-                    Vector2i geo_id  = geo_ids_view[i];
-                    Vector2i inst_id = inst_ids_view[i];
+                    IndexT l_gid = l_geo_id_view[i];
+                    IndexT r_gid = r_geo_id_view[i];
+                    IndexT l_iid = l_inst_id_view[i];
+                    IndexT r_iid = r_inst_id_view[i];
 
-                    body_ids_list.push_back({info.body_id(geo_id(0), inst_id(0)),
-                                             info.body_id(geo_id(1), inst_id(1))});
+                    body_ids_list.push_back({info.body_id(l_gid, l_iid),
+                                             info.body_id(r_gid, r_iid)});
 
                     Transform LT{
-                        info.body_geo(geo_slots, geo_id(0))->transforms().view()[inst_id(0)]};
+                        info.body_geo(geo_slots, l_gid)->transforms().view()[l_iid]};
                     Transform RT{
-                        info.body_geo(geo_slots, geo_id(1))->transforms().view()[inst_id(1)]};
-
-                    // Ps[e[1]] is the anchor in world space (body1's attachment point,
-                    // set as RT * r_local_pos in apply_to). Express it in each body's local frame.
-                    Vector3 anchor = Ps[e[1]];
+                        info.body_geo(geo_slots, r_gid)->transforms().view()[r_iid]};
 
                     Vector6 rest_c;
-                    rest_c.segment<3>(0) = LT.inverse() * anchor;
-                    rest_c.segment<3>(3) = RT.inverse() * anchor;
+                    if(use_local_positions)
+                    {
+                        rest_c.segment<3>(0) = pos0_attr->view()[i];
+                        rest_c.segment<3>(3) = pos1_attr->view()[i];
+                    }
+                    else
+                    {
+                        Vector3 anchor = Ps[i];
+                        rest_c.segment<3>(0) = LT.inverse() * anchor;
+                        rest_c.segment<3>(3) = RT.inverse() * anchor;
+                    }
                     rest_c_list.push_back(rest_c);
                 }
 

--- a/src/backends/cuda/affine_body/constraints/affine_body_prismatic_joint_external_force_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/affine_body_prismatic_joint_external_force_constraint.cu
@@ -49,13 +49,18 @@ static void collect_prismatic_data(InterAffineBodyAnimator::FilteredInfo& info,
             auto sc = geo.as<geometry::SimplicialComplex>();
             UIPC_ASSERT(sc, "AffineBodyPrismaticJointExternalForceConstraint: geometry must be SimplicialComplex");
 
-            auto geo_ids = sc->edges().find<Vector2i>("geo_ids");
-            UIPC_ASSERT(geo_ids, "AffineBodyPrismaticJointExternalForceConstraint: Geometry must have 'geo_ids' attribute on `edges`");
-            auto geo_ids_view = geo_ids->view();
-
-            auto inst_ids = sc->edges().find<Vector2i>("inst_ids");
-            UIPC_ASSERT(inst_ids, "AffineBodyPrismaticJointExternalForceConstraint: Geometry must have 'inst_ids' attribute on `edges`");
-            auto inst_ids_view = inst_ids->view();
+            auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+            UIPC_ASSERT(l_geo_id, "AffineBodyPrismaticJointExternalForceConstraint: Geometry must have 'l_geo_id' attribute on `edges`");
+            auto l_geo_id_view = l_geo_id->view();
+            auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+            UIPC_ASSERT(r_geo_id, "AffineBodyPrismaticJointExternalForceConstraint: Geometry must have 'r_geo_id' attribute on `edges`");
+            auto r_geo_id_view = r_geo_id->view();
+            auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+            UIPC_ASSERT(l_inst_id, "AffineBodyPrismaticJointExternalForceConstraint: Geometry must have 'l_inst_id' attribute on `edges`");
+            auto l_inst_id_view = l_inst_id->view();
+            auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+            UIPC_ASSERT(r_inst_id, "AffineBodyPrismaticJointExternalForceConstraint: Geometry must have 'r_inst_id' attribute on `edges`");
+            auto r_inst_id_view = r_inst_id->view();
 
             auto is_constrained = sc->edges().find<IndexT>("external_force/is_constrained");
             UIPC_ASSERT(is_constrained, "AffineBodyPrismaticJointExternalForceConstraint: Geometry must have 'external_force/is_constrained' attribute on `edges`");
@@ -70,35 +75,55 @@ static void collect_prismatic_data(InterAffineBodyAnimator::FilteredInfo& info,
             auto Es = sc->edges().topo().view();
             auto Ps = sc->positions().view();
 
+            auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+            auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+            auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+            auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+            bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
+
             for(auto&& [i, e] : enumerate(Es))
             {
                 h_is_constrained.push_back(is_constrained_view[i]);
 
-                Vector2i geo_id  = geo_ids_view[i];
-                Vector2i inst_id = inst_ids_view[i];
+                IndexT l_gid = l_geo_id_view[i];
+                IndexT r_gid = r_geo_id_view[i];
+                IndexT l_iid = l_inst_id_view[i];
+                IndexT r_iid = r_inst_id_view[i];
 
-                Vector2i body_ids = {info.body_id(geo_id(0), inst_id(0)),
-                                     info.body_id(geo_id(1), inst_id(1))};
+                Vector2i body_ids = {info.body_id(l_gid, l_iid),
+                                     info.body_id(r_gid, r_iid)};
                 h_body_ids.push_back(body_ids);
 
-                auto left_sc  = info.body_geo(geo_slots, geo_id(0));
-                auto right_sc = info.body_geo(geo_slots, geo_id(1));
+                auto left_sc  = info.body_geo(geo_slots, l_gid);
+                auto right_sc = info.body_geo(geo_slots, r_gid);
 
-                Vector3 P0      = Ps[e[0]];
-                Vector3 P1      = Ps[e[1]];
-                Vector3 tangent = (P1 - P0).normalized();
+                Transform LT{left_sc->transforms().view()[l_iid]};
+                Transform RT{right_sc->transforms().view()[r_iid]};
 
-                Transform LT{left_sc->transforms().view()[inst_id(0)]};
-                Transform RT{right_sc->transforms().view()[inst_id(1)]};
+                Vector3 tangent;
+                Vector6 rest_position;
+                if(use_local)
+                {
+                    Vector3 lp0 = LT * l_pos0_attr->view()[i];
+                    Vector3 lp1 = LT * l_pos1_attr->view()[i];
+                    tangent = (lp1 - lp0).normalized();
+                    rest_position.segment<3>(0) = l_pos0_attr->view()[i];
+                    rest_position.segment<3>(3) = r_pos0_attr->view()[i];
+                }
+                else
+                {
+                    Vector3 P0      = Ps[e[0]];
+                    Vector3 P1      = Ps[e[1]];
+                    tangent = (P1 - P0).normalized();
+                    rest_position.segment<3>(0) = LT.inverse() * P0;
+                    rest_position.segment<3>(3) = RT.inverse() * P0;
+                }
 
                 Vector6 rest_tangent;
                 rest_tangent.segment<3>(0) = LT.rotation().inverse() * tangent;
                 rest_tangent.segment<3>(3) = RT.rotation().inverse() * tangent;
                 h_rest_tangents.push_back(rest_tangent);
 
-                Vector6 rest_position;
-                rest_position.segment<3>(0) = LT.inverse() * P0;
-                rest_position.segment<3>(3) = RT.inverse() * P0;
                 h_rest_positions.push_back(rest_position);
 
                 h_forces.push_back(external_force_view[i]);

--- a/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_force_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/affine_body_revolute_joint_external_force_constraint.cu
@@ -38,13 +38,18 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
             auto sc = geo.as<geometry::SimplicialComplex>();
             UIPC_ASSERT(sc, "AffineBodyRevoluteJointExternalForceConstraint: geometry must be SimplicialComplex");
 
-            auto geo_ids = sc->edges().find<Vector2i>("geo_ids");
-            UIPC_ASSERT(geo_ids, "AffineBodyRevoluteJointExternalForceConstraint: Geometry must have 'geo_ids' attribute on `edges`");
-            auto geo_ids_view = geo_ids->view();
-
-            auto inst_ids = sc->edges().find<Vector2i>("inst_ids");
-            UIPC_ASSERT(inst_ids, "AffineBodyRevoluteJointExternalForceConstraint: Geometry must have 'inst_ids' attribute on `edges`");
-            auto inst_ids_view = inst_ids->view();
+            auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
+            UIPC_ASSERT(l_geo_id, "AffineBodyRevoluteJointExternalForceConstraint: Geometry must have 'l_geo_id' attribute on `edges`");
+            auto l_geo_id_view = l_geo_id->view();
+            auto r_geo_id = sc->edges().find<IndexT>("r_geo_id");
+            UIPC_ASSERT(r_geo_id, "AffineBodyRevoluteJointExternalForceConstraint: Geometry must have 'r_geo_id' attribute on `edges`");
+            auto r_geo_id_view = r_geo_id->view();
+            auto l_inst_id = sc->edges().find<IndexT>("l_inst_id");
+            UIPC_ASSERT(l_inst_id, "AffineBodyRevoluteJointExternalForceConstraint: Geometry must have 'l_inst_id' attribute on `edges`");
+            auto l_inst_id_view = l_inst_id->view();
+            auto r_inst_id = sc->edges().find<IndexT>("r_inst_id");
+            UIPC_ASSERT(r_inst_id, "AffineBodyRevoluteJointExternalForceConstraint: Geometry must have 'r_inst_id' attribute on `edges`");
+            auto r_inst_id_view = r_inst_id->view();
 
             auto is_constrained = sc->edges().find<IndexT>("external_torque/is_constrained");
             UIPC_ASSERT(is_constrained, "AffineBodyRevoluteJointExternalForceConstraint: Geometry must have 'external_torque/is_constrained' attribute on `edges`");
@@ -58,6 +63,12 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
 
             auto Es = sc->edges().topo().view();
             auto Ps = sc->positions().view();
+
+            auto l_pos0_attr = sc->edges().find<Vector3>("l_position0");
+            auto l_pos1_attr = sc->edges().find<Vector3>("l_position1");
+            auto r_pos0_attr = sc->edges().find<Vector3>("r_position0");
+            auto r_pos1_attr = sc->edges().find<Vector3>("r_position1");
+            bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
 
             auto toNormal = [&](const Vector3& W) -> Vector3
             {
@@ -75,44 +86,58 @@ static void collect_joint_data(InterAffineBodyAnimator::FilteredInfo& info,
             {
                 h_is_constrained.push_back(is_constrained_view[i]);
 
-                Vector2i geo_id  = geo_ids_view[i];
-                Vector2i inst_id = inst_ids_view[i];
+                IndexT l_gid = l_geo_id_view[i];
+                IndexT r_gid = r_geo_id_view[i];
+                IndexT l_iid = l_inst_id_view[i];
+                IndexT r_iid = r_inst_id_view[i];
 
-                Vector2i body_ids = {info.body_id(geo_id(0), inst_id(0)),
-                                     info.body_id(geo_id(1), inst_id(1))};
+                Vector2i body_ids = {info.body_id(l_gid, l_iid),
+                                     info.body_id(r_gid, r_iid)};
                 h_body_ids.push_back(body_ids);
 
-                auto left_sc  = info.body_geo(geo_slots, geo_id(0));
-                auto right_sc = info.body_geo(geo_slots, geo_id(1));
+                auto left_sc  = info.body_geo(geo_slots, l_gid);
+                auto right_sc = info.body_geo(geo_slots, r_gid);
 
-                Vector3 P0  = Ps[e[0]];
-                Vector3 P1  = Ps[e[1]];
-                Vector3 mid = (P0 + P1) / 2;
-                Vector3 Dir = (P1 - P0);
+                Transform LT{left_sc->transforms().view()[l_iid]};
+                Transform RT{right_sc->transforms().view()[r_iid]};
 
-                UIPC_ASSERT(Dir.squaredNorm() > 1e-24,
-                            "AffineBodyRevoluteJointExternalForceConstraint: Edge with zero length detected");
+                Vector3  UnitE;
+                Vector12 rest_pos;
+                if(use_local)
+                {
+                    Vector3 lp0 = LT * l_pos0_attr->view()[i];
+                    Vector3 lp1 = LT * l_pos1_attr->view()[i];
+                    UnitE = (lp1 - lp0).normalized();
 
-                Vector3 HalfAxis = Dir.normalized() / 2;
-                P0               = mid - HalfAxis;
-                P1               = mid + HalfAxis;
+                    rest_pos.segment<3>(0) = l_pos0_attr->view()[i];
+                    rest_pos.segment<3>(3) = l_pos1_attr->view()[i];
+                    rest_pos.segment<3>(6) = r_pos0_attr->view()[i];
+                    rest_pos.segment<3>(9) = r_pos1_attr->view()[i];
+                }
+                else
+                {
+                    Vector3 P0  = Ps[e[0]];
+                    Vector3 P1  = Ps[e[1]];
+                    Vector3 mid = (P0 + P1) / 2;
+                    Vector3 Dir = (P1 - P0);
 
+                    UIPC_ASSERT(Dir.squaredNorm() > 1e-24,
+                                "AffineBodyRevoluteJointExternalForceConstraint: Edge with zero length detected");
 
-                Vector3 UnitE = (P1 - P0).normalized();
-                // normal
+                    Vector3 HalfAxis = Dir.normalized() / 2;
+                    P0               = mid - HalfAxis;
+                    P1               = mid + HalfAxis;
+                    UnitE            = (P1 - P0).normalized();
+
+                    rest_pos.segment<3>(0) = LT.inverse() * P0;
+                    rest_pos.segment<3>(3) = LT.inverse() * P1;
+                    rest_pos.segment<3>(6) = RT.inverse() * P0;
+                    rest_pos.segment<3>(9) = RT.inverse() * P1;
+                }
+                h_rest_positions.push_back(rest_pos);
+
                 Vector3 normal = toNormal(UnitE);
                 Vector3 vec    = normal.cross(UnitE).normalized();
-
-
-                Transform LT{left_sc->transforms().view()[inst_id(0)]};
-                Transform RT{right_sc->transforms().view()[inst_id(1)]};
-
-                Vector12 rest_pos;
-                rest_pos.segment<3>(0) = LT.inverse() * P0;
-                rest_pos.segment<3>(3) = LT.inverse() * P1;
-                rest_pos.segment<3>(6) = RT.inverse() * P0;
-                rest_pos.segment<3>(9) = RT.inverse() * P1;
-                h_rest_positions.push_back(rest_pos);
 
                 Vector6 rest_axis;
                 rest_axis.segment<3>(0) = LT.rotation().inverse() * vec;

--- a/src/backends/cuda/affine_body/constraints/external_articulation_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/external_articulation_constraint.cu
@@ -260,34 +260,86 @@ class ExternalArticulationConstraint final : public InterAffineBodyConstraint
         h_joint_id_to_uid.push_back(uid_value);
 
         // 1. Get Joint's two Links
-        auto joint_geo_ids  = joint_mesh->edges().find<Vector2i>("geo_ids");
-        auto joint_inst_ids = joint_mesh->edges().find<Vector2i>("inst_ids");
-        auto joint_geo_ids_view  = joint_geo_ids->view();
-        auto joint_inst_ids_view = joint_inst_ids->view();
+        auto joint_l_geo_id = joint_mesh->edges().find<IndexT>("l_geo_id");
+        UIPC_ASSERT(joint_l_geo_id,
+                    "ExternalArticulationConstraint: Joint geometry must have 'l_geo_id' attribute on `edges`");
+        auto joint_r_geo_id = joint_mesh->edges().find<IndexT>("r_geo_id");
+        UIPC_ASSERT(joint_r_geo_id,
+                    "ExternalArticulationConstraint: Joint geometry must have 'r_geo_id' attribute on `edges`");
+        auto joint_l_inst_id = joint_mesh->edges().find<IndexT>("l_inst_id");
+        UIPC_ASSERT(joint_l_inst_id,
+                    "ExternalArticulationConstraint: Joint geometry must have 'l_inst_id' attribute on `edges`");
+        auto joint_r_inst_id = joint_mesh->edges().find<IndexT>("r_inst_id");
+        UIPC_ASSERT(joint_r_inst_id,
+                    "ExternalArticulationConstraint: Joint geometry must have 'r_inst_id' attribute on `edges`");
+        auto joint_l_geo_id_view  = joint_l_geo_id->view();
+        auto joint_r_geo_id_view  = joint_r_geo_id->view();
+        auto joint_l_inst_id_view = joint_l_inst_id->view();
+        auto joint_r_inst_id_view = joint_r_inst_id->view();
 
-        const Vector2i geo_id  = joint_geo_ids_view[index];
-        const Vector2i inst_id = joint_inst_ids_view[index];
+        const IndexT l_gid = joint_l_geo_id_view[index];
+        const IndexT r_gid = joint_r_geo_id_view[index];
+        const IndexT l_iid = joint_l_inst_id_view[index];
+        const IndexT r_iid = joint_r_inst_id_view[index];
 
         Vector2i body_id = {
-            info.body_id(geo_id[0], inst_id[0]),
-            info.body_id(geo_id[1], inst_id[1]),
+            info.body_id(l_gid, l_iid),
+            info.body_id(r_gid, r_iid),
         };
         h_joint_id_to_body_ids.push_back(body_id);
 
-        auto L_link_geo = info.body_geo(geo_slots, geo_id[0]);
-        auto R_link_geo = info.body_geo(geo_slots, geo_id[1]);
+        auto L_link_geo = info.body_geo(geo_slots, l_gid);
+        auto R_link_geo = info.body_geo(geo_slots, r_gid);
+
+        auto l_pos0_attr = joint_mesh->edges().find<Vector3>("l_position0");
+        auto l_pos1_attr = joint_mesh->edges().find<Vector3>("l_position1");
+        auto r_pos0_attr = joint_mesh->edges().find<Vector3>("r_position0");
+        auto r_pos1_attr = joint_mesh->edges().find<Vector3>("r_position1");
+        bool use_local = l_pos0_attr && l_pos1_attr && r_pos0_attr && r_pos1_attr;
 
         Vector6 L_basis, R_basis;
 
-        if(uid_value == ExternalArticulationConstituion::RevoluteJointConstitutionUID)
+        if(use_local)
         {
-            std::tie(L_basis, R_basis) = get_revolute_basis(
-                L_link_geo, inst_id[0], R_link_geo, inst_id[1], joint_mesh, index);
+            Transform LT{L_link_geo->transforms().view()[l_iid]};
+            Transform RT{R_link_geo->transforms().view()[r_iid]};
+
+            if(uid_value == ExternalArticulationConstituion::RevoluteJointConstitutionUID)
+            {
+                Vector3 t = LT.rotation() * (l_pos1_attr->view()[index] - l_pos0_attr->view()[index]);
+                Vector3 n, b_vec;
+                orthonormal_basis(t, n, b_vec);
+                Matrix3x3 L_inv_rot = LT.rotation().inverse();
+                Matrix3x3 R_inv_rot = RT.rotation().inverse();
+                L_basis.segment<3>(0) = L_inv_rot * b_vec;
+                L_basis.segment<3>(3) = L_inv_rot * n;
+                R_basis.segment<3>(0) = R_inv_rot * b_vec;
+                R_basis.segment<3>(3) = R_inv_rot * n;
+            }
+            else if(uid_value == ExternalArticulationConstituion::PrismaticJointConstitutionUID)
+            {
+                Vector3 l_t = (LT.rotation() * (l_pos1_attr->view()[index] - l_pos0_attr->view()[index])).normalized();
+                Vector3 l_c = LT * l_pos0_attr->view()[index];
+                Vector3 r_t = (RT.rotation() * (r_pos1_attr->view()[index] - r_pos0_attr->view()[index])).normalized();
+                Vector3 r_c = RT * r_pos0_attr->view()[index];
+                L_basis.segment<3>(0) = LT.inverse() * l_c;
+                L_basis.segment<3>(3) = LT.rotation().inverse() * l_t;
+                R_basis.segment<3>(0) = RT.inverse() * r_c;
+                R_basis.segment<3>(3) = RT.rotation().inverse() * r_t;
+            }
         }
-        else if(uid_value == ExternalArticulationConstituion::PrismaticJointConstitutionUID)
+        else
         {
-            std::tie(L_basis, R_basis) = get_prismatic_basis(
-                L_link_geo, inst_id[0], R_link_geo, inst_id[1], joint_mesh, index);
+            if(uid_value == ExternalArticulationConstituion::RevoluteJointConstitutionUID)
+            {
+                std::tie(L_basis, R_basis) = get_revolute_basis(
+                    L_link_geo, l_iid, R_link_geo, r_iid, joint_mesh, index);
+            }
+            else if(uid_value == ExternalArticulationConstituion::PrismaticJointConstitutionUID)
+            {
+                std::tie(L_basis, R_basis) = get_prismatic_basis(
+                    L_link_geo, l_iid, R_link_geo, r_iid, joint_mesh, index);
+            }
         }
 
         h_joint_id_to_L_basis.push_back(L_basis);
@@ -295,8 +347,8 @@ class ExternalArticulationConstraint final : public InterAffineBodyConstraint
 
         // 2. Get Joint's 2 ref_q_prev (if any)
         Vector2i ref_q_prev_ids = {
-            get_ref_q_prev(L_link_geo, inst_id[0], body_id[0]),
-            get_ref_q_prev(R_link_geo, inst_id[1], body_id[1]),
+            get_ref_q_prev(L_link_geo, l_iid, body_id[0]),
+            get_ref_q_prev(R_link_geo, r_iid, body_id[1]),
         };
 
         h_joint_id_to_ref_q_prev_ids.push_back(ref_q_prev_ids);

--- a/src/backends/cuda/contact_system/contact_models/ipc_simplex_frictional_contact.cu
+++ b/src/backends/cuda/contact_system/contact_models/ipc_simplex_frictional_contact.cu
@@ -324,7 +324,7 @@ class IPCSimplexFrictionalContact final : public SimplexFrictionalContact
                    {
                        if(idx < ee_offset)
                        {
-                           // ── PT friction ──
+                           // PT friction
                            int i = idx;
                            const auto& PT = PTs(i);
                            Vector4i cids = {contact_ids(PT[0]), contact_ids(PT[1]),
@@ -371,7 +371,7 @@ class IPCSimplexFrictionalContact final : public SimplexFrictionalContact
                        }
                        else if(idx < pe_offset)
                        {
-                           // ── EE friction ──
+                           // EE friction
                            int i = idx - ee_offset;
                            const auto& EE = EEs(i);
                            Vector4i cids = {contact_ids(EE[0]), contact_ids(EE[1]),
@@ -438,7 +438,7 @@ class IPCSimplexFrictionalContact final : public SimplexFrictionalContact
                        }
                        else if(idx < pp_offset)
                        {
-                           // ── PE friction ──
+                           // PE friction
                            int i = idx - pe_offset;
                            const auto& PE = PEs(i);
                            Vector3i cids = {contact_ids(PE[0]), contact_ids(PE[1]), contact_ids(PE[2])};
@@ -478,7 +478,7 @@ class IPCSimplexFrictionalContact final : public SimplexFrictionalContact
                        }
                        else
                        {
-                           // ── PP friction ──
+                           // PP friction
                            int i = idx - pp_offset;
                            const auto& PP = PPs(i);
                            Vector2i cids = {contact_ids(PP[0]), contact_ids(PP[1])};

--- a/src/constitution/affine_body_fixed_joint.cpp
+++ b/src/constitution/affine_body_fixed_joint.cpp
@@ -31,6 +31,75 @@ AffineBodyFixedJoint::AffineBodyFixedJoint(const Json& config)
 
 AffineBodyFixedJoint::~AffineBodyFixedJoint() = default;
 
+geometry::SimplicialComplex AffineBodyFixedJoint::create_geometry(
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = l_geo_slots.size();
+    UIPC_ASSERT(N == r_geo_slots.size(),
+                "l_geo_slots({}) vs r_geo_slots({}) size mismatch",
+                N,
+                r_geo_slots.size());
+    UIPC_ASSERT(N == l_instance_ids.size(),
+                "l_geo_slots({}) vs l_instance_ids({}) size mismatch",
+                N,
+                l_instance_ids.size());
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(N);
+    auto pos_view = view(sc.positions());
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        auto l_sc = l_geo_slots[i]->geometry().as<geometry::SimplicialComplex>();
+        auto r_sc = r_geo_slots[i]->geometry().as<geometry::SimplicialComplex>();
+
+        Transform LT{l_sc->transforms().view()[l_instance_ids[i]]};
+        Transform RT{r_sc->transforms().view()[r_instance_ids[i]]};
+
+        pos_view[i] = (LT.translation() + RT.translation()) * 0.5;
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
+
+geometry::SimplicialComplex AffineBodyFixedJoint::create_geometry(
+    span<const Vector3>                      l_positions,
+    span<const Vector3>                      r_positions,
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = l_positions.size();
+    UIPC_ASSERT(N == r_positions.size(),
+                "l_positions({}) vs r_positions({}) size mismatch",
+                N,
+                r_positions.size());
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(N);
+
+    auto pos0_attr = sc.vertices().create<Vector3>("l_position", Vector3::Zero());
+    auto pos1_attr = sc.vertices().create<Vector3>("r_position", Vector3::Zero());
+    auto pos0_view = view(*pos0_attr);
+    auto pos1_view = view(*pos1_attr);
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        pos0_view[i] = l_positions[i];
+        pos1_view[i] = r_positions[i];
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
+
 void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
                                     span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
                                     span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
@@ -56,50 +125,28 @@ void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
 
 void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
                                     span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
-                                    span<IndexT> l_instance_id,
+                                    span<IndexT> l_instance_ids,
                                     span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                                    span<IndexT> r_instance_id,
-                                    span<Float>  strength_ratio)
+                                    span<IndexT> r_instance_ids,
+                                    span<Float>  strength_ratios)
 {
     auto size = l_geo_slots.size();
     UIPC_ASSERT(size == r_geo_slots.size(),
                 "Size mismatch: l_geo_slots({}) vs r_geo_slots({})",
                 l_geo_slots.size(),
                 r_geo_slots.size());
-    UIPC_ASSERT(size == l_instance_id.size(),
-                "Size mismatch: l_geo_slots({}) vs l_instance_id({})",
+    UIPC_ASSERT(size == l_instance_ids.size(),
+                "Size mismatch: l_geo_slots({}) vs l_instance_ids({})",
                 l_geo_slots.size(),
-                l_instance_id.size());
-    UIPC_ASSERT(size == r_instance_id.size(),
-                "Size mismatch: r_geo_slots({}) vs r_instance_id({})",
+                l_instance_ids.size());
+    UIPC_ASSERT(size == r_instance_ids.size(),
+                "Size mismatch: r_geo_slots({}) vs r_instance_ids({})",
                 r_geo_slots.size(),
-                r_instance_id.size());
-    UIPC_ASSERT(size == strength_ratio.size(),
-                "Size mismatch: l_geo_slots({}) vs strength_ratio({})",
+                r_instance_ids.size());
+    UIPC_ASSERT(size == strength_ratios.size(),
+                "Size mismatch: l_geo_slots({}) vs strength_ratios({})",
                 l_geo_slots.size(),
-                strength_ratio.size());
-
-    // Build vertices: 2 per joint (body world positions)
-    sc.vertices().resize(2 * size);
-    auto pos_view = view(sc.positions());
-
-    // Build edges: 1 per joint
-    sc.edges().resize(size);
-    auto topo = sc.edges().create<Vector2i>(builtin::topo, Vector2i::Zero(), false);
-    auto topo_view = view(*topo);
-
-    for(SizeT i = 0; i < size; ++i)
-    {
-        auto l_sc = l_geo_slots[i]->geometry().as<geometry::SimplicialComplex>();
-        auto r_sc = r_geo_slots[i]->geometry().as<geometry::SimplicialComplex>();
-
-        Transform LT{l_sc->transforms().view()[l_instance_id[i]]};
-        Transform RT{r_sc->transforms().view()[r_instance_id[i]]};
-
-        pos_view[2 * i + 0] = LT.translation();
-        pos_view[2 * i + 1] = RT.translation();
-        topo_view[i] = Vector2i{static_cast<int>(2 * i), static_cast<int>(2 * i + 1)};
-    }
+                strength_ratios.size());
 
     auto uid = sc.meta().find<U64>(builtin::constitution_uid);
     if(!uid)
@@ -108,33 +155,39 @@ void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
     }
     view(*uid)[0] = this->uid();
 
-    auto geo_ids = sc.edges().find<Vector2i>("geo_ids");
-    if(!geo_ids)
-    {
-        geo_ids = sc.edges().create<Vector2i>("geo_ids", Vector2i{-1, -1});
-    }
-    auto geo_ids_view = view(*geo_ids);
+    auto l_geo_id_attr = sc.vertices().find<IndexT>("l_geo_id");
+    if(!l_geo_id_attr)
+        l_geo_id_attr = sc.vertices().create<IndexT>("l_geo_id", IndexT{-1});
+    auto l_geo_id_view = view(*l_geo_id_attr);
 
-    auto inst_ids = sc.edges().find<Vector2i>("inst_ids");
-    if(!inst_ids)
-    {
-        inst_ids = sc.edges().create<Vector2i>("inst_ids", Vector2i{-1, -1});
-    }
-    auto inst_ids_view = view(*inst_ids);
+    auto r_geo_id_attr = sc.vertices().find<IndexT>("r_geo_id");
+    if(!r_geo_id_attr)
+        r_geo_id_attr = sc.vertices().create<IndexT>("r_geo_id", IndexT{-1});
+    auto r_geo_id_view = view(*r_geo_id_attr);
 
-    auto strength_ratio_attr = sc.edges().find<Float>("strength_ratio");
+    auto l_inst_id_attr = sc.vertices().find<IndexT>("l_inst_id");
+    if(!l_inst_id_attr)
+        l_inst_id_attr = sc.vertices().create<IndexT>("l_inst_id", IndexT{-1});
+    auto l_inst_id_view = view(*l_inst_id_attr);
+
+    auto r_inst_id_attr = sc.vertices().find<IndexT>("r_inst_id");
+    if(!r_inst_id_attr)
+        r_inst_id_attr = sc.vertices().create<IndexT>("r_inst_id", IndexT{-1});
+    auto r_inst_id_view = view(*r_inst_id_attr);
+
+    auto strength_ratio_attr = sc.vertices().find<Float>("strength_ratio");
     if(!strength_ratio_attr)
     {
-        strength_ratio_attr = sc.edges().create<Float>("strength_ratio", 0.0);
+        strength_ratio_attr = sc.vertices().create<Float>("strength_ratio", 0.0);
     }
     auto strength_ratio_view = view(*strength_ratio_attr);
-    std::ranges::copy(strength_ratio, strength_ratio_view.begin());
+    std::ranges::copy(strength_ratios, strength_ratio_view.begin());
 
     for(auto&& [i, l_slot] : enumerate(l_geo_slots))
     {
         auto r_slot = r_geo_slots[i];
-        auto l_inst = l_instance_id[i];
-        auto r_inst = r_instance_id[i];
+        auto l_inst = l_instance_ids[i];
+        auto r_inst = r_instance_ids[i];
 
         UIPC_ASSERT(l_inst >= 0
                         && l_inst < static_cast<IndexT>(
@@ -149,8 +202,10 @@ void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
                     r_inst,
                     r_slot->geometry().instances().size());
 
-        geo_ids_view[i]  = Vector2i{l_slot->id(), r_slot->id()};
-        inst_ids_view[i] = Vector2i{l_inst, r_inst};
+        l_geo_id_view[i]  = l_slot->id();
+        r_geo_id_view[i]  = r_slot->id();
+        l_inst_id_view[i] = l_inst;
+        r_inst_id_view[i] = r_inst;
     }
 }
 

--- a/src/constitution/affine_body_prismatic_joint.cpp
+++ b/src/constitution/affine_body_prismatic_joint.cpp
@@ -31,6 +31,93 @@ AffineBodyPrismaticJoint::AffineBodyPrismaticJoint(const Json& config)
 
 AffineBodyPrismaticJoint::~AffineBodyPrismaticJoint() = default;
 
+geometry::SimplicialComplex AffineBodyPrismaticJoint::create_geometry(
+    span<const Vector3>                      position0s,
+    span<const Vector3>                      position1s,
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = position0s.size();
+    UIPC_ASSERT(N == position1s.size(),
+                "position0s({}) vs position1s({}) size mismatch",
+                N,
+                position1s.size());
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(2 * N);
+    auto pos_view = view(sc.positions());
+
+    sc.edges().resize(N);
+    auto topo = sc.edges().create<Vector2i>(builtin::topo, Vector2i::Zero(), false);
+    auto topo_view = view(*topo);
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        pos_view[2 * i + 0] = position0s[i];
+        pos_view[2 * i + 1] = position1s[i];
+        topo_view[i] = Vector2i{static_cast<int>(2 * i), static_cast<int>(2 * i + 1)};
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
+
+geometry::SimplicialComplex AffineBodyPrismaticJoint::create_geometry(
+    span<const Vector3>                      l_position0,
+    span<const Vector3>                      l_position1,
+    span<const Vector3>                      r_position0,
+    span<const Vector3>                      r_position1,
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = l_position0.size();
+    UIPC_ASSERT(N == l_position1.size(),
+                "l_position0({}) vs l_position1({}) size mismatch",
+                N,
+                l_position1.size());
+    UIPC_ASSERT(N == r_position0.size(),
+                "l_position0({}) vs r_position0({}) size mismatch",
+                N,
+                r_position0.size());
+    UIPC_ASSERT(N == r_position1.size(),
+                "l_position0({}) vs r_position1({}) size mismatch",
+                N,
+                r_position1.size());
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(2 * N);
+
+    sc.edges().resize(N);
+    auto topo = sc.edges().create<Vector2i>(builtin::topo, Vector2i::Zero(), false);
+    auto topo_view = view(*topo);
+
+    auto l_pos0_attr = sc.edges().create<Vector3>("l_position0", Vector3::Zero());
+    auto l_pos1_attr = sc.edges().create<Vector3>("l_position1", Vector3::Zero());
+    auto r_pos0_attr = sc.edges().create<Vector3>("r_position0", Vector3::Zero());
+    auto r_pos1_attr = sc.edges().create<Vector3>("r_position1", Vector3::Zero());
+    auto l_pos0_view = view(*l_pos0_attr);
+    auto l_pos1_view = view(*l_pos1_attr);
+    auto r_pos0_view = view(*r_pos0_attr);
+    auto r_pos1_view = view(*r_pos1_attr);
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        topo_view[i]    = Vector2i{static_cast<int>(2 * i), static_cast<int>(2 * i + 1)};
+        l_pos0_view[i]  = l_position0[i];
+        l_pos1_view[i]  = l_position1[i];
+        r_pos0_view[i]  = r_position0[i];
+        r_pos1_view[i]  = r_position1[i];
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
 
 void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
                                         span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
@@ -62,32 +149,32 @@ void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
 
 void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
                                         span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
-                                        span<IndexT> l_instance_id,
+                                        span<IndexT> l_instance_ids,
                                         span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                                        span<IndexT> r_instance_id,
-                                        span<Float>  strength_ratio)
+                                        span<IndexT> r_instance_ids,
+                                        span<Float>  strength_ratios)
 {
     auto size = edges.edges().size();
     UIPC_ASSERT(size == l_geo_slots.size(),
                 "The number of edges ({}) does not match the number of left geo slots ({})",
                 size,
                 l_geo_slots.size());
-    UIPC_ASSERT(size == l_instance_id.size(),
+    UIPC_ASSERT(size == l_instance_ids.size(),
                 "The number of edges ({}) does not match the number of left instance IDs ({})",
                 size,
-                l_instance_id.size());
+                l_instance_ids.size());
     UIPC_ASSERT(size == r_geo_slots.size(),
                 "The number of edges ({}) does not match the number of right geo slots ({})",
                 size,
                 r_geo_slots.size());
-    UIPC_ASSERT(size == r_instance_id.size(),
+    UIPC_ASSERT(size == r_instance_ids.size(),
                 "The number of edges ({}) does not match the number of right instance IDs ({})",
                 size,
-                r_instance_id.size());
-    UIPC_ASSERT(size == strength_ratio.size(),
+                r_instance_ids.size());
+    UIPC_ASSERT(size == strength_ratios.size(),
                 "The number of edges ({}) does not match the number of strength ratios ({})",
                 size,
-                strength_ratio.size());
+                strength_ratios.size());
 
     auto uid = edges.meta().find<U64>(builtin::constitution_uid);
     if(!uid)
@@ -96,19 +183,25 @@ void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
     }
     view(*uid)[0] = this->uid();
 
-    auto geo_ids = edges.edges().find<Vector2i>("geo_ids");
-    if(!geo_ids)
-    {
-        geo_ids = edges.edges().create<Vector2i>("geo_ids", Vector2i{-1, -1});
-    }
-    auto geo_ids_view = view(*geo_ids);
+    auto l_geo_id_attr = edges.edges().find<IndexT>("l_geo_id");
+    if(!l_geo_id_attr)
+        l_geo_id_attr = edges.edges().create<IndexT>("l_geo_id", IndexT{-1});
+    auto l_geo_id_view = view(*l_geo_id_attr);
 
-    auto inst_ids = edges.edges().find<Vector2i>("inst_ids");
-    if(!inst_ids)
-    {
-        inst_ids = edges.edges().create<Vector2i>("inst_ids", Vector2i{-1, -1});
-    }
-    auto inst_ids_view = view(*inst_ids);
+    auto r_geo_id_attr = edges.edges().find<IndexT>("r_geo_id");
+    if(!r_geo_id_attr)
+        r_geo_id_attr = edges.edges().create<IndexT>("r_geo_id", IndexT{-1});
+    auto r_geo_id_view = view(*r_geo_id_attr);
+
+    auto l_inst_id_attr = edges.edges().find<IndexT>("l_inst_id");
+    if(!l_inst_id_attr)
+        l_inst_id_attr = edges.edges().create<IndexT>("l_inst_id", IndexT{-1});
+    auto l_inst_id_view = view(*l_inst_id_attr);
+
+    auto r_inst_id_attr = edges.edges().find<IndexT>("r_inst_id");
+    if(!r_inst_id_attr)
+        r_inst_id_attr = edges.edges().create<IndexT>("r_inst_id", IndexT{-1});
+    auto r_inst_id_view = view(*r_inst_id_attr);
 
     auto strength_ratio_attr = edges.edges().find<Float>("strength_ratio");
     if(!strength_ratio_attr)
@@ -116,13 +209,13 @@ void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
         strength_ratio_attr = edges.edges().create<Float>("strength_ratio", 0.0);
     }
     auto strength_ratio_view = view(*strength_ratio_attr);
-    std::ranges::copy(strength_ratio, strength_ratio_view.begin());
+    std::ranges::copy(strength_ratios, strength_ratio_view.begin());
 
     for(auto&& [i, l_slot] : enumerate(l_geo_slots))
     {
         auto r_slot = r_geo_slots[i];
-        auto l_inst = l_instance_id[i];
-        auto r_inst = r_instance_id[i];
+        auto l_inst = l_instance_ids[i];
+        auto r_inst = r_instance_ids[i];
 
         UIPC_ASSERT(l_inst >= 0
                         && l_inst < static_cast<IndexT>(
@@ -137,8 +230,10 @@ void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
                     r_inst,
                     r_slot->geometry().instances().size());
 
-        geo_ids_view[i]  = Vector2i{l_slot->id(), r_slot->id()};
-        inst_ids_view[i] = Vector2i{l_inst, r_inst};
+        l_geo_id_view[i]  = l_slot->id();
+        r_geo_id_view[i]  = r_slot->id();
+        l_inst_id_view[i] = l_inst;
+        r_inst_id_view[i] = r_inst;
     }
 }
 

--- a/src/constitution/affine_body_revolute_joint.cpp
+++ b/src/constitution/affine_body_revolute_joint.cpp
@@ -31,6 +31,93 @@ AffineBodyRevoluteJoint::AffineBodyRevoluteJoint(const Json& config)
 
 AffineBodyRevoluteJoint::~AffineBodyRevoluteJoint() = default;
 
+geometry::SimplicialComplex AffineBodyRevoluteJoint::create_geometry(
+    span<const Vector3>                      position0s,
+    span<const Vector3>                      position1s,
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = position0s.size();
+    UIPC_ASSERT(N == position1s.size(),
+                "position0s({}) vs position1s({}) size mismatch",
+                N,
+                position1s.size());
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(2 * N);
+    auto pos_view = view(sc.positions());
+
+    sc.edges().resize(N);
+    auto topo = sc.edges().create<Vector2i>(builtin::topo, Vector2i::Zero(), false);
+    auto topo_view = view(*topo);
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        pos_view[2 * i + 0] = position0s[i];
+        pos_view[2 * i + 1] = position1s[i];
+        topo_view[i] = Vector2i{static_cast<int>(2 * i), static_cast<int>(2 * i + 1)};
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
+
+geometry::SimplicialComplex AffineBodyRevoluteJoint::create_geometry(
+    span<const Vector3>                      l_position0,
+    span<const Vector3>                      l_position1,
+    span<const Vector3>                      r_position0,
+    span<const Vector3>                      r_position1,
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = l_position0.size();
+    UIPC_ASSERT(N == l_position1.size(),
+                "l_position0({}) vs l_position1({}) size mismatch",
+                N,
+                l_position1.size());
+    UIPC_ASSERT(N == r_position0.size(),
+                "l_position0({}) vs r_position0({}) size mismatch",
+                N,
+                r_position0.size());
+    UIPC_ASSERT(N == r_position1.size(),
+                "l_position0({}) vs r_position1({}) size mismatch",
+                N,
+                r_position1.size());
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(2 * N);
+
+    sc.edges().resize(N);
+    auto topo = sc.edges().create<Vector2i>(builtin::topo, Vector2i::Zero(), false);
+    auto topo_view = view(*topo);
+
+    auto l_pos0_attr = sc.edges().create<Vector3>("l_position0", Vector3::Zero());
+    auto l_pos1_attr = sc.edges().create<Vector3>("l_position1", Vector3::Zero());
+    auto r_pos0_attr = sc.edges().create<Vector3>("r_position0", Vector3::Zero());
+    auto r_pos1_attr = sc.edges().create<Vector3>("r_position1", Vector3::Zero());
+    auto l_pos0_view = view(*l_pos0_attr);
+    auto l_pos1_view = view(*l_pos1_attr);
+    auto r_pos0_view = view(*r_pos0_attr);
+    auto r_pos1_view = view(*r_pos1_attr);
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        topo_view[i]    = Vector2i{static_cast<int>(2 * i), static_cast<int>(2 * i + 1)};
+        l_pos0_view[i]  = l_position0[i];
+        l_pos1_view[i]  = l_position1[i];
+        r_pos0_view[i]  = r_position0[i];
+        r_pos1_view[i]  = r_position1[i];
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
 
 void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
                                        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
@@ -62,32 +149,32 @@ void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
 
 void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
                                        span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
-                                       span<IndexT> l_instance_id,
+                                       span<IndexT> l_instance_ids,
                                        span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                                       span<IndexT> r_instance_id,
-                                       span<Float>  strength_ratio)
+                                       span<IndexT> r_instance_ids,
+                                       span<Float>  strength_ratios)
 {
     auto size = edges.edges().size();
     UIPC_ASSERT(size == l_geo_slots.size(),
                 "The number of edges ({}) does not match the number of left geo slots ({})",
                 size,
                 l_geo_slots.size());
-    UIPC_ASSERT(size == l_instance_id.size(),
+    UIPC_ASSERT(size == l_instance_ids.size(),
                 "The number of edges ({}) does not match the number of left instance IDs ({})",
                 size,
-                l_instance_id.size());
+                l_instance_ids.size());
     UIPC_ASSERT(size == r_geo_slots.size(),
                 "The number of edges ({}) does not match the number of right geo slots ({})",
                 size,
                 r_geo_slots.size());
-    UIPC_ASSERT(size == r_instance_id.size(),
+    UIPC_ASSERT(size == r_instance_ids.size(),
                 "The number of edges ({}) does not match the number of right instance IDs ({})",
                 size,
-                r_instance_id.size());
-    UIPC_ASSERT(size == strength_ratio.size(),
+                r_instance_ids.size());
+    UIPC_ASSERT(size == strength_ratios.size(),
                 "The number of edges ({}) does not match the number of strength ratios ({})",
                 size,
-                strength_ratio.size());
+                strength_ratios.size());
 
     auto uid = edges.meta().find<U64>(builtin::constitution_uid);
     if(!uid)
@@ -96,19 +183,25 @@ void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
     }
     view(*uid)[0] = this->uid();
 
-    auto geo_ids = edges.edges().find<Vector2i>("geo_ids");
-    if(!geo_ids)
-    {
-        geo_ids = edges.edges().create<Vector2i>("geo_ids", Vector2i{-1, -1});
-    }
-    auto geo_ids_view = view(*geo_ids);
+    auto l_geo_id_attr = edges.edges().find<IndexT>("l_geo_id");
+    if(!l_geo_id_attr)
+        l_geo_id_attr = edges.edges().create<IndexT>("l_geo_id", IndexT{-1});
+    auto l_geo_id_view = view(*l_geo_id_attr);
 
-    auto inst_ids = edges.edges().find<Vector2i>("inst_ids");
-    if(!inst_ids)
-    {
-        inst_ids = edges.edges().create<Vector2i>("inst_ids", Vector2i{-1, -1});
-    }
-    auto inst_ids_view = view(*inst_ids);
+    auto r_geo_id_attr = edges.edges().find<IndexT>("r_geo_id");
+    if(!r_geo_id_attr)
+        r_geo_id_attr = edges.edges().create<IndexT>("r_geo_id", IndexT{-1});
+    auto r_geo_id_view = view(*r_geo_id_attr);
+
+    auto l_inst_id_attr = edges.edges().find<IndexT>("l_inst_id");
+    if(!l_inst_id_attr)
+        l_inst_id_attr = edges.edges().create<IndexT>("l_inst_id", IndexT{-1});
+    auto l_inst_id_view = view(*l_inst_id_attr);
+
+    auto r_inst_id_attr = edges.edges().find<IndexT>("r_inst_id");
+    if(!r_inst_id_attr)
+        r_inst_id_attr = edges.edges().create<IndexT>("r_inst_id", IndexT{-1});
+    auto r_inst_id_view = view(*r_inst_id_attr);
 
     auto strength_ratio_attr = edges.edges().find<Float>("strength_ratio");
     if(!strength_ratio_attr)
@@ -116,13 +209,13 @@ void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
         strength_ratio_attr = edges.edges().create<Float>("strength_ratio", 0.0);
     }
     auto strength_ratio_view = view(*strength_ratio_attr);
-    std::ranges::copy(strength_ratio, strength_ratio_view.begin());
+    std::ranges::copy(strength_ratios, strength_ratio_view.begin());
 
     for(auto&& [i, l_slot] : enumerate(l_geo_slots))
     {
         auto r_slot = r_geo_slots[i];
-        auto l_inst = l_instance_id[i];
-        auto r_inst = r_instance_id[i];
+        auto l_inst = l_instance_ids[i];
+        auto r_inst = r_instance_ids[i];
 
         UIPC_ASSERT(l_inst >= 0
                         && l_inst < static_cast<IndexT>(
@@ -137,8 +230,10 @@ void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
                     r_inst,
                     r_slot->geometry().instances().size());
 
-        geo_ids_view[i]  = Vector2i{l_slot->id(), r_slot->id()};
-        inst_ids_view[i] = Vector2i{l_inst, r_inst};
+        l_geo_id_view[i]  = l_slot->id();
+        r_geo_id_view[i]  = r_slot->id();
+        l_inst_id_view[i] = l_inst;
+        r_inst_id_view[i] = r_inst;
     }
 }
 

--- a/src/constitution/affine_body_spherical_joint.cpp
+++ b/src/constitution/affine_body_spherical_joint.cpp
@@ -3,6 +3,7 @@
 #include <uipc/builtin/constitution_type.h>
 #include <uipc/builtin/attribute_name.h>
 #include <uipc/common/log.h>
+#include <uipc/common/enumerate.h>
 #include <Eigen/Geometry>
 
 namespace uipc::constitution
@@ -31,10 +32,65 @@ AffineBodySphericalJoint::AffineBodySphericalJoint(const Json& config)
 
 AffineBodySphericalJoint::~AffineBodySphericalJoint() = default;
 
+geometry::SimplicialComplex AffineBodySphericalJoint::create_geometry(
+    span<const Vector3>                      positions,
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = positions.size();
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(N);
+    auto pos_view = view(sc.positions());
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        pos_view[i] = positions[i];
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
+
+geometry::SimplicialComplex AffineBodySphericalJoint::create_geometry(
+    span<const Vector3>                      l_positions,
+    span<const Vector3>                      r_positions,
+    span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
+    span<IndexT>                             l_instance_ids,
+    span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
+    span<IndexT>                             r_instance_ids,
+    span<Float>                              strength_ratios)
+{
+    auto N = l_positions.size();
+    UIPC_ASSERT(N == r_positions.size(),
+                "l_positions({}) vs r_positions({}) size mismatch",
+                N,
+                r_positions.size());
+
+    geometry::SimplicialComplex sc;
+    sc.vertices().resize(N);
+
+    auto pos0_attr = sc.vertices().create<Vector3>("l_position", Vector3::Zero());
+    auto pos1_attr = sc.vertices().create<Vector3>("r_position", Vector3::Zero());
+    auto pos0_view = view(*pos0_attr);
+    auto pos1_view = view(*pos1_attr);
+
+    for(SizeT i = 0; i < N; ++i)
+    {
+        pos0_view[i] = l_positions[i];
+        pos1_view[i] = r_positions[i];
+    }
+
+    apply_to(sc, l_geo_slots, l_instance_ids, r_geo_slots, r_instance_ids, strength_ratios);
+    return sc;
+}
+
 void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
                                         span<S<geometry::SimplicialComplexSlot>> l_geo_slots,
                                         span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
-                                        span<Vector3> r_local_pos,
                                         Float         strength_ratio)
 {
     auto size = l_geo_slots.size();
@@ -52,7 +108,6 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
              span{l_instance_ids},
              span{r_geo_slots},
              span{r_instance_ids},
-             span{r_local_pos},
              span{strength_ratios});
 }
 
@@ -61,7 +116,6 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
                                         span<IndexT> l_instance_ids,
                                         span<S<geometry::SimplicialComplexSlot>> r_geo_slots,
                                         span<IndexT>  r_instance_ids,
-                                        span<Vector3> r_local_pos,
                                         span<Float>   strength_ratios)
 {
     auto size = l_geo_slots.size();
@@ -77,40 +131,10 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
                 "Size mismatch: l_geo_slots ({}) vs r_instance_ids ({})",
                 size,
                 r_instance_ids.size());
-    UIPC_ASSERT(size == r_local_pos.size(),
-                "Size mismatch: l_geo_slots ({}) vs r_local_pos ({})",
-                size,
-                r_local_pos.size());
     UIPC_ASSERT(size == strength_ratios.size(),
                 "Size mismatch: l_geo_slots ({}) vs strength_ratios ({})",
                 size,
                 strength_ratios.size());
-
-    // Build vertices: 2 per joint
-    //   vertex 0: body0's world-space center (for edge visualization)
-    //   vertex 1: anchor point in world space = RT * r_local_pos (body1's attachment)
-    sc.vertices().resize(2 * size);
-    auto pos_view = view(sc.positions());
-
-    // Build edges: 1 per joint
-    sc.edges().resize(size);
-    auto topo = sc.edges().create<Vector2i>(builtin::topo, Vector2i::Zero(), false);
-    auto topo_view = view(*topo);
-
-    for(SizeT i = 0; i < size; ++i)
-    {
-        auto l_sc = l_geo_slots[i]->geometry().as<geometry::SimplicialComplex>();
-        auto r_sc = r_geo_slots[i]->geometry().as<geometry::SimplicialComplex>();
-
-        Transform LT{l_sc->transforms().view()[l_instance_ids[i]]};
-        Transform RT{r_sc->transforms().view()[r_instance_ids[i]]};
-
-        // vertex 0: body0's center (visualization only)
-        pos_view[2 * i + 0] = LT.translation();
-        // vertex 1: anchor = body1's attachment point in world space
-        pos_view[2 * i + 1] = RT * r_local_pos[i];
-        topo_view[i] = Vector2i{static_cast<int>(2 * i), static_cast<int>(2 * i + 1)};
-    }
 
     auto uid = sc.meta().find<U64>(builtin::constitution_uid);
     if(!uid)
@@ -119,24 +143,30 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
     }
     view(*uid)[0] = this->uid();
 
-    auto geo_ids = sc.edges().find<Vector2i>("geo_ids");
-    if(!geo_ids)
-    {
-        geo_ids = sc.edges().create<Vector2i>("geo_ids", Vector2i{-1, -1});
-    }
-    auto geo_ids_view = view(*geo_ids);
+    auto l_geo_id_attr = sc.vertices().find<IndexT>("l_geo_id");
+    if(!l_geo_id_attr)
+        l_geo_id_attr = sc.vertices().create<IndexT>("l_geo_id", IndexT{-1});
+    auto l_geo_id_view = view(*l_geo_id_attr);
 
-    auto inst_ids = sc.edges().find<Vector2i>("inst_ids");
-    if(!inst_ids)
-    {
-        inst_ids = sc.edges().create<Vector2i>("inst_ids", Vector2i{-1, -1});
-    }
-    auto inst_ids_view = view(*inst_ids);
+    auto r_geo_id_attr = sc.vertices().find<IndexT>("r_geo_id");
+    if(!r_geo_id_attr)
+        r_geo_id_attr = sc.vertices().create<IndexT>("r_geo_id", IndexT{-1});
+    auto r_geo_id_view = view(*r_geo_id_attr);
 
-    auto strength_ratio_attr = sc.edges().find<Float>("strength_ratio");
+    auto l_inst_id_attr = sc.vertices().find<IndexT>("l_inst_id");
+    if(!l_inst_id_attr)
+        l_inst_id_attr = sc.vertices().create<IndexT>("l_inst_id", IndexT{-1});
+    auto l_inst_id_view = view(*l_inst_id_attr);
+
+    auto r_inst_id_attr = sc.vertices().find<IndexT>("r_inst_id");
+    if(!r_inst_id_attr)
+        r_inst_id_attr = sc.vertices().create<IndexT>("r_inst_id", IndexT{-1});
+    auto r_inst_id_view = view(*r_inst_id_attr);
+
+    auto strength_ratio_attr = sc.vertices().find<Float>("strength_ratio");
     if(!strength_ratio_attr)
     {
-        strength_ratio_attr = sc.edges().create<Float>("strength_ratio", 0.0);
+        strength_ratio_attr = sc.vertices().create<Float>("strength_ratio", 0.0);
     }
     auto strength_ratio_view = view(*strength_ratio_attr);
     std::ranges::copy(strength_ratios, strength_ratio_view.begin());
@@ -160,8 +190,10 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
                     r_inst,
                     r_slot->geometry().instances().size());
 
-        geo_ids_view[i]  = Vector2i{l_slot->id(), r_slot->id()};
-        inst_ids_view[i] = Vector2i{l_inst, r_inst};
+        l_geo_id_view[i]  = l_slot->id();
+        r_geo_id_view[i]  = r_slot->id();
+        l_inst_id_view[i] = l_inst;
+        r_inst_id_view[i] = r_inst;
     }
 }
 

--- a/src/pybind/pyuipc/constitution/affine_body_fixed_joint.cpp
+++ b/src/pybind/pyuipc/constitution/affine_body_fixed_joint.cpp
@@ -25,6 +25,98 @@ Args:
 Returns:
     dict: Default configuration dictionary.)");
 
+    // World create_geometry
+    class_AffineBodyFixedJoint.def(
+        "create_geometry",
+        [](AffineBodyFixedJoint&    self,
+           py::list                 l_geo_slots,
+           py::array_t<IndexT>      l_instance_ids,
+           py::list                 r_geo_slots,
+           py::array_t<IndexT>      r_instance_ids,
+           py::array_t<Float>       strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create fixed joint geometry using world-space positions (computed from body transforms).
+
+Args:
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
+    // Local create_geometry
+    class_AffineBodyFixedJoint.def(
+        "create_geometry",
+        [](AffineBodyFixedJoint&    self,
+           py::array_t<Float>       l_positions,
+           py::array_t<Float>       r_positions,
+           py::list                 l_geo_slots,
+           py::array_t<IndexT>      l_instance_ids,
+           py::list                 r_geo_slots,
+           py::array_t<IndexT>      r_instance_ids,
+           py::array_t<Float>       strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(as_span_of<Vector3>(l_positions),
+                                        as_span_of<Vector3>(r_positions),
+                                        span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("l_positions"),
+        py::arg("r_positions"),
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create fixed joint geometry using local-space attachment positions.
+
+Args:
+    l_positions: Local-space attachment positions on the left body (Nx3 array).
+    r_positions: Local-space attachment positions on the right body (Nx3 array).
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
     //  Single instance mode
     class_AffineBodyFixedJoint.def(
         "apply_to",
@@ -53,10 +145,10 @@ Returns:
         py::arg("l_geo_slots"),
         py::arg("r_geo_slots"),
         py::arg("strength_ratio") = Float{100.0},
-        py::doc(R"(Create fixed joint between two affine bodies (single-instance mode).
-sc: An empty SimplicialComplex; vertices and edges are built internally.
-l_geo_slots: List of left geometry slots for each joint.
-r_geo_slots: List of right geometry slots for each joint.
+        py::doc(R"(Bind fixed joint geometry to affine bodies (single-instance mode).
+sc: A SimplicialComplex with vertices representing joint attachment points.
+l_geo_slots: Left geometry slots for each joint.
+r_geo_slots: Right geometry slots for each joint.
 strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joints.)"));
 
     //  Multi-instance mode
@@ -65,10 +157,10 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
         [](AffineBodyFixedJoint&         self,
            geometry::SimplicialComplex&  sc,
            py::list                      l_geo_slots,
-           py::array_t<IndexT>           l_instance_id,
+           py::array_t<IndexT>           l_instance_ids,
            py::list                      r_geo_slots,
-           py::array_t<IndexT>           r_instance_id,
-           py::array_t<Float>            strength_ratio)
+           py::array_t<IndexT>           r_instance_ids,
+           py::array_t<Float>            strength_ratios)
         {
             vector<S<geometry::SimplicialComplexSlot>> l_slots;
             vector<S<geometry::SimplicialComplexSlot>> r_slots;
@@ -87,23 +179,23 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
 
             self.apply_to(sc,
                           span{l_slots},
-                          as_span<IndexT>(l_instance_id),
+                          as_span<IndexT>(l_instance_ids),
                           span{r_slots},
-                          as_span<IndexT>(r_instance_id),
-                          as_span<Float>(strength_ratio));
+                          as_span<IndexT>(r_instance_ids),
+                          as_span<Float>(strength_ratios));
         },
         py::arg("sc"),
         py::arg("l_geo_slots"),
-        py::arg("l_instance_id"),
+        py::arg("l_instance_ids"),
         py::arg("r_geo_slots"),
-        py::arg("r_instance_id"),
-        py::arg("strength_ratio"),
-        py::doc(R"(Create fixed joint between two affine bodies (multi-instance mode).
-sc: An empty SimplicialComplex; vertices and edges are built internally.
-l_geo_slots: List of left geometry slots for each joint.
-l_instance_id: List of instance IDs for left geometries.
-r_geo_slots: List of right geometry slots for each joint.
-r_instance_id: List of instance IDs for right geometries.
-strength_ratio: List of strength ratios for each joint (one per edge).)"));
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        py::doc(R"(Bind fixed joint geometry to affine bodies (multi-instance mode).
+sc: A SimplicialComplex with vertices representing joint attachment points.
+l_geo_slots: Left geometry slots for each joint.
+l_instance_ids: Instance IDs for left geometries.
+r_geo_slots: Right geometry slots for each joint.
+r_instance_ids: Instance IDs for right geometries.
+strength_ratios: Strength ratios for each joint (one per vertex).)"));
 }
 }  // namespace pyuipc::constitution

--- a/src/pybind/pyuipc/constitution/affine_body_prismatic_joint.cpp
+++ b/src/pybind/pyuipc/constitution/affine_body_prismatic_joint.cpp
@@ -25,6 +25,114 @@ Args:
 Returns:
     dict: Default configuration dictionary.)");
 
+    // World create_geometry
+    class_AffineBodyPrismaticJoint.def(
+        "create_geometry",
+        [](AffineBodyPrismaticJoint& self,
+           py::array_t<Float>        position0s,
+           py::array_t<Float>        position1s,
+           py::list                  l_geo_slots,
+           py::array_t<IndexT>       l_instance_ids,
+           py::list                  r_geo_slots,
+           py::array_t<IndexT>       r_instance_ids,
+           py::array_t<Float>        strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(as_span_of<Vector3>(position0s),
+                                        as_span_of<Vector3>(position1s),
+                                        span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("position0s"),
+        py::arg("position1s"),
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create prismatic joint geometry using world-space axis endpoints.
+
+Args:
+    position0s: World positions of the first axis endpoint for each joint (Nx3 array).
+    position1s: World positions of the second axis endpoint for each joint (Nx3 array).
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
+    // Local create_geometry
+    class_AffineBodyPrismaticJoint.def(
+        "create_geometry",
+        [](AffineBodyPrismaticJoint& self,
+           py::array_t<Float>        l_position0,
+           py::array_t<Float>        l_position1,
+           py::array_t<Float>        r_position0,
+           py::array_t<Float>        r_position1,
+           py::list                  l_geo_slots,
+           py::array_t<IndexT>       l_instance_ids,
+           py::list                  r_geo_slots,
+           py::array_t<IndexT>       r_instance_ids,
+           py::array_t<Float>        strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(as_span_of<Vector3>(l_position0),
+                                        as_span_of<Vector3>(l_position1),
+                                        as_span_of<Vector3>(r_position0),
+                                        as_span_of<Vector3>(r_position1),
+                                        span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("l_position0"),
+        py::arg("l_position1"),
+        py::arg("r_position0"),
+        py::arg("r_position1"),
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create prismatic joint geometry using local-space axis endpoints.
+
+Args:
+    l_position0: Local positions of the first axis endpoint on the left body (Nx3 array).
+    l_position1: Local positions of the second axis endpoint on the left body (Nx3 array).
+    r_position0: Local positions of the first axis endpoint on the right body (Nx3 array).
+    r_position1: Local positions of the second axis endpoint on the right body (Nx3 array).
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
     //  Single instance mode
     class_AffineBodyPrismaticJoint.def(
         "apply_to",
@@ -65,10 +173,10 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
         [](AffineBodyPrismaticJoint&    self,
            geometry::SimplicialComplex& edges,
            py::list                     l_geo_slots,
-           py::array_t<IndexT>          l_instance_id,
+           py::array_t<IndexT>          l_instance_ids,
            py::list                     r_geo_slots,
-           py::array_t<IndexT>          r_instance_id,
-           py::array_t<Float>           strength_ratio)
+           py::array_t<IndexT>          r_instance_ids,
+           py::array_t<Float>           strength_ratios)
         {
             vector<S<geometry::SimplicialComplexSlot>> l_slots;
             vector<S<geometry::SimplicialComplexSlot>> r_slots;
@@ -87,23 +195,23 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
 
             self.apply_to(edges,
                           span{l_slots},
-                          as_span<IndexT>(l_instance_id),
+                          as_span<IndexT>(l_instance_ids),
                           span{r_slots},
-                          as_span<IndexT>(r_instance_id),
-                          as_span<Float>(strength_ratio));
+                          as_span<IndexT>(r_instance_ids),
+                          as_span<Float>(strength_ratios));
         },
         py::arg("sc"),
         py::arg("l_geo_slots"),
-        py::arg("l_instance_id"),
+        py::arg("l_instance_ids"),
         py::arg("r_geo_slots"),
-        py::arg("r_instance_id"),
-        py::arg("strength_ratio"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
         py::doc(R"(Create joint between two affine bodies (multi-instance mode).
 sc: Every edge in the simplicial complex is treated as a joint axis.
 l_geo_slots: List of left geometry slots for each joint.
-l_instance_id: List of instance IDs for left geometries.
+l_instance_ids: List of instance IDs for left geometries.
 r_geo_slots: List of right geometry slots for each joint.
-r_instance_id: List of instance IDs for right geometries.
-strength_ratio: List of strength ratios for each joint (one per edge).)"));
+r_instance_ids: List of instance IDs for right geometries.
+strength_ratios: List of strength ratios for each joint (one per edge).)"));
 }
 }  // namespace pyuipc::constitution

--- a/src/pybind/pyuipc/constitution/affine_body_revolute_joint.cpp
+++ b/src/pybind/pyuipc/constitution/affine_body_revolute_joint.cpp
@@ -25,6 +25,114 @@ Args:
 Returns:
     dict: Default configuration dictionary.)");
 
+    // World create_geometry
+    class_AffineBodyRevoluteJoint.def(
+        "create_geometry",
+        [](AffineBodyRevoluteJoint& self,
+           py::array_t<Float>       position0s,
+           py::array_t<Float>       position1s,
+           py::list                 l_geo_slots,
+           py::array_t<IndexT>      l_instance_ids,
+           py::list                 r_geo_slots,
+           py::array_t<IndexT>      r_instance_ids,
+           py::array_t<Float>       strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(as_span_of<Vector3>(position0s),
+                                        as_span_of<Vector3>(position1s),
+                                        span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("position0s"),
+        py::arg("position1s"),
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create revolute joint geometry using world-space axis endpoints.
+
+Args:
+    position0s: World positions of the first axis endpoint for each joint (Nx3 array).
+    position1s: World positions of the second axis endpoint for each joint (Nx3 array).
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
+    // Local create_geometry
+    class_AffineBodyRevoluteJoint.def(
+        "create_geometry",
+        [](AffineBodyRevoluteJoint& self,
+           py::array_t<Float>       l_position0,
+           py::array_t<Float>       l_position1,
+           py::array_t<Float>       r_position0,
+           py::array_t<Float>       r_position1,
+           py::list                 l_geo_slots,
+           py::array_t<IndexT>      l_instance_ids,
+           py::list                 r_geo_slots,
+           py::array_t<IndexT>      r_instance_ids,
+           py::array_t<Float>       strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(as_span_of<Vector3>(l_position0),
+                                        as_span_of<Vector3>(l_position1),
+                                        as_span_of<Vector3>(r_position0),
+                                        as_span_of<Vector3>(r_position1),
+                                        span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("l_position0"),
+        py::arg("l_position1"),
+        py::arg("r_position0"),
+        py::arg("r_position1"),
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create revolute joint geometry using local-space axis endpoints.
+
+Args:
+    l_position0: Local positions of the first axis endpoint on the left body (Nx3 array).
+    l_position1: Local positions of the second axis endpoint on the left body (Nx3 array).
+    r_position0: Local positions of the first axis endpoint on the right body (Nx3 array).
+    r_position1: Local positions of the second axis endpoint on the right body (Nx3 array).
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
     //  Single instance mode
     class_AffineBodyRevoluteJoint.def(
         "apply_to",
@@ -65,10 +173,10 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
         [](AffineBodyRevoluteJoint&     self,
            geometry::SimplicialComplex& edges,
            py::list                     l_geo_slots,
-           py::array_t<IndexT>          l_instance_id,
+           py::array_t<IndexT>          l_instance_ids,
            py::list                     r_geo_slots,
-           py::array_t<IndexT>          r_instance_id,
-           py::array_t<Float>           strength_ratio)
+           py::array_t<IndexT>          r_instance_ids,
+           py::array_t<Float>           strength_ratios)
         {
             vector<S<geometry::SimplicialComplexSlot>> l_slots;
             vector<S<geometry::SimplicialComplexSlot>> r_slots;
@@ -87,23 +195,23 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
 
             self.apply_to(edges,
                           span{l_slots},
-                          as_span<IndexT>(l_instance_id),
+                          as_span<IndexT>(l_instance_ids),
                           span{r_slots},
-                          as_span<IndexT>(r_instance_id),
-                          as_span<Float>(strength_ratio));
+                          as_span<IndexT>(r_instance_ids),
+                          as_span<Float>(strength_ratios));
         },
         py::arg("sc"),
         py::arg("l_geo_slots"),
-        py::arg("l_instance_id"),
+        py::arg("l_instance_ids"),
         py::arg("r_geo_slots"),
-        py::arg("r_instance_id"),
-        py::arg("strength_ratio"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
         py::doc(R"(Create joint between two affine bodies (multi-instance mode).
 sc: Every edge in the simplicial complex is treated as a joint axis.
 l_geo_slots: List of left geometry slots for each joint.
-l_instance_id: List of instance IDs for left geometries.
+l_instance_ids: List of instance IDs for left geometries.
 r_geo_slots: List of right geometry slots for each joint.
-r_instance_id: List of instance IDs for right geometries.
-strength_ratio: List of strength ratios for each joint (one per edge).)"));
+r_instance_ids: List of instance IDs for right geometries.
+strength_ratios: List of strength ratios for each joint (one per edge).)"));
 }
 }  // namespace pyuipc::constitution

--- a/src/pybind/pyuipc/constitution/affine_body_spherical_joint.cpp
+++ b/src/pybind/pyuipc/constitution/affine_body_spherical_joint.cpp
@@ -14,8 +14,7 @@ PyAffineBodySphericalJoint::PyAffineBodySphericalJoint(py::module& m)
             "AffineBodySphericalJoint",
             R"(AffineBodySphericalJoint constitution for ball-and-socket joints between affine bodies.
 Constrains only the translational degrees of freedom (anchor points coincide),
-while allowing free relative rotation.
-The anchor is specified as a position in body1 (right body)'s local frame.)");
+while allowing free relative rotation.)");
 
     class_AffineBodySphericalJoint.def(py::init<const Json&>(),
                                        py::arg("config") =
@@ -30,49 +29,133 @@ Args:
 Returns:
     dict: Default configuration dictionary.)");
 
-    // Simplified API: per-joint anchors + uniform strength
+    // World create_geometry
+    class_AffineBodySphericalJoint.def(
+        "create_geometry",
+        [](AffineBodySphericalJoint&    self,
+           py::array_t<Float>           positions,
+           py::list                     l_geo_slots,
+           py::array_t<IndexT>          l_instance_ids,
+           py::list                     r_geo_slots,
+           py::array_t<IndexT>          r_instance_ids,
+           py::array_t<Float>           strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(as_span_of<Vector3>(positions),
+                                        span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("positions"),
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create spherical joint geometry using world-space anchor positions.
+
+Args:
+    positions: World positions of the anchor point for each joint (Nx3 array).
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
+    // Local create_geometry
+    class_AffineBodySphericalJoint.def(
+        "create_geometry",
+        [](AffineBodySphericalJoint&    self,
+           py::array_t<Float>           l_positions,
+           py::array_t<Float>           r_positions,
+           py::list                     l_geo_slots,
+           py::array_t<IndexT>          l_instance_ids,
+           py::list                     r_geo_slots,
+           py::array_t<IndexT>          r_instance_ids,
+           py::array_t<Float>           strength_ratios)
+        {
+            vector<S<geometry::SimplicialComplexSlot>> l_slots;
+            vector<S<geometry::SimplicialComplexSlot>> r_slots;
+            l_slots.reserve(l_geo_slots.size());
+            r_slots.reserve(r_geo_slots.size());
+            for(auto item : l_geo_slots)
+                l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+            for(auto item : r_geo_slots)
+                r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
+
+            return self.create_geometry(as_span_of<Vector3>(l_positions),
+                                        as_span_of<Vector3>(r_positions),
+                                        span{l_slots},
+                                        as_span<IndexT>(l_instance_ids),
+                                        span{r_slots},
+                                        as_span<IndexT>(r_instance_ids),
+                                        as_span<Float>(strength_ratios));
+        },
+        py::arg("l_positions"),
+        py::arg("r_positions"),
+        py::arg("l_geo_slots"),
+        py::arg("l_instance_ids"),
+        py::arg("r_geo_slots"),
+        py::arg("r_instance_ids"),
+        py::arg("strength_ratios"),
+        R"(Create spherical joint geometry using local-space anchor positions.
+
+Args:
+    l_positions: Local-space anchor positions on the left body (Nx3 array).
+    r_positions: Local-space anchor positions on the right body (Nx3 array).
+    l_geo_slots: Left geometry slots for each joint.
+    l_instance_ids: Instance IDs for left geometries.
+    r_geo_slots: Right geometry slots for each joint.
+    r_instance_ids: Instance IDs for right geometries.
+    strength_ratios: Strength ratio for each joint.
+
+Returns:
+    SimplicialComplex: The joint geometry mesh.)");
+
+    // Single-instance apply_to
     class_AffineBodySphericalJoint.def(
         "apply_to",
         [](AffineBodySphericalJoint&    self,
            geometry::SimplicialComplex& sc,
            py::list                     l_geo_slots,
            py::list                     r_geo_slots,
-           py::array_t<Float>           r_local_pos,
            Float                        strength_ratio)
         {
             vector<S<geometry::SimplicialComplexSlot>> l_slots;
             vector<S<geometry::SimplicialComplexSlot>> r_slots;
             l_slots.reserve(l_geo_slots.size());
             r_slots.reserve(r_geo_slots.size());
-
             for(auto item : l_geo_slots)
-            {
                 l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
-            }
             for(auto item : r_geo_slots)
-            {
                 r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
-            }
 
-            self.apply_to(sc,
-                          span{l_slots},
-                          span{r_slots},
-                          as_span_of<Vector3>(r_local_pos),
-                          strength_ratio);
+            self.apply_to(sc, span{l_slots}, span{r_slots}, strength_ratio);
         },
         py::arg("sc"),
         py::arg("l_geo_slots"),
         py::arg("r_geo_slots"),
-        py::arg("r_local_pos"),
         py::arg("strength_ratio") = Float{100.0},
-        py::doc(R"(Create a spherical joint between two affine bodies (single-instance mode).
-sc: An empty SimplicialComplex; vertices and edges are built internally.
-l_geo_slots: List of left geometry slots for each joint.
-r_geo_slots: List of right geometry slots for each joint.
-r_local_pos: Array of [x, y, z] anchor positions in body1 (right body)'s local frame (one per joint).
+        py::doc(R"(Bind spherical joint geometry to affine bodies (single-instance mode).
+sc: A SimplicialComplex with vertices representing joint anchor points.
+l_geo_slots: Left geometry slots for each joint.
+r_geo_slots: Right geometry slots for each joint.
 strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joints.)"));
 
-    // Full API: explicit local anchor position on body1
+    // Multi-instance apply_to
     class_AffineBodySphericalJoint.def(
         "apply_to",
         [](AffineBodySphericalJoint&    self,
@@ -81,30 +164,22 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
            py::array_t<IndexT>          l_instance_ids,
            py::list                     r_geo_slots,
            py::array_t<IndexT>          r_instance_ids,
-           py::array_t<Float>           r_local_pos,
            py::array_t<Float>           strength_ratios)
         {
             vector<S<geometry::SimplicialComplexSlot>> l_slots;
             vector<S<geometry::SimplicialComplexSlot>> r_slots;
-
             l_slots.reserve(l_geo_slots.size());
             r_slots.reserve(r_geo_slots.size());
-
             for(auto item : l_geo_slots)
-            {
                 l_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
-            }
             for(auto item : r_geo_slots)
-            {
                 r_slots.push_back(py::cast<S<geometry::SimplicialComplexSlot>>(item));
-            }
 
             self.apply_to(sc,
                           span{l_slots},
                           as_span<IndexT>(l_instance_ids),
                           span{r_slots},
                           as_span<IndexT>(r_instance_ids),
-                          as_span_of<Vector3>(r_local_pos),
                           as_span<Float>(strength_ratios));
         },
         py::arg("sc"),
@@ -112,15 +187,13 @@ strength_ratio: Stiffness = strength_ratio * (BodyMassA + BodyMassB) for all joi
         py::arg("l_instance_ids"),
         py::arg("r_geo_slots"),
         py::arg("r_instance_ids"),
-        py::arg("r_local_pos"),
         py::arg("strength_ratios"),
-        py::doc(R"(Create a spherical joint between two affine bodies (multi-instance mode).
-sc: An empty SimplicialComplex; vertices and edges are built internally.
-l_geo_slots: List of left geometry slots for each joint.
-l_instance_ids: List of instance IDs for left geometries.
-r_geo_slots: List of right geometry slots for each joint.
-r_instance_ids: List of instance IDs for right geometries.
-r_local_pos: List of [x, y, z] anchor positions in body1 (right body)'s local frame.
-strength_ratios: List of strength ratios for each joint (one per edge).)"));
+        py::doc(R"(Bind spherical joint geometry to affine bodies (multi-instance mode).
+sc: A SimplicialComplex with vertices representing joint anchor points.
+l_geo_slots: Left geometry slots for each joint.
+l_instance_ids: Instance IDs for left geometries.
+r_geo_slots: Right geometry slots for each joint.
+r_instance_ids: Instance IDs for right geometries.
+strength_ratios: Strength ratios for each joint (one per vertex).)"));
 }
 }  // namespace pyuipc::constitution


### PR DESCRIPTION
## Summary

- **New `create_geometry` API**: Add `create_geometry` methods (World and Local overloads) for all four base joint types (Revolute, Prismatic, Fixed, Spherical). World overloads write `vertices.position`; Local overloads write local-space attributes (`l_position0`/`r_position0` for edge-based joints, `l_position`/`r_position` for vertex-based joints). The `apply_to` method is refactored to be a pure binding operation (writing constitution UID, geometry/instance IDs, and strength ratio only).
- **Attribute renaming**: Split `geo_ids`/`inst_ids` (`Vector2i`) into separate `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id` (`IndexT`). Rename Fixed/Spherical local position attributes from `position0`/`position1` to `l_position`/`r_position`.
- **Topology change**: Fixed and Spherical joints now use vertex-based topology (1 vertex per joint) instead of edge-based.
- **CUDA backend**: Implement local-position priority rule — if local attributes are present on the mesh, use them; otherwise fall back to world positions. Updated all joint kernels, limit kernels, external force constraints, and articulation constraints.
- **Test cases**: Add 4 new local-position sim cases (88-91) with aligned/misaligned pairs and `isApprox` assertions. Fix duplicate sim_case number prefixes by re-sorting 76-91 by commit date.
- **Pybind & docs**: Update Python bindings and specification markdown for all joint types.

## Breaking Changes

- `apply_to` signature changed for all joint types (now takes separate `l_geo_slots`/`r_geo_slots` and `l_instance_ids`/`r_instance_ids` instead of combined vectors).
- Fixed/Spherical joints now vertex-based instead of edge-based.
- Attribute names changed: `geo_ids` -> `l_geo_id`/`r_geo_id`, `inst_ids` -> `l_inst_id`/`r_inst_id`, `position0`/`position1` -> `l_position`/`r_position` (Fixed/Spherical).

## Test plan

- [x] All 8 joint world-position tests pass (76-80, 77-78)
- [x] All 4 joint local-position tests pass (88-91) with `isApprox` assertions
- [x] Build succeeds with RelWithDebInfo configuration
- [ ] Verify Python bindings work with updated API
