### PR TITLE
fix(core): update sanity check config and remove stale cuda dependency

### DIFF
--- a/docs/specification/scene_config.md
+++ b/docs/specification/scene_config.md
@@ -102,7 +102,7 @@ See [Contact Details](scene_configs/contact.md) for IPC vs AL-IPC pipeline selec
 
 | Key | Type | Default | Option | Description |
 |-----|------|---------|--------|-------------|
-| `sanity_check/backend` | String | `"cpu"` | `"none"` `"cpu"` `"cuda"` | Sanity check backend: `none` disables, `cpu` runs CPU checks, `cuda` runs CUDA-accelerated checks |
+| `sanity_check/enable` | Int | `1` | | Enable sanity checks before simulation |
 | `sanity_check/mode` | String | `"normal"` | `"normal"` `"quiet"` | `normal` writes diagnostic meshes on failure; `quiet` skips file output |
 
 ## Differentiable Simulation

--- a/python/src/uipc/adapter/warp/__init__.py
+++ b/python/src/uipc/adapter/warp/__init__.py
@@ -1,8 +1,9 @@
-from uipc.backend import Buffer
-from uipc.backend import BufferView
-import warp as pywarp
 from typing import Any
+
+import warp as pywarp
 import warp.types as wtypes
+
+from uipc.backend import Buffer, BufferView
 
 
 class WarpBuffer:
@@ -22,7 +23,7 @@ class WarpBuffer:
 
     @staticmethod
     def _a2b(a: pywarp.array) -> BufferView:
-        assert a.ndim == 1, "Only 1D arrays are supported, got {}D".format(a.ndim)
+        assert a.ndim == 1, f"Only 1D arrays are supported, got {a.ndim}D"
         ptr: int = 0
         if a.ptr is not None:
             ptr = a.ptr
@@ -35,7 +36,7 @@ class WarpBuffer:
             backend_name=str(a.device),
         )
 
-    def __init__(self, size: int, dtype: Any, device: str = "cpu"):
+    def __init__(self, size: int, dtype: Any, device: pywarp.Device | str = "cpu"):
         """
         Initialize a WarpBuffer with the given size, dtype, and device.
         """
@@ -75,10 +76,8 @@ def buffer_view(array: pywarp.array) -> BufferView:
     return WarpBuffer._a2b(array)
 
 
-def buffer(size: int, dtype: Any, device: str = "cpu") -> WarpBuffer:
+def buffer(size: int, dtype: Any, device: pywarp.Device | str = "cpu") -> WarpBuffer:
     """
     Create a WarpBuffer with the given size, dtype, and device.
     """
     return WarpBuffer(size, dtype, device)
-
-

--- a/src/pybind/xmake.lua
+++ b/src/pybind/xmake.lua
@@ -22,9 +22,6 @@ target("pyuipc")
         "uipc_io",
         "uipc_sanity_check"
     )
-    if has_config("backend_cuda") then
-        add_deps("uipc_cuda_sanity_check")
-    end
     add_packages("pybind11")
     on_load(function (target)
         import("core.base.semver")


### PR DESCRIPTION
## Summary

Follow-up cleanup to #422 (extract CUDA sanity check into standalone module):

- **Config simplification**: Replace `sanity_check/backend` config (with options `"none"`, `"cpu"`, `"cuda"`) with a simpler `sanity_check/enable` toggle (Int, default `1`)
- **Build fix**: Remove stale `uipc_cuda_sanity_check` dependency from `pyuipc` target, since CUDA sanity checks are now loaded as a standalone backend module

## Related

- Follow-up to #422
