### PR TITLE
feat(constitution): add FiniteElementExternalForce for per-vertex external forces on FEM bodies

### DIFF
--- a/apps/tests/sim_case/45_finite_element_external_vertex_force.cpp
+++ b/apps/tests/sim_case/45_finite_element_external_vertex_force.cpp
@@ -1,0 +1,106 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/stable_neo_hookean.h>
+#include <uipc/constitution/finite_element_external_force.h>
+#include <uipc/geometry/utils/flip_inward_triangles.h>
+#include <uipc/geometry/utils/label_surface.h>
+#include <uipc/geometry/utils/label_triangle_orient.h>
+
+TEST_CASE("45_finite_element_external_vertex_force", "[fem][external_force]")
+{
+    using namespace uipc;
+    using namespace uipc::core;
+    using namespace uipc::geometry;
+    using namespace uipc::constitution;
+
+    namespace fs = std::filesystem;
+
+    std::string tetmesh_dir{AssetDir::tetmesh_path()};
+    auto        output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                 = test::Scene::default_config();
+    config["gravity"]           = Vector3{0, 0, 0};
+    config["contact"]["enable"] = false;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+    {
+        StableNeoHookean          snh;
+        FiniteElementExternalForce ext_force;
+
+        Matrix4x4 pre_trans = Matrix4x4::Identity();
+        pre_trans(0, 0)     = 0.2;
+        pre_trans(1, 1)     = 0.2;
+        pre_trans(2, 2)     = 0.2;
+
+        SimplicialComplexIO io{pre_trans};
+        auto cube = io.read(fmt::format("{}/cube.msh", tetmesh_dir));
+
+        label_surface(cube);
+        label_triangle_orient(cube);
+
+        auto parm = ElasticModuli::youngs_poisson(1e5, 0.499);
+        snh.apply_to(cube, parm, 1e3);
+
+        ext_force.apply_to(cube, Vector3::Zero());
+
+        auto object = scene.objects().create("cube");
+        object->geometries().create(cube);
+
+        scene.animator().insert(
+            *object,
+            [](Animation::UpdateInfo& info)
+            {
+                Float time = info.dt() * info.frame();
+
+                Float force_magnitude = 50.0;
+                Float orbit_speed     = 0.5;
+
+                Float   orbit_angle = orbit_speed * time;
+                Vector3 force{std::cos(orbit_angle) * force_magnitude,
+                              0.0,
+                              std::sin(orbit_angle) * force_magnitude};
+
+                for(auto& geo_slot : info.geo_slots())
+                {
+                    auto& geo = geo_slot->geometry();
+                    auto* sc  = geo.as<SimplicialComplex>();
+                    if(!sc)
+                        continue;
+
+                    auto force_attr = sc->vertices().find<Vector3>("external_force");
+                    if(!force_attr)
+                        continue;
+
+                    auto is_constrained =
+                        sc->vertices().find<IndexT>(builtin::is_constrained);
+                    if(is_constrained)
+                    {
+                        auto is_constrained_view = view(*is_constrained);
+                        std::ranges::fill(is_constrained_view, 1);
+                    }
+
+                    auto force_view = view(*force_attr);
+                    std::ranges::fill(force_view, force);
+                }
+            });
+    }
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, 0));
+
+    while(world.frame() < 100)
+    {
+        world.advance();
+        REQUIRE(world.is_valid());
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+}

--- a/include/uipc/constitution/finite_element_external_force.h
+++ b/include/uipc/constitution/finite_element_external_force.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <uipc/common/type_define.h>
+#include <uipc/constitution/constitution.h>
+#include <uipc/geometry/simplicial_complex.h>
+
+namespace uipc::constitution
+{
+class UIPC_CONSTITUTION_API FiniteElementExternalForce final : public IConstitution
+{
+    using Base = IConstitution;
+
+  public:
+    FiniteElementExternalForce(const Json& config = default_config());
+    ~FiniteElementExternalForce();
+
+    /**
+     * @brief Apply external force (3D) to finite element vertices
+     * @param sc SimplicialComplex representing finite element geometry
+     * @param force 3D force vector applied uniformly to all vertices
+     */
+    void apply_to(geometry::SimplicialComplex& sc, const Vector3& force);
+
+    static Json default_config();
+
+  protected:
+    virtual U64 get_uid() const noexcept override;
+
+  private:
+    Json m_config;
+};
+}  // namespace uipc::constitution

--- a/src/backends/cuda/finite_element/bdf/fem_bdf1_time_integrator.cu
+++ b/src/backends/cuda/finite_element/bdf/fem_bdf1_time_integrator.cu
@@ -30,6 +30,7 @@ class FEMBDF1Integrator final : public FEMTimeIntegrator
                     vs         = info.vs().cviewer().name("vs"),
                     x_tildes   = info.x_tildes().viewer().name("x_tildes"),
                     gravities  = info.gravities().cviewer().name("gravities"),
+                    external_force_accs = info.external_force_accs().cviewer().name("external_force_accs"),
                     dt         = info.dt()] __device__(int i) mutable
                    {
                        // record previous position
@@ -43,12 +44,13 @@ class FEMBDF1Integrator final : public FEMTimeIntegrator
 
                        if(!is_fixed(i))
                        {
-                           const Vector3& g = gravities(i);
+                           const Vector3& g         = gravities(i);
+                           const Vector3& f_ext_acc = external_force_accs(i);
 
-                           // 1) static problem: x_tilde = x_prev + g * dt * dt
-                           x_tilde += g * dt * dt;
+                           // 1) static problem: x_tilde = x_prev + (g + f_ext_acc) * dt * dt
+                           x_tilde += (g + f_ext_acc) * dt * dt;
 
-                           // 2) dynamic problem: x_tilde = x_prev + v * dt + g * dt * dt
+                           // 2) dynamic problem: x_tilde = x_prev + v * dt + (g + f_ext_acc) * dt * dt
                            if(is_dynamic(i))
                            {
                                x_tilde += v * dt;

--- a/src/backends/cuda/finite_element/bdf/fem_bdf2_time_integrator.cu
+++ b/src/backends/cuda/finite_element/bdf/fem_bdf2_time_integrator.cu
@@ -47,6 +47,7 @@ class FEMBDF2Integrator final : public FEMTimeIntegrator
                     v_n_1s     = state->v_n_1s().cviewer().name("v_n_1s"),
                     x_tildes   = info.x_tildes().viewer().name("x_tilde"),
                     gravity    = info.gravities().cviewer().name("gravity"),
+                    external_force_accs = info.external_force_accs().cviewer().name("external_force_accs"),
                     dt         = info.dt()] __device__(int i) mutable
                    {
                        // x_n is tracked in x_prevs for current step.
@@ -55,7 +56,7 @@ class FEMBDF2Integrator final : public FEMTimeIntegrator
                        Vector3 x_n_1 = x_n_1s(i);
                        Vector3 v_n   = v_ns(i);
                        Vector3 v_n_1 = v_n_1s(i);
-                       Vector3 g     = gravity(i);
+                       Vector3 g     = gravity(i) + external_force_accs(i);
 
                        if(is_fixed(i))
                        {

--- a/src/backends/cuda/finite_element/constraints/finite_element_external_vertex_force_constraint.cu
+++ b/src/backends/cuda/finite_element/constraints/finite_element_external_vertex_force_constraint.cu
@@ -1,0 +1,104 @@
+#include <finite_element/constraints/finite_element_external_vertex_force_constraint.h>
+#include <finite_element/finite_element_method.h>
+#include <uipc/common/enumerate.h>
+#include <uipc/common/zip.h>
+#include <uipc/builtin/attribute_name.h>
+
+namespace uipc::backend::cuda
+{
+REGISTER_SIM_SYSTEM(FiniteElementExternalVertexForceConstraint);
+
+void FiniteElementExternalVertexForceConstraint::do_build(BuildInfo& info) {}
+
+U64 FiniteElementExternalVertexForceConstraint::get_uid() const noexcept
+{
+    return UID;
+}
+
+void FiniteElementExternalVertexForceConstraint::do_init(FiniteElementAnimator::FilteredInfo& info)
+{
+    do_step(info);
+}
+
+muda::CBufferView<Vector3> FiniteElementExternalVertexForceConstraint::forces() const noexcept
+{
+    return m_impl.forces.view();
+}
+
+muda::CBufferView<IndexT> FiniteElementExternalVertexForceConstraint::vertex_ids() const noexcept
+{
+    return m_impl.vertex_ids.view();
+}
+
+void FiniteElementExternalVertexForceConstraint::Impl::step(
+    backend::WorldVisitor&              world,
+    FiniteElementAnimator::FilteredInfo& info)
+{
+    using ForEachInfo = FiniteElementMethod::ForEachInfo;
+
+    h_forces.clear();
+    h_vertex_ids.clear();
+
+    auto   geo_slots             = world.scene().geometries();
+    IndexT current_vertex_offset = 0;
+
+    info.for_each(
+        geo_slots,
+        [&](geometry::SimplicialComplex& sc)
+        {
+            auto vertex_offset =
+                sc.meta().find<IndexT>(builtin::backend_fem_vertex_offset);
+            UIPC_ASSERT(vertex_offset,
+                        "`backend_fem_vertex_offset` attribute not found");
+            current_vertex_offset = vertex_offset->view().front();
+
+            auto is_constrained = sc.vertices().find<IndexT>(builtin::is_constrained);
+            UIPC_ASSERT(is_constrained,
+                        "`is_constrained` attribute not found");
+            auto external_force = sc.vertices().find<Vector3>("external_force");
+            UIPC_ASSERT(external_force,
+                        "`external_force` attribute not found");
+
+            return zip(is_constrained->view(), external_force->view());
+        },
+        [&](const ForEachInfo& I, auto&& values)
+        {
+            auto vI = I.local_index() + current_vertex_offset;
+            auto&& [is_constrained, force] = values;
+            if(is_constrained)
+            {
+                h_vertex_ids.push_back(vI);
+                h_forces.push_back(force);
+            }
+        });
+
+    if(!h_forces.empty())
+    {
+        forces.copy_from(h_forces);
+        vertex_ids.copy_from(h_vertex_ids);
+    }
+}
+
+void FiniteElementExternalVertexForceConstraint::do_step(FiniteElementAnimator::FilteredInfo& info)
+{
+    m_impl.step(world(), info);
+}
+
+void FiniteElementExternalVertexForceConstraint::do_report_extent(
+    FiniteElementAnimator::ReportExtentInfo& info)
+{
+    info.energy_count(0);
+    info.gradient_count(0);
+    info.hessian_count(0);
+}
+
+void FiniteElementExternalVertexForceConstraint::do_compute_energy(
+    FiniteElementAnimator::ComputeEnergyInfo& info)
+{
+}
+
+void FiniteElementExternalVertexForceConstraint::do_compute_gradient_hessian(
+    FiniteElementAnimator::ComputeGradientHessianInfo& info)
+{
+}
+}  // namespace uipc::backend::cuda

--- a/src/backends/cuda/finite_element/constraints/finite_element_external_vertex_force_constraint.h
+++ b/src/backends/cuda/finite_element/constraints/finite_element_external_vertex_force_constraint.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <finite_element/finite_element_constraint.h>
+
+namespace uipc::backend::cuda
+{
+/**
+ * @brief Constraint that reads per-vertex external forces from geometry attributes
+ *
+ * This constraint reads "external_force" (Vector3) attributes from vertices
+ * and stores them inside its local buffers. No energy/gradient/hessian --
+ * forces are applied through x_tilde in the time integrator.
+ */
+class FiniteElementExternalVertexForceConstraint final : public FiniteElementConstraint
+{
+  public:
+    using FiniteElementConstraint::FiniteElementConstraint;
+
+    static constexpr U64 UID = 671;
+
+    class Impl
+    {
+      public:
+        vector<Vector3>             h_forces;
+        vector<IndexT>              h_vertex_ids;
+        muda::DeviceBuffer<Vector3> forces;
+        muda::DeviceBuffer<IndexT>  vertex_ids;
+
+        void step(backend::WorldVisitor& world, FiniteElementAnimator::FilteredInfo& info);
+    };
+
+    muda::CBufferView<Vector3> forces() const noexcept;
+    muda::CBufferView<IndexT>  vertex_ids() const noexcept;
+
+  private:
+    virtual void do_build(BuildInfo& info) override;
+    virtual U64  get_uid() const noexcept override;
+    virtual void do_init(FiniteElementAnimator::FilteredInfo& info) override;
+    virtual void do_step(FiniteElementAnimator::FilteredInfo& info) override;
+    virtual void do_report_extent(FiniteElementAnimator::ReportExtentInfo& info) override;
+    virtual void do_compute_energy(FiniteElementAnimator::ComputeEnergyInfo& info) override;
+    virtual void do_compute_gradient_hessian(FiniteElementAnimator::ComputeGradientHessianInfo& info) override;
+
+    Impl m_impl;
+};
+}  // namespace uipc::backend::cuda

--- a/src/backends/cuda/finite_element/fem_time_integrator.h
+++ b/src/backends/cuda/finite_element/fem_time_integrator.h
@@ -72,6 +72,11 @@ class FEMTimeIntegrator : public TimeIntegrator
             return m_impl->finite_element_method->gravities();
         }
 
+        auto external_force_accs() const noexcept
+        {
+            return m_impl->finite_element_method->vertex_external_force_accs();
+        }
+
       protected:
         Impl* m_impl = nullptr;
     };

--- a/src/backends/cuda/finite_element/finite_element_external_force_manager.cu
+++ b/src/backends/cuda/finite_element/finite_element_external_force_manager.cu
@@ -1,0 +1,91 @@
+#include <finite_element/finite_element_external_force_manager.h>
+#include <finite_element/finite_element_method.h>
+#include <finite_element/finite_element_external_force_reporter.h>
+
+namespace uipc::backend::cuda
+{
+REGISTER_SIM_SYSTEM(FEMExternalForceManager);
+
+void FEMExternalForceManager::do_build(BuildInfo& info)
+{
+    m_impl.finite_element_method = &require<FiniteElementMethod>();
+}
+
+void FEMExternalForceManager::register_reporter(FiniteElementExternalForceReporter* reporter)
+{
+    check_state(SimEngineState::BuildSystems, "register_reporter");
+    m_impl.m_reporters.register_sim_system(*reporter);
+}
+
+void FEMExternalForceManager::Impl::clear()
+{
+    auto external_forces =
+        finite_element_method->m_impl.vertex_external_forces.view();
+
+    using namespace muda;
+    ParallelFor()
+        .file_line(__FILE__, __LINE__)
+        .apply(external_forces.size(),
+               [forces = external_forces.viewer().name("forces")] __device__(int i) mutable
+               { forces(i).setZero(); });
+}
+
+void FEMExternalForceManager::Impl::step()
+{
+    ExternalForceInfo info{this};
+    for(auto reporter : m_reporters.view())
+    {
+        reporter->step(info);
+    }
+
+    using namespace muda;
+
+    auto& fem = finite_element_method->m_impl;
+
+    auto force_accs = fem.vertex_external_force_accs.view();
+    auto forces     = fem.vertex_external_forces.view();
+    auto masses     = finite_element_method->masses();
+
+    SizeT vertex_count = forces.size();
+
+    ParallelFor()
+        .file_line(__FILE__, __LINE__)
+        .apply(vertex_count,
+               [forces     = forces.cviewer().name("forces"),
+                force_accs = force_accs.viewer().name("force_accs"),
+                masses     = masses.cviewer().name("masses")] __device__(int i)
+               {
+                   const Vector3& F = forces(i);
+                   Float          m = masses(i);
+
+                   // a = F / m (avoid division by zero for massless vertices)
+                   if(m > 0.0)
+                       force_accs(i) = F / m;
+                   else
+                       force_accs(i).setZero();
+               });
+}
+
+void FEMExternalForceManager::do_init()
+{
+    for(auto reporter : m_impl.m_reporters.view())
+    {
+        reporter->init();
+    }
+}
+
+void FEMExternalForceManager::do_clear()
+{
+    m_impl.clear();
+}
+
+void FEMExternalForceManager::do_step()
+{
+    m_impl.step();
+}
+
+muda::BufferView<Vector3> FEMExternalForceManager::ExternalForceInfo::external_forces() noexcept
+{
+    return m_impl->finite_element_method->m_impl.vertex_external_forces.view();
+}
+}  // namespace uipc::backend::cuda

--- a/src/backends/cuda/finite_element/finite_element_external_force_manager.h
+++ b/src/backends/cuda/finite_element/finite_element_external_force_manager.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <external_force/external_force_reporter.h>
+#include <muda/buffer/buffer_view.h>
+
+namespace uipc::backend::cuda
+{
+class FiniteElementMethod;
+class FiniteElementExternalForceReporter;
+
+/**
+ * @brief Manager for finite element external forces
+ *
+ * This reporter manages all FEM-specific external force reporters.
+ * It is responsible for:
+ * 1. Clearing the external force buffer before constraints update
+ * 2. Collecting external forces from all registered reporters
+ * 3. Computing the external accelerations after all forces have been applied
+ *
+ * Hierarchy:
+ * - FEMExternalForceManager (this class, derives from ExternalForceReporter)
+ *   - Manages FiniteElementExternalForceReporter instances
+ *     - FiniteElementExternalVertexForce (applies force to vertices)
+ */
+class FEMExternalForceManager final : public ExternalForceReporter
+{
+  public:
+    using ExternalForceReporter::ExternalForceReporter;
+
+    static constexpr U64 UID = 671;
+
+    class Impl
+    {
+      public:
+        FiniteElementMethod* finite_element_method = nullptr;
+        SimSystemSlotCollection<FiniteElementExternalForceReporter> m_reporters;
+
+        void clear();
+        void step();
+    };
+
+    class ExternalForceInfo
+    {
+      public:
+        ExternalForceInfo(Impl* impl) noexcept
+            : m_impl(impl)
+        {
+        }
+        muda::BufferView<Vector3> external_forces() noexcept;
+
+      private:
+        friend class FEMExternalForceManager;
+        Impl* m_impl = nullptr;
+    };
+
+  private:
+    virtual void do_build(BuildInfo& info) override;
+    virtual U64  get_uid() const noexcept override { return UID; }
+    virtual void do_init() override;
+    virtual void do_clear() override;
+    virtual void do_step() override;
+
+    friend class FiniteElementExternalForceReporter;
+    void register_reporter(FiniteElementExternalForceReporter* reporter);
+
+    Impl m_impl;
+};
+}  // namespace uipc::backend::cuda

--- a/src/backends/cuda/finite_element/finite_element_external_force_reporter.cu
+++ b/src/backends/cuda/finite_element/finite_element_external_force_reporter.cu
@@ -1,0 +1,29 @@
+#include <finite_element/finite_element_external_force_reporter.h>
+#include <finite_element/finite_element_external_force_manager.h>
+
+namespace uipc::backend::cuda
+{
+void FiniteElementExternalForceReporter::do_build()
+{
+    BuildInfo info;
+    do_build(info);
+
+    auto& manager = require<FEMExternalForceManager>();
+    manager.register_reporter(this);
+}
+
+U64 FiniteElementExternalForceReporter::uid() const noexcept
+{
+    return get_uid();
+}
+
+void FiniteElementExternalForceReporter::init()
+{
+    do_init();
+}
+
+void FiniteElementExternalForceReporter::step(ExternalForceInfo& info)
+{
+    do_step(info);
+}
+}  // namespace uipc::backend::cuda

--- a/src/backends/cuda/finite_element/finite_element_external_force_reporter.h
+++ b/src/backends/cuda/finite_element/finite_element_external_force_reporter.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <sim_system.h>
+#include <finite_element/finite_element_external_force_manager.h>
+
+namespace uipc::backend::cuda
+{
+class FEMExternalForceManager;
+
+/**
+ * @brief Base class for finite element external force reporters
+ *
+ * Reporters scatter-add external forces into the per-vertex force buffer.
+ * The manager then computes per-vertex accelerations a = F/m.
+ *
+ * Specific implementations:
+ * - FiniteElementExternalVertexForce: Applies force directly to vertices
+ *
+ * Lifecycle:
+ * - do_init(): Called once during initialization
+ * - do_step(): Called every frame to scatter forces into the shared buffer
+ */
+class FiniteElementExternalForceReporter : public SimSystem
+{
+  public:
+    using SimSystem::SimSystem;
+
+    class BuildInfo
+    {
+      public:
+    };
+
+    U64 uid() const noexcept;
+
+    using ExternalForceInfo = FEMExternalForceManager::ExternalForceInfo;
+
+  protected:
+    virtual void do_build(BuildInfo& info)        = 0;
+    virtual U64  get_uid() const noexcept         = 0;
+    virtual void do_init()                        = 0;
+    virtual void do_step(ExternalForceInfo& info) = 0;
+
+  private:
+    friend class FEMExternalForceManager;
+    virtual void do_build() override final;
+
+    void init();
+    void step(ExternalForceInfo& info);
+
+    SizeT m_index = ~0ull;
+};
+}  // namespace uipc::backend::cuda

--- a/src/backends/cuda/finite_element/finite_element_external_vertex_force.cu
+++ b/src/backends/cuda/finite_element/finite_element_external_vertex_force.cu
@@ -1,0 +1,52 @@
+#include <finite_element/finite_element_external_force_reporter.h>
+#include <finite_element/constraints/finite_element_external_vertex_force_constraint.h>
+#include <finite_element/finite_element_method.h>
+#include <muda/ext/eigen/atomic.h>
+
+namespace uipc::backend::cuda
+{
+/**
+ * @brief Scatter-add external forces from constraint buffers into the
+ *        per-vertex external force buffer on FiniteElementMethod.
+ */
+class FiniteElementExternalVertexForce final : public FiniteElementExternalForceReporter
+{
+  public:
+    static constexpr U64 UID = 671;
+
+    using FiniteElementExternalForceReporter::FiniteElementExternalForceReporter;
+
+    SimSystemSlot<FiniteElementMethod>                          finite_element_method;
+    SimSystemSlot<FiniteElementExternalVertexForceConstraint>   constraint;
+
+    virtual void do_build(BuildInfo& info) override
+    {
+        finite_element_method = require<FiniteElementMethod>();
+        constraint            = require<FiniteElementExternalVertexForceConstraint>();
+    }
+
+    U64 get_uid() const noexcept override { return UID; }
+
+    void do_init() override {}
+
+    void do_step(ExternalForceInfo& info) override
+    {
+        SizeT force_count = constraint->forces().size();
+
+        using namespace muda;
+        ParallelFor()
+            .file_line(__FILE__, __LINE__)
+            .apply(force_count,
+                   [forces     = info.external_forces().viewer().name("forces"),
+                    vertex_ids = constraint->vertex_ids().viewer().name("vertex_ids"),
+                    vertex_forces = constraint->forces().viewer().name(
+                        "vertex_forces")] __device__(int i) mutable
+                   {
+                       auto vid = vertex_ids(i);
+                       eigen::atomic_add(forces(vid), vertex_forces(i));
+                   });
+    }
+};
+
+REGISTER_SIM_SYSTEM(FiniteElementExternalVertexForce);
+}  // namespace uipc::backend::cuda

--- a/src/backends/cuda/finite_element/finite_element_method.cu
+++ b/src/backends/cuda/finite_element/finite_element_method.cu
@@ -915,6 +915,9 @@ void FiniteElementMethod::Impl::_build_on_device()
     thicknesses.resize(h_thicknesses.size());
     thicknesses.view().copy_from(h_thicknesses.data());
 
+    vertex_external_forces.resize(xs.size(), Vector3::Zero());
+    vertex_external_force_accs.resize(xs.size(), Vector3::Zero());
+
     // 2) Elements
     codim_0ds.resize(h_codim_0ds.size());
     codim_0ds.view().copy_from(h_codim_0ds.data());

--- a/src/backends/cuda/finite_element/finite_element_method.h
+++ b/src/backends/cuda/finite_element/finite_element_method.h
@@ -31,6 +31,7 @@ class Codim1DConstitutionDiffParmReporter;
 class Codim0DConstitutionDiffParmReporter;
 
 class FiniteElementDiffDofReporter;
+class FEMExternalForceManager;
 
 class FiniteElementMethod final : public SimSystem
 {
@@ -273,6 +274,9 @@ class FiniteElementMethod final : public SimSystem
         muda::DeviceBuffer<Float>   masses;    // Mass
         muda::DeviceBuffer<Float>   thicknesses;  // Thickness
 
+        muda::DeviceBuffer<Vector3> vertex_external_forces;      // per-vertex F_ext
+        muda::DeviceBuffer<Vector3> vertex_external_force_accs;  // per-vertex a_ext = F/m
+
 
         //tex:
         // FEM3D Material Basis
@@ -329,6 +333,8 @@ class FiniteElementMethod final : public SimSystem
     auto rest_lengths() const noexcept { return m_impl.rest_lengths.view(); }
     auto Dm3x3_invs() const noexcept { return m_impl.Dm3x3_invs.view(); }
     auto gravities() const noexcept { return m_impl.gravities.view(); }
+    auto vertex_external_forces() const noexcept { return m_impl.vertex_external_forces.view(); }
+    auto vertex_external_force_accs() const noexcept { return m_impl.vertex_external_force_accs.view(); }
 
     /**
      * @brief return the frame-local dof offset of FEM for the given frame
@@ -396,6 +402,7 @@ class FiniteElementMethod final : public SimSystem
     friend class FEMTimeIntegrator;
 
     friend class FiniteElementStateAccessorFeatureOverrider;
+    friend class FEMExternalForceManager;
 
     friend class SimEngine;
     void init();  // only be called by SimEngine

--- a/src/constitution/finite_element_external_force.cpp
+++ b/src/constitution/finite_element_external_force.cpp
@@ -1,0 +1,68 @@
+#include <uipc/constitution/finite_element_external_force.h>
+#include <uipc/builtin/constitution_uid_auto_register.h>
+#include <uipc/builtin/constitution_type.h>
+#include <uipc/builtin/attribute_name.h>
+#include <uipc/geometry/attribute_collection.h>
+#include <uipc/common/set.h>
+
+namespace uipc::constitution
+{
+static constexpr U64 ConstitutionUID = 671;
+
+REGISTER_CONSTITUTION_UIDS()
+{
+    using namespace uipc::builtin;
+    list<UIDInfo> uids;
+    uids.push_back(UIDInfo{.uid  = ConstitutionUID,
+                           .name = "FiniteElementExternalForce",
+                           .type = string{builtin::Constraint}});
+    return uids;
+}
+
+FiniteElementExternalForce::FiniteElementExternalForce(const Json& config)
+{
+    m_config = config;
+}
+
+FiniteElementExternalForce::~FiniteElementExternalForce() = default;
+
+void FiniteElementExternalForce::apply_to(geometry::SimplicialComplex& sc,
+                                          const Vector3&               force)
+{
+    auto uids = sc.meta().find<VectorXu64>(builtin::constraint_uids);
+    if(!uids)
+        uids = sc.meta().create<VectorXu64>(builtin::constraint_uids);
+
+    auto&    vs = geometry::view(*uids).front();
+    set<U64> uids_set(vs.begin(), vs.end());
+    uids_set.insert(uid());
+    vs.resize(uids_set.size());
+    std::ranges::copy(uids_set, vs.begin());
+
+    auto is_constrained_attr = sc.vertices().find<IndexT>(builtin::is_constrained);
+    if(!is_constrained_attr)
+    {
+        is_constrained_attr = sc.vertices().create<IndexT>(builtin::is_constrained, 0);
+    }
+
+    auto external_force_attr = sc.vertices().find<Vector3>("external_force");
+    if(!external_force_attr)
+    {
+        external_force_attr =
+            sc.vertices().create<Vector3>("external_force", Vector3::Zero());
+    }
+
+    auto external_force_view = view(*external_force_attr);
+    std::ranges::fill(external_force_view, force);
+}
+
+Json FiniteElementExternalForce::default_config()
+{
+    return Json::object();
+}
+
+U64 FiniteElementExternalForce::get_uid() const noexcept
+{
+    return ConstitutionUID;
+}
+}  // namespace uipc::constitution

--- a/src/pybind/pyuipc/constitution/finite_element_external_force.cpp
+++ b/src/pybind/pyuipc/constitution/finite_element_external_force.cpp
@@ -1,0 +1,30 @@
+#include <pyuipc/constitution/finite_element_external_force.h>
+#include <uipc/constitution/finite_element_external_force.h>
+#include <pybind11/eigen.h>
+
+namespace pyuipc::constitution
+{
+using namespace uipc::constitution;
+
+PyFiniteElementExternalForce::PyFiniteElementExternalForce(py::module& m)
+{
+    auto class_FiniteElementExternalForce =
+        py::class_<FiniteElementExternalForce, IConstitution>(m, "FiniteElementExternalForce");
+
+    class_FiniteElementExternalForce
+        .def(py::init<const Json&>(),
+             py::arg("config") = FiniteElementExternalForce::default_config())
+        .def("apply_to",
+             &FiniteElementExternalForce::apply_to,
+             py::arg("sc"),
+             py::arg("force"),
+             R"(Apply external force (3D) to finite element vertices.
+
+             Args:
+                 sc: SimplicialComplex representing finite element geometry
+                 force: 3D force vector applied uniformly to all vertices
+             )")
+        .def_static("default_config",
+                    &FiniteElementExternalForce::default_config);
+}
+}  // namespace pyuipc::constitution

--- a/src/pybind/pyuipc/constitution/finite_element_external_force.h
+++ b/src/pybind/pyuipc/constitution/finite_element_external_force.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <pyuipc/pyuipc.h>
+
+namespace pyuipc::constitution
+{
+class PyFiniteElementExternalForce
+{
+  public:
+    PyFiniteElementExternalForce(py::module& m);
+};
+}  // namespace pyuipc::constitution

--- a/src/pybind/pyuipc/constitution/module.cpp
+++ b/src/pybind/pyuipc/constitution/module.cpp
@@ -37,6 +37,7 @@
 #include <pyuipc/constitution/affine_body_external_force.h>
 #include <pyuipc/constitution/affine_body_prismatic_joint_external_force.h>
 #include <pyuipc/constitution/affine_body_revolute_joint_external_force.h>
+#include <pyuipc/constitution/finite_element_external_force.h>
 #include <pyuipc/constitution/external_articulation_constraint.h>
 
 namespace pyuipc::constitution
@@ -87,6 +88,9 @@ PyModule::PyModule(py::module& m)
     PySoftVertexStitch{m};
     PySoftVertexEdgeStitch{m};
     PySoftVertexTriangleStitch{m};
+
+    // Finite Element External Force
+    PyFiniteElementExternalForce{m};
 
     // Constraints
     PySoftPositionConstraint{m};


### PR DESCRIPTION
## Summary

Add `FiniteElementExternalForce` support, mirroring the existing `AffineBodyExternalBodyForce` architecture for per-vertex `Vector3` external forces on FEM bodies.

### Motivation

The affine body system already supports external forces via `AffineBodyExternalBodyForce`, but there was no equivalent for finite element meshes. This PR fills that gap, enabling use cases such as wind simulation on cloth, applied loads on deformable objects, etc.

### Architecture

The implementation follows the same 5-layer pattern as the affine body external force:

1. **Frontend Constitution** (`FiniteElementExternalForce`, UID 671) - Tags geometry vertices with `external_force` (Vector3) and `is_constrained` attributes
2. **CUDA Constraint** (`FiniteElementExternalVertexForceConstraint`) - Gathers force/constraint data from geometry into device buffers; reports zero energy/gradient/hessian
3. **Reporter Base** (`FiniteElementExternalForceReporter`) - Abstract base for FEM external force reporters
4. **Manager** (`FEMExternalForceManager`) - Clears force buffers, orchestrates sub-reporters, computes per-vertex acceleration `a_i = F_i / m_i`
5. **Concrete Reporter** (`FiniteElementExternalVertexForce`) - Scatters per-vertex forces via `atomic_add`

### Integration with Time Integrators

External force accelerations are incorporated into `x_tilde` in both BDF1 and BDF2 integrators:
- **BDF1**: `x_tilde += (gravity + external_force_acc) * dt²`
- **BDF2**: gravity vector is augmented with `external_force_acc` before passing to `BDF2::compute_x_tilde`

### Python Bindings

`FiniteElementExternalForce` is exposed via pybind with `apply_to(sc, force_vec3)` API.

### New Files
- `include/uipc/constitution/finite_element_external_force.h`
- `src/constitution/finite_element_external_force.cpp`
- `src/backends/cuda/finite_element/constraints/finite_element_external_vertex_force_constraint.{h,cu}`
- `src/backends/cuda/finite_element/finite_element_external_force_reporter.{h,cu}`
- `src/backends/cuda/finite_element/finite_element_external_force_manager.{h,cu}`
- `src/backends/cuda/finite_element/finite_element_external_vertex_force.cu`
- `src/pybind/pyuipc/constitution/finite_element_external_force.{h,cpp}`
- `apps/tests/sim_case/45_finite_element_external_vertex_force.cpp`

### Modified Files
- `FiniteElementMethod`: added `vertex_external_forces` / `vertex_external_force_accs` buffers + friend declaration
- `FEMTimeIntegrator::BaseInfo`: exposed `external_force_accs()` accessor
- `FEMBDF1Integrator` / `FEMBDF2Integrator`: incorporate external force accelerations into `x_tilde`
- `pybind/constitution/module.cpp`: register `PyFiniteElementExternalForce`
