### PR TITLE
docs(constitution): fix joint doc inconsistencies with implementation

### DIFF
--- a/docs/specification/constitutions/affine_body_driving_prismatic_joint.md
+++ b/docs/specification/constitutions/affine_body_driving_prismatic_joint.md
@@ -13,7 +13,7 @@ The driving joint supports two operating modes:
 - **Active mode** (`is_passive = 0`): the joint drives toward a user-specified `aim_distance`.
 - **Passive mode** (`is_passive = 1`): the joint resists external forces by treating the current distance as the target, effectively locking the joint in place.
 
-The constraint can also be toggled on and off at runtime via the `is_constrained` flag.
+The constraint can also be toggled on and off at runtime via the `driving/is_constrained` flag.
 
 ## Energy
 
@@ -44,7 +44,7 @@ where $K = \gamma (m_i + m_j)$, $\gamma$ is the **user defined** `strength_ratio
 
 The two symmetric terms ensure that the constraint is evaluated from both bodies' perspectives.
 
-When `is_constrained = 0`, the energy is zero and the driving effect is disabled.
+When `driving/is_constrained = 0`, the energy is zero and the driving effect is disabled.
 
 ## State Update
 
@@ -67,7 +67,7 @@ On the joint geometry (1D simplicial complex), on **edges** (one edge per joint)
 Driving-specific attributes on **edges**:
 
 - `driving/strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
-- `is_constrained`: enables (`1`) or disables (`0`) the driving effect
+- `driving/is_constrained`: enables (`1`) or disables (`0`) the driving effect
 - `is_passive`: passive mode (`1`) locks at the current distance; active mode (`0`) drives to `aim_distance`
 - `aim_distance`: $d_{\text{aim}}$, the target distance in active mode
 - `distance`: $d_{\text{current}}$, the current displacement (updated by the backend each time step)

--- a/docs/specification/constitutions/affine_body_driving_revolute_joint.md
+++ b/docs/specification/constitutions/affine_body_driving_revolute_joint.md
@@ -13,7 +13,7 @@ The driving joint supports two operating modes:
 - **Active mode** (`is_passive = 0`): the joint drives toward a user-specified `aim_angle`.
 - **Passive mode** (`is_passive = 1`): the joint resists external forces by treating the current angle as the target, effectively locking the joint in place.
 
-The constraint can also be toggled on and off at runtime via the `is_constrained` flag.
+The constraint can also be toggled on and off at runtime via the `driving/is_constrained` flag.
 
 ## Energy
 
@@ -48,7 +48,7 @@ $$
 
 where $K = \gamma (m_i + m_j)$, $\gamma$ is the **user defined** `strength_ratio` parameter, and $m_i$, $m_j$ are the masses of the two affine bodies.
 
-When `is_constrained = 0`, the energy is zero and the driving effect is disabled.
+When `driving/is_constrained = 0`, the energy is zero and the driving effect is disabled.
 
 ## State Update
 
@@ -71,7 +71,7 @@ On the joint geometry (1D simplicial complex), on **edges** (one edge per joint)
 Driving-specific attributes on **edges**:
 
 - `driving/strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
-- `is_constrained`: enables (`1`) or disables (`0`) the driving effect
+- `driving/is_constrained`: enables (`1`) or disables (`0`) the driving effect
 - `is_passive`: passive mode (`1`) locks at the current angle; active mode (`0`) drives to `aim_angle`
 - `aim_angle`: $\theta_{\text{aim}}$, the target angle in active mode
 - `angle`: $\theta_{\text{current}}$, the current relative angle (updated by the backend each time step)

--- a/docs/specification/constitutions/affine_body_spherical_joint.md
+++ b/docs/specification/constitutions/affine_body_spherical_joint.md
@@ -70,7 +70,7 @@ Unlike the [Affine Body Fixed Joint](./affine_body_fixed_joint.md), there is **n
 
 ### Parameter range
 
-`strength_ratio` $\gamma$ is dimensionless; it scales the penalty with combined mass. Typical values are problem-dependent; the regression test uses $\gamma = 100$ for a small two-cube scene.
+`strength_ratio` $\gamma$ is dimensionless; it scales the penalty with combined mass. A proper initial value is $\gamma = 100$.
 
 ## Attributes and geometry
 

--- a/include/uipc/constitution/affine_body_fixed_joint.h
+++ b/include/uipc/constitution/affine_body_fixed_joint.h
@@ -31,7 +31,7 @@ class UIPC_CONSTITUTION_API AffineBodyFixedJoint final : public InterAffineBodyC
      * @brief Create fixed joint geometry with local-space positions.
      *
      * Builds a vertex-based SimplicialComplex (1 vertex per joint).
-     * Writes local position attributes (position0, position1) on vertices.
+     * Writes local position attributes (l_position, r_position) on vertices.
      */
     [[nodiscard]] geometry::SimplicialComplex create_geometry(
         span<const Vector3>                      l_positions,

--- a/include/uipc/constitution/affine_body_spherical_joint.h
+++ b/include/uipc/constitution/affine_body_spherical_joint.h
@@ -32,7 +32,7 @@ class UIPC_CONSTITUTION_API AffineBodySphericalJoint final : public InterAffineB
      * @brief Create spherical joint geometry with local-space anchor positions.
      *
      * Builds a vertex-based SimplicialComplex (1 vertex per joint).
-     * Writes local position attributes (position0, position1) on vertices.
+     * Writes local position attributes (l_position, r_position) on vertices.
      */
     [[nodiscard]] geometry::SimplicialComplex create_geometry(
         span<const Vector3>                      l_positions,


### PR DESCRIPTION
## Summary

Fix specification documentation to match the actual C++ / CUDA implementation for all affine body joint constitutions.

- **Fixed/Spherical joint header comments**: corrected local position attribute names from `position0, position1` to `l_position, r_position`
- **Spherical joint spec**: removed informal "regression test" phrasing; replaced with "A proper initial value is $\gamma = 100$"
- **Driving Revolute/Prismatic joint specs**: corrected attribute name from `is_constrained` to `driving/is_constrained` in attribute lists and prose (3 occurrences per doc)

All other joint docs (base Revolute, Prismatic, Fixed, Spherical, Limit, External Force) were verified correct against the implementation — attribute names, topologies (edge vs vertex), and UIDs all match.
