### PR TITLE
refactor(core): replace frontend UIPC_ASSERT with exception-throwing UIPC_ASSERT_THROW

### DIFF
--- a/include/uipc/backend/buffer_view.h
+++ b/include/uipc/backend/buffer_view.h
@@ -16,7 +16,7 @@ class UIPC_CORE_API BufferView
                SizeT            element_count,
                SizeT            element_size,
                SizeT            element_stride,
-               std::string_view backend_name) noexcept;
+               std::string_view backend_name);
 
     HandleT          handle() const noexcept;
     SizeT            offset() const noexcept;
@@ -27,7 +27,7 @@ class UIPC_CORE_API BufferView
     std::string_view backend() const noexcept;
     operator bool() const noexcept;
 
-    BufferView subview(SizeT offset, SizeT element_count) const noexcept;
+    BufferView subview(SizeT offset, SizeT element_count) const;
 
   private:
     HandleT m_handle = 0;

--- a/include/uipc/backend/visitors/scene_visitor.h
+++ b/include/uipc/backend/visitors/scene_visitor.h
@@ -33,7 +33,7 @@ class UIPC_CORE_API SceneVisitor
     SceneVisitor& operator=(SceneVisitor&&)      = delete;
 
     void begin_pending() noexcept;
-    void solve_pending() noexcept;
+    void solve_pending();
     bool is_pending() const noexcept;
 
     span<S<geometry::GeometrySlot>> geometries() const noexcept;

--- a/include/uipc/common/log.h
+++ b/include/uipc/common/log.h
@@ -3,6 +3,7 @@
 #include <uipc/common/string.h>
 #include <uipc/common/config.h>
 #include <uipc/common/abort.h>
+#include <uipc/common/exception.h>
 
 #define UIPC_LOG_WITH_LOCATION(level, ...)                                     \
     do                                                                         \
@@ -32,3 +33,15 @@
             ::uipc::abort();                                                                      \
         }                                                                                         \
     } while(0);
+
+#define UIPC_ASSERT_THROW(condition, ...)                                          \
+    do                                                                             \
+    {                                                                              \
+        if(!(condition))                                                           \
+        {                                                                          \
+            ::uipc::string msg = ::fmt::format(__VA_ARGS__);                       \
+            throw ::uipc::Exception(                                               \
+                ::fmt::format("Assertion " #condition " failed. {} {}({})",        \
+                              msg, __FILE__, __LINE__));                            \
+        }                                                                          \
+    } while(0)

--- a/include/uipc/core/animator.h
+++ b/include/uipc/core/animator.h
@@ -20,7 +20,7 @@ class Scene;
 class UIPC_CORE_API Animator
 {
   public:
-    void  substep(SizeT n) noexcept;
+    void  substep(SizeT n);
     SizeT substep() const noexcept;
     SizeT animation_count() const noexcept;
     bool  has_animation(IndexT id) const noexcept;

--- a/include/uipc/core/details/object.inl
+++ b/include/uipc/core/details/object.inl
@@ -7,7 +7,7 @@ ObjectGeometrySlots<GeometryT> Object::Geometries::create(const GeometryT& geome
 {
     m_object.m_geometry_ids.push_back(m_object.geometry_collection().next_id());
 
-    UIPC_ASSERT(m_object.geometry_collection().next_id()
+    UIPC_ASSERT_THROW(m_object.geometry_collection().next_id()
                     == m_object.rest_geometry_collection().next_id(),
                 "Geometry sim_systems element count ({}) is not equal to rest geometry sim_systems element count ({}), why?",
                 m_object.geometry_collection().size(),

--- a/include/uipc/core/internal/scene.h
+++ b/include/uipc/core/internal/scene.h
@@ -32,7 +32,7 @@ class UIPC_CORE_API Scene : public std::enable_shared_from_this<Scene>
 
     void init(internal::World& world) noexcept;
     void begin_pending() noexcept;
-    void solve_pending() noexcept;
+    void solve_pending();
 
 
     // IO
@@ -43,7 +43,7 @@ class UIPC_CORE_API Scene : public std::enable_shared_from_this<Scene>
 
     auto& config() const noexcept { return m_config; }
     auto& config() noexcept { return m_config; }
-    Float dt() const noexcept;
+    Float dt() const;
     bool  is_started() const noexcept { return m_started; }
     bool  is_pending() const noexcept { return m_pending; }
     auto& contact_tabular() const noexcept { return m_contact_tabular; }

--- a/include/uipc/geometry/attribute.h
+++ b/include/uipc/geometry/attribute.h
@@ -33,9 +33,9 @@ class UIPC_CORE_API IAttribute
 
     [[nodiscard]] Json to_json() const noexcept;
 
-    void from_json(const Json& j) noexcept;
+    void from_json(const Json& j);
 
-    void from_json_array(const Json& j) noexcept;
+    void from_json_array(const Json& j);
     /**
      * @brief Get the type name of data stored in the attribute slot.
      */
@@ -51,7 +51,7 @@ class UIPC_CORE_API IAttribute
     S<IAttribute> clone_empty() const;
     void          clear();
     void          reorder(span<const SizeT> O) noexcept;
-    void copy_from(const IAttribute& other, const AttributeCopy& copy) noexcept;
+    void copy_from(const IAttribute& other, const AttributeCopy& copy);
 
   protected:
     virtual SizeT            get_size() const               = 0;
@@ -63,14 +63,14 @@ class UIPC_CORE_API IAttribute
     virtual S<IAttribute> do_clone() const                         = 0;
     virtual S<IAttribute> do_clone_empty() const                   = 0;
     virtual void          do_reorder(span<const SizeT> O) noexcept = 0;
-    virtual void do_copy_from(const IAttribute& other, const AttributeCopy& copy) noexcept = 0;
+    virtual void do_copy_from(const IAttribute& other, const AttributeCopy& copy) = 0;
 
 
     virtual Json do_to_json(SizeT i) const noexcept = 0;
     virtual Json do_to_json() const noexcept        = 0;
 
-    virtual void do_from_json(const Json& j) noexcept       = 0;
-    virtual void do_from_json_array(const Json& j) noexcept = 0;
+    virtual void do_from_json(const Json& j)       = 0;
+    virtual void do_from_json_array(const Json& j) = 0;
 };
 
 template <typename T>
@@ -112,13 +112,13 @@ class Attribute : public IAttribute
     virtual S<IAttribute> do_clone() const override;
     virtual S<IAttribute> do_clone_empty() const override;
     virtual void          do_reorder(span<const SizeT> O) noexcept override;
-    virtual void do_copy_from(const IAttribute& other, const AttributeCopy& copy) noexcept override;
+    virtual void do_copy_from(const IAttribute& other, const AttributeCopy& copy) override;
 
     virtual Json do_to_json(SizeT i) const noexcept override;
     virtual Json do_to_json() const noexcept override;
 
-    virtual void do_from_json(const Json& j) noexcept override;
-    virtual void do_from_json_array(const Json& j) noexcept override;
+    virtual void do_from_json(const Json& j) override;
+    virtual void do_from_json_array(const Json& j) override;
 
   private:
     vector<T> m_values;

--- a/include/uipc/geometry/attribute_copy.h
+++ b/include/uipc/geometry/attribute_copy.h
@@ -66,7 +66,7 @@ class UIPC_CORE_API AttributeCopy
     span<const std::pair<SizeT, SizeT>> m_pairs;
 
     template <typename T>
-    void copy(span<T> dst, span<const T> src) const noexcept;
+    void copy(span<T> dst, span<const T> src) const;
 };
 }  // namespace uipc::geometry
 

--- a/include/uipc/geometry/attribute_slot.h
+++ b/include/uipc/geometry/attribute_slot.h
@@ -60,7 +60,7 @@ class UIPC_CORE_API IAttributeSlot
 
     [[nodiscard]] Json to_json(SizeT i) const;
 
-    void from_json_array(const Json& j) noexcept;
+    void from_json_array(const Json& j);
 
     [[nodiscard]] bool is_evolving() const noexcept;
     void               is_evolving(bool v) noexcept;

--- a/include/uipc/geometry/details/attribute.inl
+++ b/include/uipc/geometry/details/attribute.inl
@@ -75,7 +75,7 @@ void Attribute<T>::do_reorder(span<const SizeT> O) noexcept
 }
 
 template <typename T>
-void Attribute<T>::do_copy_from(const IAttribute& other, const AttributeCopy& copy) noexcept
+void Attribute<T>::do_copy_from(const IAttribute& other, const AttributeCopy& copy)
 {
     auto& other_attr = static_cast<const Attribute<T>&>(other);
     copy.template copy<T>(m_values, other_attr.m_values);
@@ -115,9 +115,9 @@ Json Attribute<T>::do_to_json() const noexcept
 }
 
 template <typename T>
-void Attribute<T>::do_from_json_array(const Json& j) noexcept
+void Attribute<T>::do_from_json_array(const Json& j)
 {
-    UIPC_ASSERT(j.is_array(), "To create an Attribute from json array, this json must be an array");
+    UIPC_ASSERT_THROW(j.is_array(), "To create an Attribute from json array, this json must be an array");
     try
     {
         m_values = j.get<vector<T>>();
@@ -130,9 +130,9 @@ void Attribute<T>::do_from_json_array(const Json& j) noexcept
 }
 
 template <typename T>
-void Attribute<T>::do_from_json(const Json& j) noexcept
+void Attribute<T>::do_from_json(const Json& j)
 {
-    UIPC_ASSERT(j.is_object(), "To create an Attribute, this json must be an object");
+    UIPC_ASSERT_THROW(j.is_object(), "To create an Attribute, this json must be an object");
 
     auto values_it = j.find("values");
     if(values_it == j.end())

--- a/include/uipc/geometry/details/attribute_copy.inl
+++ b/include/uipc/geometry/details/attribute_copy.inl
@@ -3,7 +3,7 @@
 namespace uipc::geometry
 {
 template <typename T>
-void AttributeCopy::copy(span<T> dst, span<const T> src) const noexcept
+void AttributeCopy::copy(span<T> dst, span<const T> src) const
 {
     switch(m_type)
     {
@@ -12,7 +12,7 @@ void AttributeCopy::copy(span<T> dst, span<const T> src) const noexcept
         }
         break;
         case uipc::geometry::AttributeCopy::SameDim: {
-            UIPC_ASSERT(src.size() == dst.size(),
+            UIPC_ASSERT_THROW(src.size() == dst.size(),
                         "Attribute size mismatch, dst is {}, src is {}.",
                         dst.size(),
                         src.size());
@@ -27,7 +27,7 @@ void AttributeCopy::copy(span<T> dst, span<const T> src) const noexcept
         break;
         case uipc::geometry::AttributeCopy::Pull: {
             auto pull_mapping = m_mapping;
-            UIPC_ASSERT(pull_mapping.size() == dst.size(),
+            UIPC_ASSERT_THROW(pull_mapping.size() == dst.size(),
                         "Pull mapping size mismatch, dst size is {}, mapper size is {}",
                         dst.size(),
                         pull_mapping.size());
@@ -39,7 +39,7 @@ void AttributeCopy::copy(span<T> dst, span<const T> src) const noexcept
         break;
         case uipc::geometry::AttributeCopy::Push: {
             auto push_mapping = m_mapping;
-            UIPC_ASSERT(push_mapping.size() == src.size(),
+            UIPC_ASSERT_THROW(push_mapping.size() == src.size(),
                         "Push mapping size mismatch, src size is {}, mapper size is {}",
                         src.size(),
                         push_mapping.size());
@@ -57,7 +57,7 @@ void AttributeCopy::copy(span<T> dst, span<const T> src) const noexcept
         }
         break;
         default:
-            UIPC_ASSERT(false, "Invalid attribute copy type");
+            UIPC_ASSERT_THROW(false, "Invalid attribute copy type");
             break;
     }
 }

--- a/include/uipc/geometry/geometry_collection.h
+++ b/include/uipc/geometry/geometry_collection.h
@@ -69,7 +69,7 @@ class UIPC_CORE_API GeometryCollection : public IGeometryCollection
     void pending_destroy(IndexT id) noexcept;
 
 
-    void solve_pending() noexcept;
+    void solve_pending();
 
     span<S<geometry::GeometrySlot>> geometry_slots() const noexcept;
     span<S<geometry::GeometrySlot>> pending_create_slots() const noexcept;

--- a/include/uipc/geometry/utils/simplex_utils.h
+++ b/include/uipc/geometry/utils/simplex_utils.h
@@ -17,6 +17,6 @@ class UIPC_GEOMETRY_API SimplexUtils
     static bool compare_tri(const Vector3i&, const Vector3i&) noexcept;
     static bool compare_tet(const Vector4i&, const Vector4i&) noexcept;
 
-    static void outward_tri_from_tet(span<const Vector3, 4> Vs, span<Vector3i, 4> Fs) noexcept;
+    static void outward_tri_from_tet(span<const Vector3, 4> Vs, span<Vector3i, 4> Fs);
 };
 }  // namespace uipc::geometry

--- a/src/constitution/affine_body_constitution.cpp
+++ b/src/constitution/affine_body_constitution.cpp
@@ -90,7 +90,7 @@ void AffineBodyConstitution::create_abd_attributes(geometry::SimplicialComplex& 
     auto kappa_view = geometry::view(*kappa_attr);
     std::ranges::fill(kappa_view, kappa);
 
-    UIPC_ASSERT(volume > 0,
+    UIPC_ASSERT_THROW(volume > 0,
                 "Volume of the mesh is non-positive ({}), which is not allowed.",
                 volume);
 

--- a/src/constitution/affine_body_driving_prismatic_joint.cpp
+++ b/src/constitution/affine_body_driving_prismatic_joint.cpp
@@ -37,13 +37,13 @@ void AffineBodyDrivingPrismaticJoint::apply_to(geometry::SimplicialComplex& sc, 
 void AffineBodyDrivingPrismaticJoint::apply_to(geometry::SimplicialComplex& sc,
                                                span<Float> strength_ratio)
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "AffineBodyDrivingPrismaticJoint can only be applied to 1D simplicial complex (linemesh), "
                 "but got {}D",
                 sc.dim());
 
     auto size = sc.edges().size();
-    UIPC_ASSERT(strength_ratio.size() == size,
+    UIPC_ASSERT_THROW(strength_ratio.size() == size,
                 "Strength ratio size mismatch: expected {}, got {}",
                 size,
                 strength_ratio.size());
@@ -51,7 +51,7 @@ void AffineBodyDrivingPrismaticJoint::apply_to(geometry::SimplicialComplex& sc,
     Base::apply_to(sc);
 
     auto uid = sc.meta().find<U64>(builtin::constitution_uid);
-    UIPC_ASSERT(uid && uid->view()[0] == 20,  // UID of AffineBodyPrismaticJoint
+    UIPC_ASSERT_THROW(uid && uid->view()[0] == 20,  // UID of AffineBodyPrismaticJoint
                 "Simplicial complex does not have constitution uid. "
                 "Please apply an AffineBodyPrismaticJoint before applying AffineBodyDrivingPrismaticJoint");
 

--- a/src/constitution/affine_body_driving_revolute_joint.cpp
+++ b/src/constitution/affine_body_driving_revolute_joint.cpp
@@ -34,20 +34,20 @@ void AffineBodyDrivingRevoluteJoint::apply_to(geometry::SimplicialComplex& sc, F
 void AffineBodyDrivingRevoluteJoint::apply_to(geometry::SimplicialComplex& sc,
                                               span<Float> strength_ratio)
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "AffineBodyDrivingRevoluteJoint can only be applied to 1D simplicial complex (linemesh), "
                 "but got {}D",
                 sc.dim());
 
     auto size = sc.edges().size();
-    UIPC_ASSERT(strength_ratio.size() == size,
+    UIPC_ASSERT_THROW(strength_ratio.size() == size,
                 "Strength ratio size mismatch: expected {}, got {}",
                 size,
                 strength_ratio.size());
     Base::apply_to(sc);
 
     auto uid = sc.meta().find<U64>(builtin::constitution_uid);
-    UIPC_ASSERT(uid && uid->view()[0] == 18,  // UID of AffineBodyRevoluteJoint
+    UIPC_ASSERT_THROW(uid && uid->view()[0] == 18,  // UID of AffineBodyRevoluteJoint
                 "Simplicial complex does not have constitution uid. "
                 "Please apply an AffineBodyRevoluteJoint before applying AffineBodyDrivingRevoluteJoint");
 

--- a/src/constitution/affine_body_fixed_joint.cpp
+++ b/src/constitution/affine_body_fixed_joint.cpp
@@ -39,11 +39,11 @@ geometry::SimplicialComplex AffineBodyFixedJoint::create_geometry(
     span<Float>                              strength_ratios)
 {
     auto N = l_geo_slots.size();
-    UIPC_ASSERT(N == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(N == r_geo_slots.size(),
                 "l_geo_slots({}) vs r_geo_slots({}) size mismatch",
                 N,
                 r_geo_slots.size());
-    UIPC_ASSERT(N == l_instance_ids.size(),
+    UIPC_ASSERT_THROW(N == l_instance_ids.size(),
                 "l_geo_slots({}) vs l_instance_ids({}) size mismatch",
                 N,
                 l_instance_ids.size());
@@ -77,7 +77,7 @@ geometry::SimplicialComplex AffineBodyFixedJoint::create_geometry(
     span<Float>                              strength_ratios)
 {
     auto N = l_positions.size();
-    UIPC_ASSERT(N == r_positions.size(),
+    UIPC_ASSERT_THROW(N == r_positions.size(),
                 "l_positions({}) vs r_positions({}) size mismatch",
                 N,
                 r_positions.size());
@@ -106,7 +106,7 @@ void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
                                     Float strength_ratio)
 {
     auto size = l_geo_slots.size();
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "The number of left geo slots ({}) does not match the number of right geo slots ({})",
                 l_geo_slots.size(),
                 r_geo_slots.size());
@@ -131,19 +131,19 @@ void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
                                     span<Float>  strength_ratios)
 {
     auto size = l_geo_slots.size();
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "Size mismatch: l_geo_slots({}) vs r_geo_slots({})",
                 l_geo_slots.size(),
                 r_geo_slots.size());
-    UIPC_ASSERT(size == l_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == l_instance_ids.size(),
                 "Size mismatch: l_geo_slots({}) vs l_instance_ids({})",
                 l_geo_slots.size(),
                 l_instance_ids.size());
-    UIPC_ASSERT(size == r_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == r_instance_ids.size(),
                 "Size mismatch: r_geo_slots({}) vs r_instance_ids({})",
                 r_geo_slots.size(),
                 r_instance_ids.size());
-    UIPC_ASSERT(size == strength_ratios.size(),
+    UIPC_ASSERT_THROW(size == strength_ratios.size(),
                 "Size mismatch: l_geo_slots({}) vs strength_ratios({})",
                 l_geo_slots.size(),
                 strength_ratios.size());
@@ -189,13 +189,13 @@ void AffineBodyFixedJoint::apply_to(geometry::SimplicialComplex& sc,
         auto l_inst = l_instance_ids[i];
         auto r_inst = r_instance_ids[i];
 
-        UIPC_ASSERT(l_inst >= 0
+        UIPC_ASSERT_THROW(l_inst >= 0
                         && l_inst < static_cast<IndexT>(
                                l_slot->geometry().instances().size()),
                     "Left instance ID {} is out of range [0, {})",
                     l_inst,
                     l_slot->geometry().instances().size());
-        UIPC_ASSERT(r_inst >= 0
+        UIPC_ASSERT_THROW(r_inst >= 0
                         && r_inst < static_cast<IndexT>(
                                r_slot->geometry().instances().size()),
                     "Right instance ID {} is out of range [0, {})",

--- a/src/constitution/affine_body_prismatic_joint.cpp
+++ b/src/constitution/affine_body_prismatic_joint.cpp
@@ -41,7 +41,7 @@ geometry::SimplicialComplex AffineBodyPrismaticJoint::create_geometry(
     span<Float>                              strength_ratios)
 {
     auto N = position0s.size();
-    UIPC_ASSERT(N == position1s.size(),
+    UIPC_ASSERT_THROW(N == position1s.size(),
                 "position0s({}) vs position1s({}) size mismatch",
                 N,
                 position1s.size());
@@ -77,15 +77,15 @@ geometry::SimplicialComplex AffineBodyPrismaticJoint::create_geometry(
     span<Float>                              strength_ratios)
 {
     auto N = l_position0.size();
-    UIPC_ASSERT(N == l_position1.size(),
+    UIPC_ASSERT_THROW(N == l_position1.size(),
                 "l_position0({}) vs l_position1({}) size mismatch",
                 N,
                 l_position1.size());
-    UIPC_ASSERT(N == r_position0.size(),
+    UIPC_ASSERT_THROW(N == r_position0.size(),
                 "l_position0({}) vs r_position0({}) size mismatch",
                 N,
                 r_position0.size());
-    UIPC_ASSERT(N == r_position1.size(),
+    UIPC_ASSERT_THROW(N == r_position1.size(),
                 "l_position0({}) vs r_position1({}) size mismatch",
                 N,
                 r_position1.size());
@@ -125,11 +125,11 @@ void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
                                         Float strength_ratio)
 {
     auto size = edges.edges().size();
-    UIPC_ASSERT(size == l_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == l_geo_slots.size(),
                 "The number of edges ({}) does not match the number of left geo slots ({})",
                 size,
                 l_geo_slots.size());
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "The number of edges ({}) does not match the number of right geo slots ({})",
                 size,
                 r_geo_slots.size());
@@ -155,23 +155,23 @@ void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
                                         span<Float>  strength_ratios)
 {
     auto size = edges.edges().size();
-    UIPC_ASSERT(size == l_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == l_geo_slots.size(),
                 "The number of edges ({}) does not match the number of left geo slots ({})",
                 size,
                 l_geo_slots.size());
-    UIPC_ASSERT(size == l_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == l_instance_ids.size(),
                 "The number of edges ({}) does not match the number of left instance IDs ({})",
                 size,
                 l_instance_ids.size());
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "The number of edges ({}) does not match the number of right geo slots ({})",
                 size,
                 r_geo_slots.size());
-    UIPC_ASSERT(size == r_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == r_instance_ids.size(),
                 "The number of edges ({}) does not match the number of right instance IDs ({})",
                 size,
                 r_instance_ids.size());
-    UIPC_ASSERT(size == strength_ratios.size(),
+    UIPC_ASSERT_THROW(size == strength_ratios.size(),
                 "The number of edges ({}) does not match the number of strength ratios ({})",
                 size,
                 strength_ratios.size());
@@ -233,13 +233,13 @@ void AffineBodyPrismaticJoint::apply_to(geometry::SimplicialComplex& edges,
         auto l_inst = l_instance_ids[i];
         auto r_inst = r_instance_ids[i];
 
-        UIPC_ASSERT(l_inst >= 0
+        UIPC_ASSERT_THROW(l_inst >= 0
                         && l_inst < static_cast<IndexT>(
                                l_slot->geometry().instances().size()),
                     "Left instance ID {} is out of range [0, {})",
                     l_inst,
                     l_slot->geometry().instances().size());
-        UIPC_ASSERT(r_inst >= 0
+        UIPC_ASSERT_THROW(r_inst >= 0
                         && r_inst < static_cast<IndexT>(
                                r_slot->geometry().instances().size()),
                     "Right instance ID {} is out of range [0, {})",

--- a/src/constitution/affine_body_prismatic_joint_external_force.cpp
+++ b/src/constitution/affine_body_prismatic_joint_external_force.cpp
@@ -36,13 +36,13 @@ void AffineBodyPrismaticJointExternalForce::apply_to(geometry::SimplicialComplex
 void AffineBodyPrismaticJointExternalForce::apply_to(geometry::SimplicialComplex& sc,
                                                           span<Float> forces)
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "AffineBodyPrismaticJointExternalForce can only be applied to 1D simplicial complex (linemesh), "
                 "but got {}D",
                 sc.dim());
 
     auto size = sc.edges().size();
-    UIPC_ASSERT(forces.size() == size,
+    UIPC_ASSERT_THROW(forces.size() == size,
                 "Forces size mismatch: expected {}, got {}",
                 size,
                 forces.size());
@@ -50,7 +50,7 @@ void AffineBodyPrismaticJointExternalForce::apply_to(geometry::SimplicialComplex
     Base::apply_to(sc);
 
     auto uid = sc.meta().find<U64>(builtin::constitution_uid);
-    UIPC_ASSERT(uid && uid->view()[0] == 20,  // UID of AffineBodyPrismaticJoint
+    UIPC_ASSERT_THROW(uid && uid->view()[0] == 20,  // UID of AffineBodyPrismaticJoint
                 "Simplicial complex does not have constitution uid 20. "
                 "Please apply an AffineBodyPrismaticJoint before applying AffineBodyPrismaticJointExternalForce");
 

--- a/src/constitution/affine_body_prismatic_joint_limit.cpp
+++ b/src/constitution/affine_body_prismatic_joint_limit.cpp
@@ -53,34 +53,34 @@ void AffineBodyPrismaticJointLimit::apply_to(geometry::SimplicialComplex& sc,
                                              span<Float> uppers,
                                              span<Float> strengths)
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "AffineBodyPrismaticJointLimit can only be applied to 1D simplicial complex (linemesh), but got {}D",
                 sc.dim());
 
     auto base_uid = sc.meta().find<U64>(builtin::constitution_uid);
-    UIPC_ASSERT(base_uid, "AffineBodyPrismaticJointLimit requires `meta.constitution_uid` on joint mesh");
-    UIPC_ASSERT(base_uid->view()[0] == PrismaticJointUID,
+    UIPC_ASSERT_THROW(base_uid, "AffineBodyPrismaticJointLimit requires `meta.constitution_uid` on joint mesh");
+    UIPC_ASSERT_THROW(base_uid->view()[0] == PrismaticJointUID,
                 "AffineBodyPrismaticJointLimit must be applied on a prismatic joint mesh with constitution UID={}, but got {}",
                 PrismaticJointUID,
                 base_uid->view()[0]);
 
     auto edge_count = sc.edges().size();
-    UIPC_ASSERT(lowers.size() == edge_count,
+    UIPC_ASSERT_THROW(lowers.size() == edge_count,
                 "Lower limit size mismatch: expected {}, got {}",
                 edge_count,
                 lowers.size());
-    UIPC_ASSERT(uppers.size() == edge_count,
+    UIPC_ASSERT_THROW(uppers.size() == edge_count,
                 "Upper limit size mismatch: expected {}, got {}",
                 edge_count,
                 uppers.size());
-    UIPC_ASSERT(strengths.size() == edge_count,
+    UIPC_ASSERT_THROW(strengths.size() == edge_count,
                 "Strength size mismatch: expected {}, got {}",
                 edge_count,
                 strengths.size());
 
     for(auto&& [i, l] : enumerate(lowers))
     {
-        UIPC_ASSERT(l <= uppers[i],
+        UIPC_ASSERT_THROW(l <= uppers[i],
                     "Invalid limit range at edge {}: lower ({}) must be <= upper ({})",
                     i,
                     l,

--- a/src/constitution/affine_body_revolute_joint.cpp
+++ b/src/constitution/affine_body_revolute_joint.cpp
@@ -41,7 +41,7 @@ geometry::SimplicialComplex AffineBodyRevoluteJoint::create_geometry(
     span<Float>                              strength_ratios)
 {
     auto N = position0s.size();
-    UIPC_ASSERT(N == position1s.size(),
+    UIPC_ASSERT_THROW(N == position1s.size(),
                 "position0s({}) vs position1s({}) size mismatch",
                 N,
                 position1s.size());
@@ -77,15 +77,15 @@ geometry::SimplicialComplex AffineBodyRevoluteJoint::create_geometry(
     span<Float>                              strength_ratios)
 {
     auto N = l_position0.size();
-    UIPC_ASSERT(N == l_position1.size(),
+    UIPC_ASSERT_THROW(N == l_position1.size(),
                 "l_position0({}) vs l_position1({}) size mismatch",
                 N,
                 l_position1.size());
-    UIPC_ASSERT(N == r_position0.size(),
+    UIPC_ASSERT_THROW(N == r_position0.size(),
                 "l_position0({}) vs r_position0({}) size mismatch",
                 N,
                 r_position0.size());
-    UIPC_ASSERT(N == r_position1.size(),
+    UIPC_ASSERT_THROW(N == r_position1.size(),
                 "l_position0({}) vs r_position1({}) size mismatch",
                 N,
                 r_position1.size());
@@ -125,11 +125,11 @@ void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
                                        Float strength_ratio)
 {
     auto size = edges.edges().size();
-    UIPC_ASSERT(size == l_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == l_geo_slots.size(),
                 "The number of edges ({}) does not match the number of left geo slots ({})",
                 size,
                 l_geo_slots.size());
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "The number of edges ({}) does not match the number of right geo slots ({})",
                 size,
                 r_geo_slots.size());
@@ -155,23 +155,23 @@ void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
                                        span<Float>  strength_ratios)
 {
     auto size = edges.edges().size();
-    UIPC_ASSERT(size == l_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == l_geo_slots.size(),
                 "The number of edges ({}) does not match the number of left geo slots ({})",
                 size,
                 l_geo_slots.size());
-    UIPC_ASSERT(size == l_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == l_instance_ids.size(),
                 "The number of edges ({}) does not match the number of left instance IDs ({})",
                 size,
                 l_instance_ids.size());
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "The number of edges ({}) does not match the number of right geo slots ({})",
                 size,
                 r_geo_slots.size());
-    UIPC_ASSERT(size == r_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == r_instance_ids.size(),
                 "The number of edges ({}) does not match the number of right instance IDs ({})",
                 size,
                 r_instance_ids.size());
-    UIPC_ASSERT(size == strength_ratios.size(),
+    UIPC_ASSERT_THROW(size == strength_ratios.size(),
                 "The number of edges ({}) does not match the number of strength ratios ({})",
                 size,
                 strength_ratios.size());
@@ -233,13 +233,13 @@ void AffineBodyRevoluteJoint::apply_to(geometry::SimplicialComplex& edges,
         auto l_inst = l_instance_ids[i];
         auto r_inst = r_instance_ids[i];
 
-        UIPC_ASSERT(l_inst >= 0
+        UIPC_ASSERT_THROW(l_inst >= 0
                         && l_inst < static_cast<IndexT>(
                                l_slot->geometry().instances().size()),
                     "Left instance ID {} is out of range [0, {})",
                     l_inst,
                     l_slot->geometry().instances().size());
-        UIPC_ASSERT(r_inst >= 0
+        UIPC_ASSERT_THROW(r_inst >= 0
                         && r_inst < static_cast<IndexT>(
                                r_slot->geometry().instances().size()),
                     "Right instance ID {} is out of range [0, {})",

--- a/src/constitution/affine_body_revolute_joint_external_force.cpp
+++ b/src/constitution/affine_body_revolute_joint_external_force.cpp
@@ -36,13 +36,13 @@ void AffineBodyRevoluteJointExternalForce::apply_to(geometry::SimplicialComplex&
 void AffineBodyRevoluteJointExternalForce::apply_to(geometry::SimplicialComplex& sc,
                                                          span<Float> torques)
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "AffineBodyRevoluteJointExternalForce can only be applied to 1D simplicial complex (linemesh), "
                 "but got {}D",
                 sc.dim());
 
     auto size = sc.edges().size();
-    UIPC_ASSERT(torques.size() == size,
+    UIPC_ASSERT_THROW(torques.size() == size,
                 "Torques size mismatch: expected {}, got {}",
                 size,
                 torques.size());
@@ -50,7 +50,7 @@ void AffineBodyRevoluteJointExternalForce::apply_to(geometry::SimplicialComplex&
     Base::apply_to(sc);
 
     auto uid = sc.meta().find<U64>(builtin::constitution_uid);
-    UIPC_ASSERT(uid && uid->view()[0] == 18,  // UID of AffineBodyRevoluteJoint
+    UIPC_ASSERT_THROW(uid && uid->view()[0] == 18,  // UID of AffineBodyRevoluteJoint
                 "Simplicial complex does not have constitution uid 18. "
                 "Please apply an AffineBodyRevoluteJoint before applying AffineBodyRevoluteJointExternalForce");
 

--- a/src/constitution/affine_body_revolute_joint_limit.cpp
+++ b/src/constitution/affine_body_revolute_joint_limit.cpp
@@ -53,34 +53,34 @@ void AffineBodyRevoluteJointLimit::apply_to(geometry::SimplicialComplex& sc,
                                             span<Float>                  uppers,
                                             span<Float> strengths)
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "AffineBodyRevoluteJointLimit can only be applied to 1D simplicial complex (linemesh), but got {}D",
                 sc.dim());
 
     auto base_uid = sc.meta().find<U64>(builtin::constitution_uid);
-    UIPC_ASSERT(base_uid, "AffineBodyRevoluteJointLimit requires `meta.constitution_uid` on joint mesh");
-    UIPC_ASSERT(base_uid->view()[0] == RevoluteJointUID,
+    UIPC_ASSERT_THROW(base_uid, "AffineBodyRevoluteJointLimit requires `meta.constitution_uid` on joint mesh");
+    UIPC_ASSERT_THROW(base_uid->view()[0] == RevoluteJointUID,
                 "AffineBodyRevoluteJointLimit must be applied on a revolute joint mesh with constitution UID={}, but got {}",
                 RevoluteJointUID,
                 base_uid->view()[0]);
 
     auto edge_count = sc.edges().size();
-    UIPC_ASSERT(lowers.size() == edge_count,
+    UIPC_ASSERT_THROW(lowers.size() == edge_count,
                 "Lower limit size mismatch: expected {}, got {}",
                 edge_count,
                 lowers.size());
-    UIPC_ASSERT(uppers.size() == edge_count,
+    UIPC_ASSERT_THROW(uppers.size() == edge_count,
                 "Upper limit size mismatch: expected {}, got {}",
                 edge_count,
                 uppers.size());
-    UIPC_ASSERT(strengths.size() == edge_count,
+    UIPC_ASSERT_THROW(strengths.size() == edge_count,
                 "Strength size mismatch: expected {}, got {}",
                 edge_count,
                 strengths.size());
 
     for(auto&& [i, l] : enumerate(lowers))
     {
-        UIPC_ASSERT(l <= uppers[i],
+        UIPC_ASSERT_THROW(l <= uppers[i],
                     "Invalid limit range at edge {}: lower ({}) must be <= upper ({})",
                     i,
                     l,

--- a/src/constitution/affine_body_rod.cpp
+++ b/src/constitution/affine_body_rod.cpp
@@ -15,7 +15,7 @@ void AffineBodyRod::apply_to(geometry::SimplicialComplex& sc,
                              Float                        mass_density,
                              Float                        thickness) const
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "AffineBodyRod requires a 1D simplicial complex (edge mesh), got dim={}.",
                 sc.dim());
 

--- a/src/constitution/affine_body_shell.cpp
+++ b/src/constitution/affine_body_shell.cpp
@@ -15,7 +15,7 @@ void AffineBodyShell::apply_to(geometry::SimplicialComplex& sc,
                                Float                        mass_density,
                                Float                        thickness) const
 {
-    UIPC_ASSERT(sc.dim() == 2,
+    UIPC_ASSERT_THROW(sc.dim() == 2,
                 "AffineBodyShell requires a 2D simplicial complex (triangle mesh), got dim={}.",
                 sc.dim());
 

--- a/src/constitution/affine_body_spherical_joint.cpp
+++ b/src/constitution/affine_body_spherical_joint.cpp
@@ -65,7 +65,7 @@ geometry::SimplicialComplex AffineBodySphericalJoint::create_geometry(
     span<Float>                              strength_ratios)
 {
     auto N = l_positions.size();
-    UIPC_ASSERT(N == r_positions.size(),
+    UIPC_ASSERT_THROW(N == r_positions.size(),
                 "l_positions({}) vs r_positions({}) size mismatch",
                 N,
                 r_positions.size());
@@ -94,7 +94,7 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
                                         Float         strength_ratio)
 {
     auto size = l_geo_slots.size();
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "The number of left geo slots ({}) does not match the number of right geo slots ({})",
                 l_geo_slots.size(),
                 r_geo_slots.size());
@@ -119,19 +119,19 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
                                         span<Float>   strength_ratios)
 {
     auto size = l_geo_slots.size();
-    UIPC_ASSERT(size == r_geo_slots.size(),
+    UIPC_ASSERT_THROW(size == r_geo_slots.size(),
                 "Size mismatch: l_geo_slots ({}) vs r_geo_slots ({})",
                 size,
                 r_geo_slots.size());
-    UIPC_ASSERT(size == l_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == l_instance_ids.size(),
                 "Size mismatch: l_geo_slots ({}) vs l_instance_ids ({})",
                 size,
                 l_instance_ids.size());
-    UIPC_ASSERT(size == r_instance_ids.size(),
+    UIPC_ASSERT_THROW(size == r_instance_ids.size(),
                 "Size mismatch: l_geo_slots ({}) vs r_instance_ids ({})",
                 size,
                 r_instance_ids.size());
-    UIPC_ASSERT(size == strength_ratios.size(),
+    UIPC_ASSERT_THROW(size == strength_ratios.size(),
                 "Size mismatch: l_geo_slots ({}) vs strength_ratios ({})",
                 size,
                 strength_ratios.size());
@@ -177,13 +177,13 @@ void AffineBodySphericalJoint::apply_to(geometry::SimplicialComplex& sc,
         auto l_inst = l_instance_ids[i];
         auto r_inst = r_instance_ids[i];
 
-        UIPC_ASSERT(l_inst >= 0
+        UIPC_ASSERT_THROW(l_inst >= 0
                         && l_inst < static_cast<IndexT>(
                                l_slot->geometry().instances().size()),
                     "Left instance ID {} is out of range [0, {})",
                     l_inst,
                     l_slot->geometry().instances().size());
-        UIPC_ASSERT(r_inst >= 0
+        UIPC_ASSERT_THROW(r_inst >= 0
                         && r_inst < static_cast<IndexT>(
                                r_slot->geometry().instances().size()),
                     "Right instance ID {} is out of range [0, {})",

--- a/src/constitution/arap.cpp
+++ b/src/constitution/arap.cpp
@@ -24,7 +24,7 @@ void ARAP::apply_to(geometry::SimplicialComplex& sc, Float kappa, Float mass_den
 {
     Base::apply_to(sc, mass_density);
 
-    UIPC_ASSERT(sc.dim() == 3, "Now ARAP only supports 3D simplicial complex");
+    UIPC_ASSERT_THROW(sc.dim() == 3, "Now ARAP only supports 3D simplicial complex");
 
     auto kappa_attr = sc.tetrahedra().find<Float>("kappa");
     if(!kappa_attr)

--- a/src/constitution/elastic_moduli.cpp
+++ b/src/constitution/elastic_moduli.cpp
@@ -22,7 +22,7 @@ ElasticModuli ElasticModuli::youngs_poisson(Float E, Float nu)
 {
     Float lambda, mu;
     EP_to_lame(E, nu, lambda, mu);
-    UIPC_ASSERT(abs(nu) != 0.5 && abs(nu) != 1.0,
+    UIPC_ASSERT_THROW(abs(nu) != 0.5 && abs(nu) != 1.0,
                 "Poission Rate ({}) can't be 0.5 or -1.0 in ElasticModuli",
                 nu);
     return ElasticModuli{lambda, mu};
@@ -51,7 +51,7 @@ ElasticModuli2D ElasticModuli2D::youngs_poisson(Float E, Float nu)
 {
     Float lambda, mu;
     EP_to_lame_2D(E, nu, lambda, mu);
-    UIPC_ASSERT(abs(nu) != 1.0, "Poission Rate ({}) can't be 1.0 or -1.0 in ElasticModuli 2D", nu);
+    UIPC_ASSERT_THROW(abs(nu) != 1.0, "Poission Rate ({}) can't be 1.0 or -1.0 in ElasticModuli 2D", nu);
     return ElasticModuli2D{lambda, mu};
 }
 

--- a/src/constitution/external_articulation_constraint.cpp
+++ b/src/constitution/external_articulation_constraint.cpp
@@ -53,7 +53,7 @@ geometry::Geometry ExternalArticulationConstraint::create_geometry(
 
     Base::apply_to(R);  // Fill Constraint UID
 
-    UIPC_ASSERT(joint_geos.size() == indices.size(),
+    UIPC_ASSERT_THROW(joint_geos.size() == indices.size(),
                 "Selected joints size must match joint geometry size.");
 
     auto n_joints = static_cast<IndexT>(joint_geos.size());

--- a/src/constitution/hookean_spring.cpp
+++ b/src/constitution/hookean_spring.cpp
@@ -31,7 +31,7 @@ void HookeanSpring::apply_to(geometry::SimplicialComplex& sc,
 {
     Base::apply_to(sc, mass_density, thickness);
 
-    UIPC_ASSERT(sc.dim() == 1, "HookeanSpring only supports 1D simplicial complex");
+    UIPC_ASSERT_THROW(sc.dim() == 1, "HookeanSpring only supports 1D simplicial complex");
 
     auto kappa_attr = sc.edges().find<Float>("kappa");
     if(!kappa_attr)

--- a/src/constitution/neo_hookean_shell.cpp
+++ b/src/constitution/neo_hookean_shell.cpp
@@ -30,7 +30,7 @@ void NeoHookeanShell::apply_to(geometry::SimplicialComplex& sc,
     auto mu     = moduli.mu();
     auto lambda = moduli.lambda();
 
-    UIPC_ASSERT(sc.dim() == 2, "NeoHookeanShell only supports 2D simplicial complex");
+    UIPC_ASSERT_THROW(sc.dim() == 2, "NeoHookeanShell only supports 2D simplicial complex");
 
     auto mu_attr = sc.triangles().find<Float>("mu");
     if(!mu_attr)

--- a/src/constitution/particle.cpp
+++ b/src/constitution/particle.cpp
@@ -24,7 +24,7 @@ void Particle::apply_to(geometry::SimplicialComplex& sc, Float mass_density, Flo
 {
     Base::apply_to(sc, mass_density, thickness);
 
-    UIPC_ASSERT(sc.dim() == 0, "Particle only supports 0D simplicial complex");
+    UIPC_ASSERT_THROW(sc.dim() == 0, "Particle only supports 0D simplicial complex");
 }
 
 Json Particle::default_config() noexcept

--- a/src/constitution/soft_transform_constraint.cpp
+++ b/src/constitution/soft_transform_constraint.cpp
@@ -108,19 +108,19 @@ Json RotatingMotor::default_config()
 void RotatingMotor::animate(geometry::SimplicialComplex& sc, Float dt)
 {
     auto motor_rot_axis = sc.instances().find<Vector3>("motor_rot_axis");
-    UIPC_ASSERT(motor_rot_axis, "`motor_rot_axis` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(motor_rot_axis, "`motor_rot_axis` is not found in the simplicial complex instances, why can it happen?");
     auto motor_rot_vel = sc.instances().find<Float>("motor_rot_vel");
-    UIPC_ASSERT(motor_rot_vel, "`motor_rot_vel` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(motor_rot_vel, "`motor_rot_vel` is not found in the simplicial complex instances, why can it happen?");
 
     auto motor_rot_axis_view = motor_rot_axis->view();
     auto motor_rot_vel_view  = motor_rot_vel->view();
 
     auto is_constrained = sc.instances().find<IndexT>(builtin::is_constrained);
-    UIPC_ASSERT(is_constrained, "`is_constrained` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(is_constrained, "`is_constrained` is not found in the simplicial complex instances, why can it happen?");
     auto is_constrained_view = is_constrained->view();
 
     auto aim_transform = sc.instances().find<Matrix4x4>(builtin::aim_transform);
-    UIPC_ASSERT(aim_transform, "`aim_transform` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(aim_transform, "`aim_transform` is not found in the simplicial complex instances, why can it happen?");
     auto aim_transform_view = geometry::view(*aim_transform);
 
     auto transform_view = sc.transforms().view();
@@ -200,19 +200,19 @@ Json LinearMotor::default_config()
 void LinearMotor::animate(geometry::SimplicialComplex& sc, Float dt)
 {
     auto motor_axis = sc.instances().find<Vector3>("motor_axis");
-    UIPC_ASSERT(motor_axis, "`motor_axis` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(motor_axis, "`motor_axis` is not found in the simplicial complex instances, why can it happen?");
     auto motor_vel = sc.instances().find<Float>("motor_vel");
-    UIPC_ASSERT(motor_vel, "`motor_vel` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(motor_vel, "`motor_vel` is not found in the simplicial complex instances, why can it happen?");
 
     auto motor_axis_view = motor_axis->view();
     auto motor_vel_view  = motor_vel->view();
 
     auto is_constrained = sc.instances().find<IndexT>(builtin::is_constrained);
-    UIPC_ASSERT(is_constrained, "`is_constrained` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(is_constrained, "`is_constrained` is not found in the simplicial complex instances, why can it happen?");
     auto is_constrained_view = is_constrained->view();
 
     auto aim_transform = sc.instances().find<Matrix4x4>(builtin::aim_transform);
-    UIPC_ASSERT(aim_transform, "`aim_transform` is not found in the simplicial complex instances, why can it happen?");
+    UIPC_ASSERT_THROW(aim_transform, "`aim_transform` is not found in the simplicial complex instances, why can it happen?");
     auto aim_transform_view = geometry::view(*aim_transform);
 
     auto transform_view = sc.transforms().view();

--- a/src/constitution/soft_vertex_edge_stitch.cpp
+++ b/src/constitution/soft_vertex_edge_stitch.cpp
@@ -58,7 +58,7 @@ geometry::Geometry SoftVertexEdgeStitch::create_geometry(const SlotTuple& aim_ge
                                                          Float min_separate_distance) const
 {
     auto topo_slot = pair_geometry.instances().find<Vector2i>(builtin::topo);
-    UIPC_ASSERT(topo_slot, "pair_geometry must have instances with topo (Vector2i) attribute");
+    UIPC_ASSERT_THROW(topo_slot, "pair_geometry must have instances with topo (Vector2i) attribute");
     auto topo_view = topo_slot->view();
     return create_geometry_impl(
         aim_geo_slots, rest_geo_slots, topo_view, moduli.mu(), moduli.lambda(), thickness, min_separate_distance);
@@ -80,10 +80,10 @@ static geometry::Geometry create_geometry_impl(const SoftVertexEdgeStitch::SlotT
     auto geo_ids = geo.meta().create<Vector2i>("geo_ids");
     {
         auto&& [l, r] = aim_geo_slots;
-        UIPC_ASSERT(l->geometry().instances().size() == 1,
+        UIPC_ASSERT_THROW(l->geometry().instances().size() == 1,
                     "stitch must have exactly one instance, found {} instances",
                     l->geometry().instances().size());
-        UIPC_ASSERT(r->geometry().instances().size() == 1,
+        UIPC_ASSERT_THROW(r->geometry().instances().size() == 1,
                     "stitch must have exactly one instance, found {} instances",
                     r->geometry().instances().size());
         view(*geo_ids)[0] = Vector2i{l->id(), r->id()};

--- a/src/constitution/soft_vertex_stitch.cpp
+++ b/src/constitution/soft_vertex_stitch.cpp
@@ -37,10 +37,10 @@ geometry::Geometry SoftVertexStitch::create_geometry(const SlotTuple& aim_geo_sl
     auto geo_ids = geo.meta().create<Vector2i>("geo_ids");
     {
         auto&& [l, r] = aim_geo_slots;
-        UIPC_ASSERT(l->geometry().instances().size() == 1,
+        UIPC_ASSERT_THROW(l->geometry().instances().size() == 1,
                     "stitch must have exactly one instance, found {} instances",
                     l->geometry().instances().size());
-        UIPC_ASSERT(r->geometry().instances().size() == 1,
+        UIPC_ASSERT_THROW(r->geometry().instances().size() == 1,
                     "Link must have exactly one instance, found {} instances",
                     r->geometry().instances().size());
         view(*geo_ids)[0] = Vector2i{l->id(), r->id()};
@@ -122,7 +122,7 @@ geometry::Geometry SoftVertexStitch::create_geometry(const SlotTuple& aim_geo_sl
         {
             auto v_id = v_id_pair[i];
 
-            UIPC_ASSERT(v_id >= 0 && v_id < this_geo.vertices().size(),
+            UIPC_ASSERT_THROW(v_id >= 0 && v_id < this_geo.vertices().size(),
                         "Stitched vertex id {} out of range [0, {}) in Geometry({}). Please check the stitched vertex ids and the geometry slots.\n",
                         v_id,
                         this_geo.vertices().size(),

--- a/src/constitution/soft_vertex_triangle_stitch.cpp
+++ b/src/constitution/soft_vertex_triangle_stitch.cpp
@@ -56,7 +56,7 @@ geometry::Geometry SoftVertexTriangleStitch::create_geometry(const SlotTuple& ai
                                                              Float min_separate_distance) const
 {
     auto topo_slot = pair_geometry.instances().find<Vector2i>(builtin::topo);
-    UIPC_ASSERT(topo_slot, "pair_geometry must have instances with topo (Vector2i) attribute");
+    UIPC_ASSERT_THROW(topo_slot, "pair_geometry must have instances with topo (Vector2i) attribute");
     auto topo_view = topo_slot->view();
     return create_geometry_impl(
         aim_geo_slots, rest_geo_slots, topo_view, moduli.mu(), moduli.lambda(), min_separate_distance);
@@ -78,10 +78,10 @@ static geometry::Geometry create_geometry_impl(const SoftVertexTriangleStitch::S
     auto geo_ids = geo.meta().create<Vector2i>("geo_ids");
     {
         auto&& [l, r] = aim_geo_slots;
-        UIPC_ASSERT(l->geometry().instances().size() == 1,
+        UIPC_ASSERT_THROW(l->geometry().instances().size() == 1,
                     "stitch must have exactly one instance, found {} instances",
                     l->geometry().instances().size());
-        UIPC_ASSERT(r->geometry().instances().size() == 1,
+        UIPC_ASSERT_THROW(r->geometry().instances().size() == 1,
                     "stitch must have exactly one instance, found {} instances",
                     r->geometry().instances().size());
         view(*geo_ids)[0] = Vector2i{l->id(), r->id()};

--- a/src/constitution/stable_neo_hookean.cpp
+++ b/src/constitution/stable_neo_hookean.cpp
@@ -34,7 +34,7 @@ void StableNeoHookean::apply_to(geometry::SimplicialComplex& sc,
     auto snh_mu = 4 * mu / 3;
     auto snh_lambda = lambda + 5 * mu / 6;
 
-    UIPC_ASSERT(sc.dim() == 3, "StableNeoHookean only supports 3D simplicial complex");
+    UIPC_ASSERT_THROW(sc.dim() == 3, "StableNeoHookean only supports 3D simplicial complex");
 
     auto mu_attr = sc.tetrahedra().find<Float>("mu");
     if(!mu_attr)

--- a/src/constitution/strain_limiting_baraff_witkin.cpp
+++ b/src/constitution/strain_limiting_baraff_witkin.cpp
@@ -32,7 +32,7 @@ void StrainLimitingBaraffWitkinShell::apply_to(geometry::SimplicialComplex& sc,
     auto lambda = moduli.lambda();
     auto mu     = moduli.mu();
 
-    UIPC_ASSERT(sc.dim() == 2, "StrainLimitingBaraffWitkinShell only supports 2D simplicial complex");
+    UIPC_ASSERT_THROW(sc.dim() == 2, "StrainLimitingBaraffWitkinShell only supports 2D simplicial complex");
 
     auto lambda_attr = sc.triangles().find<Float>("lambda");
     if(!lambda_attr)

--- a/src/constitution/strain_plastic_discrete_shell_bending.cpp
+++ b/src/constitution/strain_plastic_discrete_shell_bending.cpp
@@ -29,13 +29,13 @@ void StrainPlasticDiscreteShellBending::apply_to(geometry::SimplicialComplex& sc
                                            Float                        yield_threshold_v,
                                            Float                        hardening_modulus_v)
 {
-    UIPC_ASSERT(std::isfinite(bending_stiffness_v),
+    UIPC_ASSERT_THROW(std::isfinite(bending_stiffness_v),
                 "StrainPlasticDiscreteShellBending requires a finite bending_stiffness, got {}",
                 bending_stiffness_v);
-    UIPC_ASSERT(std::isfinite(yield_threshold_v) && yield_threshold_v >= 0.0,
+    UIPC_ASSERT_THROW(std::isfinite(yield_threshold_v) && yield_threshold_v >= 0.0,
                 "StrainPlasticDiscreteShellBending requires a finite yield_threshold >= 0, got {}",
                 yield_threshold_v);
-    UIPC_ASSERT(std::isfinite(hardening_modulus_v) && hardening_modulus_v >= 0.0,
+    UIPC_ASSERT_THROW(std::isfinite(hardening_modulus_v) && hardening_modulus_v >= 0.0,
                 "StrainPlasticDiscreteShellBending requires hardening_modulus to be finite and >= 0, got {}",
                 hardening_modulus_v);
 

--- a/src/constitution/stress_plastic_discrete_shell_bending.cpp
+++ b/src/constitution/stress_plastic_discrete_shell_bending.cpp
@@ -29,13 +29,13 @@ void StressPlasticDiscreteShellBending::apply_to(geometry::SimplicialComplex& sc
                                                  Float                        yield_stress_v,
                                                  Float hardening_modulus_v)
 {
-    UIPC_ASSERT(std::isfinite(bending_stiffness_v),
+    UIPC_ASSERT_THROW(std::isfinite(bending_stiffness_v),
                 "StressPlasticDiscreteShellBending requires a finite bending_stiffness, got {}",
                 bending_stiffness_v);
-    UIPC_ASSERT(std::isfinite(yield_stress_v) && yield_stress_v >= 0.0,
+    UIPC_ASSERT_THROW(std::isfinite(yield_stress_v) && yield_stress_v >= 0.0,
                 "StressPlasticDiscreteShellBending requires a finite yield_stress >= 0, got {}",
                 yield_stress_v);
-    UIPC_ASSERT(std::isfinite(hardening_modulus_v) && hardening_modulus_v >= 0.0,
+    UIPC_ASSERT_THROW(std::isfinite(hardening_modulus_v) && hardening_modulus_v >= 0.0,
                 "StressPlasticDiscreteShellBending requires hardening_modulus to be finite and >= 0, got {}",
                 hardening_modulus_v);
 

--- a/src/core/backend/buffer_view.cpp
+++ b/src/core/backend/buffer_view.cpp
@@ -11,7 +11,7 @@ BufferView::BufferView(HandleT          handle,
                        SizeT            size,
                        SizeT            element_size,
                        SizeT            element_stride,
-                       std::string_view backend_name) noexcept
+                       std::string_view backend_name)
     : m_handle(handle)
     , m_offset(offset)
     , m_size(size)
@@ -19,7 +19,7 @@ BufferView::BufferView(HandleT          handle,
     , m_element_stride(element_stride)
     , m_backend(m_backend_name_map[backend_name])
 {
-    UIPC_ASSERT(element_stride >= element_size,
+    UIPC_ASSERT_THROW(element_stride >= element_size,
                 "[{}]: Element stride({}) must be greater or equal to element size({}). ",
                 backend_name,
                 element_stride,
@@ -66,9 +66,9 @@ BufferView::operator bool() const noexcept
     return m_offset != INVALID;
 }
 
-BufferView BufferView::subview(SizeT offset, SizeT size) const noexcept
+BufferView BufferView::subview(SizeT offset, SizeT size) const
 {
-    UIPC_ASSERT(offset + size <= m_size,
+    UIPC_ASSERT_THROW(offset + size <= m_size,
                 "[{}]: Subview({},{}) out of bounds({}).",
                 m_backend,
                 offset,

--- a/src/core/backend/visitors/scene_visitor.cpp
+++ b/src/core/backend/visitors/scene_visitor.cpp
@@ -20,7 +20,7 @@ void SceneVisitor::begin_pending() noexcept
     m_scene.begin_pending();
 }
 
-void SceneVisitor::solve_pending() noexcept
+void SceneVisitor::solve_pending()
 {
     m_scene.solve_pending();
 }

--- a/src/core/builtin/constitution_uid_collection.cpp
+++ b/src/core/builtin/constitution_uid_collection.cpp
@@ -22,7 +22,7 @@ ConstitutionUIDCollection::ConstitutionUIDCollection()
 
         for(auto& uid : uid_infos)
         {
-            UIPC_ASSERT(!uid.type.empty(),
+            UIPC_ASSERT_THROW(!uid.type.empty(),
                         "ConstitutionUIDCollection: Constitution type is empty for UID: {}, creator: {}({})",
                         uid.uid,
                         creator_info.file,

--- a/src/core/builtin/implicit_geometry_uid_collection.cpp
+++ b/src/core/builtin/implicit_geometry_uid_collection.cpp
@@ -23,7 +23,7 @@ ImplicitGeometryUIDCollection::ImplicitGeometryUIDCollection()
 
         for(auto& uid : uid_infos)
         {
-            UIPC_ASSERT(!uid.type.empty(),
+            UIPC_ASSERT_THROW(!uid.type.empty(),
                         "ImplicitGeometryUIDCollection: ImplicitGeometry type is empty for UID: {}, creator: {}({})",
                         uid.uid,
                         creator_info.file,

--- a/src/core/builtin/uid_register.cpp
+++ b/src/core/builtin/uid_register.cpp
@@ -6,7 +6,7 @@ namespace uipc::builtin::details
 void UIDRegister::create(const UIDInfo& info, const CreatorInfo& creator)
 {
     auto it = m_uid_to_info.find(info.uid);
-    UIPC_ASSERT(it == m_uid_to_info.end(),
+    UIPC_ASSERT_THROW(it == m_uid_to_info.end(),
                 "UID {} already exists, name={}, yours UID {}, name={}, creator: {}({})",
                 it->second.uid,
                 it->second.name,
@@ -20,7 +20,7 @@ void UIDRegister::create(const UIDInfo& info, const CreatorInfo& creator)
 const UIDInfo& UIDRegister::find(U64 uid) const
 {
     auto it = m_uid_to_info.find(uid);
-    UIPC_ASSERT(it != m_uid_to_info.end(), "UID {} not found!", uid);
+    UIPC_ASSERT_THROW(it != m_uid_to_info.end(), "UID {} not found!", uid);
     return it->second;
 }
 

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -156,7 +156,7 @@ void GlobalTimer::set_as_current()
 {
     if(m_current)
     {
-        UIPC_ASSERT(m_current->m_timer_stack.size() == 1,
+        UIPC_ASSERT_THROW(m_current->m_timer_stack.size() == 1,
                     "The last GlobalTimer is not finished! Still {} Timer in the Timer Stack",
                     m_current->m_timer_stack.size());
     }
@@ -242,7 +242,7 @@ void GlobalTimer::clear()
         return names;
     };
 
-    UIPC_ASSERT(m_timer_stack.size() == 1,
+    UIPC_ASSERT_THROW(m_timer_stack.size() == 1,
                 "Are you calling clear() in the Timer Scope? Current stack:\n{}",
                 fmt::join(timer_names(), "\n"));
 

--- a/src/core/core/affine_body_state_accessor_feature.cpp
+++ b/src/core/core/affine_body_state_accessor_feature.cpp
@@ -27,7 +27,7 @@ geometry::SimplicialComplex AffineBodyStateAccessorFeatureOverrider::do_create_g
 AffineBodyStateAccessorFeature::AffineBodyStateAccessorFeature(S<AffineBodyStateAccessorFeatureOverrider> overrider)
     : m_impl(std::move(overrider))
 {
-    UIPC_ASSERT(m_impl, "AffineBodyStateAccessorFeatureOverrider must not be null.");
+    UIPC_ASSERT_THROW(m_impl, "AffineBodyStateAccessorFeatureOverrider must not be null.");
 }
 
 SizeT AffineBodyStateAccessorFeature::body_count() const
@@ -39,7 +39,7 @@ geometry::SimplicialComplex AffineBodyStateAccessorFeature::create_geometry(Inde
                                                                             SizeT body_count)
 {
     auto total_body_num = this->body_count();
-    UIPC_ASSERT(body_offset <= total_body_num,
+    UIPC_ASSERT_THROW(body_offset <= total_body_num,
                 "body_offset ({}) must not be larger than total body number ({})",
                 body_offset,
                 total_body_num);
@@ -65,7 +65,7 @@ void AffineBodyStateAccessorFeature::copy_transform_to(backend::BufferView buffe
                                                         SizeT               body_count) const
 {
     auto total_body_num = this->body_count();
-    UIPC_ASSERT(body_offset <= total_body_num,
+    UIPC_ASSERT_THROW(body_offset <= total_body_num,
                 "body_offset ({}) must not be larger than total body number ({})",
                 body_offset,
                 total_body_num);
@@ -73,7 +73,7 @@ void AffineBodyStateAccessorFeature::copy_transform_to(backend::BufferView buffe
     if(body_count == ~0ull)
         body_count = total_body_num - body_offset;
 
-    UIPC_ASSERT(body_offset + body_count <= total_body_num,
+    UIPC_ASSERT_THROW(body_offset + body_count <= total_body_num,
                 "The requested range [{}, {}) is out of bounds for total bodies ({})",
                 body_offset,
                 body_offset + body_count,
@@ -87,7 +87,7 @@ void AffineBodyStateAccessorFeature::copy_velocity_to(backend::BufferView buffer
                                                        SizeT               body_count) const
 {
     auto total_body_num = this->body_count();
-    UIPC_ASSERT(body_offset <= total_body_num,
+    UIPC_ASSERT_THROW(body_offset <= total_body_num,
                 "body_offset ({}) must not be larger than total body number ({})",
                 body_offset,
                 total_body_num);
@@ -95,7 +95,7 @@ void AffineBodyStateAccessorFeature::copy_velocity_to(backend::BufferView buffer
     if(body_count == ~0ull)
         body_count = total_body_num - body_offset;
 
-    UIPC_ASSERT(body_offset + body_count <= total_body_num,
+    UIPC_ASSERT_THROW(body_offset + body_count <= total_body_num,
                 "The requested range [{}, {}) is out of bounds for total bodies ({})",
                 body_offset,
                 body_offset + body_count,

--- a/src/core/core/animation.cpp
+++ b/src/core/core/animation.cpp
@@ -23,10 +23,10 @@ void Animation::init()
     for(auto id : geo_ids)
     {
         auto slot = scene.find_geometry(id);
-        UIPC_ASSERT(slot, "Animation: Geometry slot not found for id={}", id);
+        UIPC_ASSERT_THROW(slot, "Animation: Geometry slot not found for id={}", id);
         m_temp_geo_slots.push_back(slot);
         auto rest_slot = scene.find_rest_geometry(id);
-        UIPC_ASSERT(rest_slot, "Animation: Rest geometry slot not found for id={}", id);
+        UIPC_ASSERT_THROW(rest_slot, "Animation: Rest geometry slot not found for id={}", id);
         m_temp_rest_geo_slots.push_back(rest_slot);
     }
 }
@@ -60,7 +60,7 @@ span<S<geometry::GeometrySlot>> Animation::UpdateInfo::rest_geo_slots() const no
 SizeT Animation::UpdateInfo::frame() const noexcept
 {
     //auto s_world = m_animation->m_scene->world().lock();
-    //UIPC_ASSERT(s_world, "World is expired, did you throw the `World`?");
+    //UIPC_ASSERT_THROW(s_world, "World is expired, did you throw the `World`?");
     //return s_world->frame();
     return m_animation->m_scene->world()->frame();
 }

--- a/src/core/core/animator.cpp
+++ b/src/core/core/animator.cpp
@@ -3,9 +3,9 @@
 #include <algorithm>
 namespace uipc::core
 {
-void Animator::substep(SizeT n) noexcept
+void Animator::substep(SizeT n)
 {
-    UIPC_ASSERT(n > 0, "Animator: Substep must be greater than 0, yours' {}", n);
+    UIPC_ASSERT_THROW(n > 0, "Animator: Substep must be greater than 0, yours' {}", n);
     m_substep = n;
 }
 
@@ -45,7 +45,7 @@ void Animator::insert(Object& obj, Animation::ActionOnUpdate&& on_update)
         if(it != m_animations.end())
         {
             auto obj = it->second.m_object;
-            UIPC_ASSERT(it == m_animations.end(),
+            UIPC_ASSERT_THROW(it == m_animations.end(),
                         "Animator: Object (name={}, id={}) already has an animation.",
                         obj->name(),
                         obj->id());

--- a/src/core/core/constitution_tabular.cpp
+++ b/src/core/core/constitution_tabular.cpp
@@ -15,7 +15,7 @@ class ConstitutionTabular::Impl
 
     void insert(const constitution::IConstitution& constitution)
     {
-        UIPC_ASSERT(!m_is_sorted, "Cannot insert into a built ConstitutionTabular");
+        UIPC_ASSERT_THROW(!m_is_sorted, "Cannot insert into a built ConstitutionTabular");
         m_uid_set.insert(constitution.uid());
         m_types.insert(std::string{constitution.type()});
     }

--- a/src/core/core/contact_tabular.cpp
+++ b/src/core/core/contact_tabular.cpp
@@ -63,7 +63,7 @@ class ContactTabular::Impl
         Vector2i ids = {L.id(), R.id()};
 
         // check if the contact element id is valid.
-        UIPC_ASSERT(L.id() < current_element_id() && L.id() >= 0
+        UIPC_ASSERT_THROW(L.id() < current_element_id() && L.id() >= 0
                         && R.id() < current_element_id() && R.id() >= 0,
                     "Invalid contact element id, id should be in [{},{}), your L={}, R={}.",
                     0,
@@ -72,7 +72,7 @@ class ContactTabular::Impl
                     R.id());
 
         // check if the name is matched.
-        UIPC_ASSERT(m_elements[L.id()].name() == L.name()
+        UIPC_ASSERT_THROW(m_elements[L.id()].name() == L.name()
                         && m_elements[R.id()].name() == R.name(),
                     "Contact element name is not matched, L=<{},{}({} required)>, R=<{},{}({} required)>,"
                     "It seems the contact element and contact model don't come from the same ContactTabular.",
@@ -201,13 +201,13 @@ class ContactTabular::Impl
 
         m_models = ac;
         m_topo   = m_models.find<Vector2i>("topo");
-        UIPC_ASSERT(m_topo, "Contact model topology is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_topo, "Contact model topology is not found, please check the attribute collection.");
         m_friction_rates = m_models.find<Float>("friction_rate");
-        UIPC_ASSERT(m_friction_rates, "Contact model friction rates is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_friction_rates, "Contact model friction rates is not found, please check the attribute collection.");
         m_resistances = m_models.find<Float>("resistance");
-        UIPC_ASSERT(m_resistances, "Contact model resistances is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_resistances, "Contact model resistances is not found, please check the attribute collection.");
         m_is_enabled = m_models.find<IndexT>("is_enabled");
-        UIPC_ASSERT(m_is_enabled, "Contact model is_enabled is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_is_enabled, "Contact model is_enabled is not found, please check the attribute collection.");
 
         m_model_map.clear();
         auto topo_view = m_topo->view();
@@ -226,13 +226,13 @@ class ContactTabular::Impl
 
         m_models.update_from(ac);
         m_topo = m_models.find<Vector2i>("topo");
-        UIPC_ASSERT(m_topo, "Contact model topology is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_topo, "Contact model topology is not found, please check the attribute collection.");
         m_friction_rates = m_models.find<Float>("friction_rate");
-        UIPC_ASSERT(m_friction_rates, "Contact model friction rates is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_friction_rates, "Contact model friction rates is not found, please check the attribute collection.");
         m_resistances = m_models.find<Float>("resistance");
-        UIPC_ASSERT(m_resistances, "Contact model resistances is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_resistances, "Contact model resistances is not found, please check the attribute collection.");
         m_is_enabled = m_models.find<IndexT>("is_enabled");
-        UIPC_ASSERT(m_is_enabled, "Contact model is_enabled is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_is_enabled, "Contact model is_enabled is not found, please check the attribute collection.");
 
         auto topo_view = m_topo->view();
         for(SizeT i = 0; i < topo_view.size(); ++i)

--- a/src/core/core/diff_sim.cpp
+++ b/src/core/core/diff_sim.cpp
@@ -58,8 +58,8 @@ class DiffSim::Impl
                     auto diff_parm = collection.find(diff_parm_name);
                     auto parm      = collection.find(parm_name);
 
-                    UIPC_ASSERT(diff_parm, "Diff Parm `{}` not found, why can it happen?", diff_parm_name);
-                    UIPC_ASSERT(parm,
+                    UIPC_ASSERT_THROW(diff_parm, "Diff Parm `{}` not found, why can it happen?", diff_parm_name);
+                    UIPC_ASSERT_THROW(parm,
                                 "Diff Parm `{}` found, but Parm `{}` not, did you forget to create an attribute with name `{}` ?",
                                 diff_parm_name,
                                 parm_name,

--- a/src/core/core/finite_element_state_accessor_feature.cpp
+++ b/src/core/core/finite_element_state_accessor_feature.cpp
@@ -30,7 +30,7 @@ FiniteElementStateAccessorFeature::FiniteElementStateAccessorFeature(
     S<FiniteElementStateAccessorFeatureOverrider> overrider)
     : m_impl(std::move(overrider))
 {
-    UIPC_ASSERT(m_impl, "FiniteElementStateAccessorFeatureOverrider must not be null.");
+    UIPC_ASSERT_THROW(m_impl, "FiniteElementStateAccessorFeatureOverrider must not be null.");
 }
 
 SizeT FiniteElementStateAccessorFeature::vertex_count() const
@@ -42,7 +42,7 @@ geometry::SimplicialComplex FiniteElementStateAccessorFeature::create_geometry(
     IndexT vertex_offset, SizeT vertex_count) const
 {
     auto total_vert_num = this->vertex_count();
-    UIPC_ASSERT(vertex_offset <= total_vert_num,
+    UIPC_ASSERT_THROW(vertex_offset <= total_vert_num,
                 "vertex_offset ({}) must not be larger than total vertex number ({})",
                 vertex_offset,
                 total_vert_num);
@@ -68,7 +68,7 @@ void FiniteElementStateAccessorFeature::copy_position_to(backend::BufferView buf
                                                           SizeT               vertex_count) const
 {
     auto total_vert_num = this->vertex_count();
-    UIPC_ASSERT(vertex_offset <= total_vert_num,
+    UIPC_ASSERT_THROW(vertex_offset <= total_vert_num,
                 "vertex_offset ({}) must not be larger than total vertex number ({})",
                 vertex_offset,
                 total_vert_num);
@@ -76,7 +76,7 @@ void FiniteElementStateAccessorFeature::copy_position_to(backend::BufferView buf
     if(vertex_count == ~0ull)
         vertex_count = total_vert_num - vertex_offset;
 
-    UIPC_ASSERT(vertex_offset + vertex_count <= total_vert_num,
+    UIPC_ASSERT_THROW(vertex_offset + vertex_count <= total_vert_num,
                 "The requested range [{}, {}) is out of bounds for total vertices ({})",
                 vertex_offset,
                 vertex_offset + vertex_count,
@@ -90,7 +90,7 @@ void FiniteElementStateAccessorFeature::copy_velocity_to(backend::BufferView buf
                                                           SizeT               vertex_count) const
 {
     auto total_vert_num = this->vertex_count();
-    UIPC_ASSERT(vertex_offset <= total_vert_num,
+    UIPC_ASSERT_THROW(vertex_offset <= total_vert_num,
                 "vertex_offset ({}) must not be larger than total vertex number ({})",
                 vertex_offset,
                 total_vert_num);
@@ -98,7 +98,7 @@ void FiniteElementStateAccessorFeature::copy_velocity_to(backend::BufferView buf
     if(vertex_count == ~0ull)
         vertex_count = total_vert_num - vertex_offset;
 
-    UIPC_ASSERT(vertex_offset + vertex_count <= total_vert_num,
+    UIPC_ASSERT_THROW(vertex_offset + vertex_count <= total_vert_num,
                 "The requested range [{}, {}) is out of bounds for total vertices ({})",
                 vertex_offset,
                 vertex_offset + vertex_count,

--- a/src/core/core/internal/scene.cpp
+++ b/src/core/core/internal/scene.cpp
@@ -30,7 +30,7 @@ void Scene::begin_pending() noexcept
     m_pending = true;
 }
 
-void Scene::solve_pending() noexcept
+void Scene::solve_pending()
 {
     m_geometries.solve_pending();
     m_rest_geometries.solve_pending();
@@ -54,10 +54,10 @@ void Scene::update_from(const SceneSnapshotCommit& commit)
     m_rest_geometries.update_from(commit.m_rest_geometries);
 }
 
-Float Scene::dt() const noexcept
+Float Scene::dt() const
 {
     auto dt_attr = m_config.find<Float>("dt");
-    UIPC_ASSERT(dt_attr, "Scene config must have a 'dt' attribute.");
+    UIPC_ASSERT_THROW(dt_attr, "Scene config must have a 'dt' attribute.");
     return dt_attr->view()[0];
 }
 

--- a/src/core/core/internal/world.cpp
+++ b/src/core/core/internal/world.cpp
@@ -13,7 +13,7 @@ namespace uipc::core::internal
 {
 static S<internal::Engine> lock(const W<internal::Engine>& e)
 {
-    UIPC_ASSERT(!e.expired(), "Engine is expired, did you throw the `Engine`?");
+    UIPC_ASSERT_THROW(!e.expired(), "Engine is expired, did you throw the `Engine`?");
     return e.lock();
 }
 
@@ -199,13 +199,13 @@ const FeatureCollection& World::features() const
 
 SanityChecker& World::sanity_checker()
 {
-    UIPC_ASSERT(m_sanity_checker, "SanityChecker is not initialized. You should call World::init() first.");
+    UIPC_ASSERT_THROW(m_sanity_checker, "SanityChecker is not initialized. You should call World::init() first.");
     return *m_sanity_checker;
 }
 
 const SanityChecker& World::sanity_checker() const
 {
-    UIPC_ASSERT(m_sanity_checker, "SanityChecker is not initialized. You should call World::init() first.");
+    UIPC_ASSERT_THROW(m_sanity_checker, "SanityChecker is not initialized. You should call World::init() first.");
     return *m_sanity_checker;
 }
 

--- a/src/core/core/scene.cpp
+++ b/src/core/core/scene.cpp
@@ -106,7 +106,7 @@ DiffSim& Scene::diff_sim()
 {
     // automatically enable diff_sim
     auto diff_sim_enable = m_internal->config().find<IndexT>("diff_sim/enable");
-    UIPC_ASSERT(diff_sim_enable, "Scene config must have a 'diff_sim/enable' attribute.");
+    UIPC_ASSERT_THROW(diff_sim_enable, "Scene config must have a 'diff_sim/enable' attribute.");
     geometry::view(*diff_sim_enable)[0] = 1;
     return m_internal->diff_sim();
 }

--- a/src/core/core/scene_default_config.cpp
+++ b/src/core/core/scene_default_config.cpp
@@ -115,7 +115,7 @@ Json to_config_json(const geometry::AttributeCollection& config)
     for(auto& name : names)
     {
         auto attr = config.find(name);
-        UIPC_ASSERT(attr != nullptr, "Attribute '{}' not found in config.", name);
+        UIPC_ASSERT_THROW(attr != nullptr, "Attribute '{}' not found in config.", name);
         auto& sub_json = nested_json(j, name);
         sub_json       = attr->to_json(0);
     }
@@ -158,7 +158,7 @@ void from_config_json(geometry::AttributeCollection& config, const Json& j)
     for(auto& name : names)
     {
         auto attr = config.find(name);
-        UIPC_ASSERT(attr != nullptr, "Attribute '{}' not found in config.", name);
+        UIPC_ASSERT_THROW(attr != nullptr, "Attribute '{}' not found in config.", name);
         auto sub_json = find_nested_json(j, name);
         if(sub_json != nullptr)
         {

--- a/src/core/core/scene_factory.cpp
+++ b/src/core/core/scene_factory.cpp
@@ -252,7 +252,7 @@ class SceneFactory::Impl
                     auto id            = slot_json["id"].get<IndexT>();
                     auto index         = slot_json["index"].get<IndexT>();
                     auto geometry_slot = ga.find(index);
-                    UIPC_ASSERT(geometry_slot,
+                    UIPC_ASSERT_THROW(geometry_slot,
                                 "Geometry slot with id {} not found in geometry atlas",
                                 index);
                     auto this_geo_slot = geometry_slot->clone();

--- a/src/core/core/scene_snapshot.cpp
+++ b/src/core/core/scene_snapshot.cpp
@@ -16,7 +16,7 @@ SceneSnapshot::SceneSnapshot(const Scene& scene)
         uipc::make_shared<geometry::AttributeCollection>(scene.m_internal->config());
 
     auto& internal_scene = *scene.m_internal;
-    UIPC_ASSERT(internal_scene.geometries().pending_create_slots().size() == 0
+    UIPC_ASSERT_THROW(internal_scene.geometries().pending_create_slots().size() == 0
                     && internal_scene.rest_geometries().pending_create_slots().size() == 0
                     && internal_scene.geometries().pending_destroy_ids().size() == 0
                     && internal_scene.rest_geometries().pending_destroy_ids().size() == 0,

--- a/src/core/core/subscene_tabular.cpp
+++ b/src/core/core/subscene_tabular.cpp
@@ -61,7 +61,7 @@ class SubsceneTabular::Impl
         Vector2i ids = {L.id(), R.id()};
 
         // check if the subscene element id is valid.
-        UIPC_ASSERT(L.id() < current_element_id() && L.id() >= 0
+        UIPC_ASSERT_THROW(L.id() < current_element_id() && L.id() >= 0
                         && R.id() < current_element_id() && R.id() >= 0,
                     "Invalid subscene element id, id should be in [{},{}), your L={}, R={}.",
                     0,
@@ -70,7 +70,7 @@ class SubsceneTabular::Impl
                     R.id());
 
         // check if the name is matched.
-        UIPC_ASSERT(m_elements[L.id()].name() == L.name()
+        UIPC_ASSERT_THROW(m_elements[L.id()].name() == L.name()
                         && m_elements[R.id()].name() == R.name(),
                     "Subscene element name is not matched, L=<{},{}({} required)>, R=<{},{}({} required)>,"
                     "It seems the subscene element and subscene model don't come from the same SubsceneTabular.",
@@ -180,9 +180,9 @@ class SubsceneTabular::Impl
 
         m_models = ac;
         m_topo   = m_models.find<Vector2i>("topo");
-        UIPC_ASSERT(m_topo, "Subscene model topology is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_topo, "Subscene model topology is not found, please check the attribute collection.");
         m_is_enabled = m_models.find<IndexT>("is_enabled");
-        UIPC_ASSERT(m_is_enabled, "Subscene model is_enabled is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_is_enabled, "Subscene model is_enabled is not found, please check the attribute collection.");
 
         m_model_map.clear();
         auto topo_view = m_topo->view();
@@ -201,9 +201,9 @@ class SubsceneTabular::Impl
 
         m_models.update_from(ac);
         m_topo = m_models.find<Vector2i>("topo");
-        UIPC_ASSERT(m_topo, "Subscene model topology is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_topo, "Subscene model topology is not found, please check the attribute collection.");
         m_is_enabled = m_models.find<IndexT>("is_enabled");
-        UIPC_ASSERT(m_is_enabled, "Subscene model is_enabled is not found, please check the attribute collection.");
+        UIPC_ASSERT_THROW(m_is_enabled, "Subscene model is_enabled is not found, please check the attribute collection.");
 
         auto topo_view = m_topo->view();
         for(SizeT i = 0; i < topo_view.size(); ++i)

--- a/src/core/diff_sim/adjoint_method_feature.cpp
+++ b/src/core/diff_sim/adjoint_method_feature.cpp
@@ -12,7 +12,7 @@ namespace uipc::diff_sim
 AdjointMethodFeature::AdjointMethodFeature(S<AdjointMethodFeatureOverrider> overrider)
     : m_impl{overrider}
 {
-    UIPC_ASSERT(overrider, "Overrider must not be null");
+    UIPC_ASSERT_THROW(overrider, "Overrider must not be null");
 }
 
 std::string_view AdjointMethodFeature::get_name() const
@@ -22,11 +22,11 @@ std::string_view AdjointMethodFeature::get_name() const
 
 void AdjointMethodFeature::select_dofs(SizeT frame, backend::BufferView in_SDI)
 {
-    UIPC_ASSERT(frame >= 1, "Frame must be >= 1, but it is {}", frame);
+    UIPC_ASSERT_THROW(frame >= 1, "Frame must be >= 1, but it is {}", frame);
 
     if(frame > 1)
     {
-        UIPC_ASSERT(last_calling_frame == frame - 1,
+        UIPC_ASSERT_THROW(last_calling_frame == frame - 1,
                     "`select_dofs` must be called in each frame in order. Last calling frame = {},"
                     " but this calling frame = {}",
                     last_calling_frame,

--- a/src/core/diff_sim/enable_grad_feature.cpp
+++ b/src/core/diff_sim/enable_grad_feature.cpp
@@ -5,7 +5,7 @@ namespace uipc::diff_sim
 EnableGradFeature::EnableGradFeature(S<EnableGradFeatureOverrider> overrider)
     : m_impl(std::move(overrider))
 {
-    UIPC_ASSERT(m_impl, "NoGradFeatureOverrider must not be null.");
+    UIPC_ASSERT_THROW(m_impl, "NoGradFeatureOverrider must not be null.");
 }
 
 void EnableGradFeature::no_grad()

--- a/src/core/diff_sim/parameter_collection.cpp
+++ b/src/core/diff_sim/parameter_collection.cpp
@@ -157,7 +157,7 @@ class ParameterCollection::Impl
 
 #undef TRY_PUSH_BACK
 
-        UIPC_ASSERT(false,
+        UIPC_ASSERT_THROW(false,
                     "Unsupported Diff Parameter Attribute [{}<{}>], [{}<{}>] ",
                     diff_parm_slot->name(),
                     diff_parm_slot->type_name(),

--- a/src/core/geometry/attribute.cpp
+++ b/src/core/geometry/attribute.cpp
@@ -19,12 +19,12 @@ Json IAttribute::to_json() const noexcept
     return do_to_json();
 }
 
-void IAttribute::from_json(const Json& j) noexcept
+void IAttribute::from_json(const Json& j)
 {
     do_from_json(j);
 }
 
-void IAttribute::from_json_array(const Json& j) noexcept
+void IAttribute::from_json_array(const Json& j)
 {
     do_from_json_array(j);
 }
@@ -63,7 +63,7 @@ void IAttribute::reorder(span<const SizeT> O) noexcept
     do_reorder(O);
 }
 
-void IAttribute::copy_from(const IAttribute& other, const AttributeCopy& copy) noexcept
+void IAttribute::copy_from(const IAttribute& other, const AttributeCopy& copy)
 {
     do_copy_from(other, copy);
 }

--- a/src/core/geometry/attribute_collection.cpp
+++ b/src/core/geometry/attribute_collection.cpp
@@ -139,7 +139,7 @@ void AttributeCollection::copy_from(const AttributeCollection& other,
         if(copy.type() == AttributeCopy::CopyType::SameDim)
         {
             // just share
-            UIPC_ASSERT(this->size() == other.size(),
+            UIPC_ASSERT_THROW(this->size() == other.size(),
                         "Attribute size mismatch, "
                         "dst size is {}, src size is {}. "
                         "Did you forget to resize the dst attribute collection before copying?",
@@ -167,7 +167,7 @@ void AttributeCollection::copy_from(const AttributeCollection& other,
             auto c = other_slot->do_clone_empty(other_slot->name(),
                                                 other_slot->allow_destroy());
 
-            UIPC_ASSERT(c->is_shared() == false, "The attribute is shared, why can it happen?");
+            UIPC_ASSERT_THROW(c->is_shared() == false, "The attribute is shared, why can it happen?");
 
             m_attributes[name] = c;
 

--- a/src/core/geometry/attribute_collection_factory.cpp
+++ b/src/core/geometry/attribute_collection_factory.cpp
@@ -160,7 +160,7 @@ class AttributeCollectionFactory::Impl
 
     S<AttributeCollection> from_json(const Json& j, DeserialSharedAttributeContext& ctx)
     {
-        UIPC_ASSERT(j.is_object(), "This json must be an object");
+        UIPC_ASSERT_THROW(j.is_object(), "This json must be an object");
         S<AttributeCollection> attribute_collections =
             attribute_collection_from_json(j, ctx);
         return attribute_collections;

--- a/src/core/geometry/attribute_factory.cpp
+++ b/src/core/geometry/attribute_factory.cpp
@@ -90,7 +90,7 @@ class AttributeFactory::Impl
     vector<S<IAttributeSlot>> from_json(const Json& j)
     {
         vector<S<IAttributeSlot>> attributes;
-        UIPC_ASSERT(j.is_array(), "This json must be an array of attributes");
+        UIPC_ASSERT_THROW(j.is_array(), "This json must be an array of attributes");
         attributes.reserve(j.size());
 
         for(SizeT i = 0; i < j.size(); ++i)

--- a/src/core/geometry/attribute_slot.cpp
+++ b/src/core/geometry/attribute_slot.cpp
@@ -42,7 +42,7 @@ Json IAttributeSlot::to_json(SizeT i) const
     return attribute().to_json(i);
 }
 
-void IAttributeSlot::from_json_array(const Json& j) noexcept
+void IAttributeSlot::from_json_array(const Json& j)
 {
     rw_access();
     attribute().from_json_array(j);
@@ -106,7 +106,7 @@ void IAttributeSlot::rw_access()
 
 void check_view(const IAttributeSlot* slot)
 {
-    UIPC_ASSERT(slot,
+    UIPC_ASSERT_THROW(slot,
                 "You are trying to access a nullptr attribute slot, please check if the attribute name is correct.\n"
                 "The last attribute name (thread local) you tried to find is: {}",
                 AttributeDebugInfo::thread_local_last_not_found_name());

--- a/src/core/geometry/geometry.cpp
+++ b/src/core/geometry/geometry.cpp
@@ -62,7 +62,7 @@ Geometry::Geometry(const Geometry& o)
     }
     m_meta     = find("meta");
     m_intances = find("instances");
-    UIPC_ASSERT(m_meta && m_intances,
+    UIPC_ASSERT_THROW(m_meta && m_intances,
                 "Meta and instances attribute collections should be created in the constructor");
 }
 
@@ -103,7 +103,7 @@ S<const AttributeCollection> Geometry::operator[](std::string_view name) const
 S<AttributeCollection> Geometry::create(std::string_view name)
 {
     auto s_name = std::string{name};
-    UIPC_ASSERT(!m_attribute_collections.contains(s_name),
+    UIPC_ASSERT_THROW(!m_attribute_collections.contains(s_name),
                 "Attribute collection with name '{}' already exists.",
                 s_name);
     auto ret                        = uipc::make_shared<AttributeCollection>();

--- a/src/core/geometry/geometry_atlas.cpp
+++ b/src/core/geometry/geometry_atlas.cpp
@@ -58,7 +58,7 @@ static void _build_attributes_index_from_attribute_collection(
         {
             IndexT index        = static_cast<IndexT>(attr_to_index.size());
             attr_to_index[attr] = index;
-            UIPC_ASSERT(index_to_attr.size() == index,
+            UIPC_ASSERT_THROW(index_to_attr.size() == index,
                         "Index to attribute size mismatch, expected {}, got {}",
                         index_to_attr.size(),
                         index);

--- a/src/core/geometry/geometry_collection.cpp
+++ b/src/core/geometry/geometry_collection.cpp
@@ -61,18 +61,18 @@ void GeometryCollection::pending_destroy(IndexT id) noexcept
     }
 }
 
-void GeometryCollection::solve_pending() noexcept
+void GeometryCollection::solve_pending()
 {
     m_dirty = true;
 
     // put the pending create into the geometries
     for(auto& [id, geo] : m_pending_create)
     {
-        UIPC_ASSERT(m_geometries.find(id) == m_geometries.end(),
+        UIPC_ASSERT_THROW(m_geometries.find(id) == m_geometries.end(),
                     "GeometrySlot ({}) already exists. Why can this happen?",
                     id);
 
-        UIPC_ASSERT(geo->state() == GeometrySlotState::PendingCreate,
+        UIPC_ASSERT_THROW(geo->state() == GeometrySlotState::PendingCreate,
                     "GeometrySlot ({}) is not in PendingCreate state. Why can this happen?",
                     id);
 
@@ -84,11 +84,11 @@ void GeometryCollection::solve_pending() noexcept
     for(auto id : m_pending_destroy)
     {
         auto it = m_geometries.find(id);
-        UIPC_ASSERT(it != m_geometries.end(),
+        UIPC_ASSERT_THROW(it != m_geometries.end(),
                     "GeometrySlot ({}) does not exist. Why can this happen?",
                     id);
 
-        UIPC_ASSERT(it->second->state() == GeometrySlotState::PendingDestroy,
+        UIPC_ASSERT_THROW(it->second->state() == GeometrySlotState::PendingDestroy,
                     "GeometrySlot ({}) is not in PendingDestroy state. Why can this happen?",
                     id);
         m_geometries.erase(it);

--- a/src/core/geometry/geometry_collection_commit.cpp
+++ b/src/core/geometry/geometry_collection_commit.cpp
@@ -16,19 +16,19 @@ GeometryCollectionCommit::GeometryCollectionCommit(const GeometryCollectionCommi
 GeometryCollectionCommit::GeometryCollectionCommit(const GeometryCollection& dst,
                                                    const GeometryCollection& src)
 {
-    UIPC_ASSERT(dst.m_pending_create.size() == 0,
+    UIPC_ASSERT_THROW(dst.m_pending_create.size() == 0,
                 "GeometryCollectionCommit: The pending create size is not 0 (size={}), this is not expected.",
                 dst.m_pending_create.size());
 
-    UIPC_ASSERT(dst.m_pending_destroy.size() == 0,
+    UIPC_ASSERT_THROW(dst.m_pending_destroy.size() == 0,
                 "GeometryCollectionCommit: The pending destroy size is not 0 (size={}), this is not expected.",
                 dst.m_pending_destroy.size());
 
-    UIPC_ASSERT(src.m_pending_create.size() == 0,
+    UIPC_ASSERT_THROW(src.m_pending_create.size() == 0,
                 "GeometryCollectionCommit: The pending create size is not 0 (size={}), this is not expected.",
                 src.m_pending_create.size());
 
-    UIPC_ASSERT(src.m_pending_destroy.size() == 0,
+    UIPC_ASSERT_THROW(src.m_pending_destroy.size() == 0,
                 "GeometryCollectionCommit: The pending destroy size is not 0 (size={}), this is not expected.",
                 src.m_pending_destroy.size());
 

--- a/src/core/geometry/geometry_factory.cpp
+++ b/src/core/geometry/geometry_factory.cpp
@@ -206,7 +206,7 @@ class GeometryFactory::Impl
 
     vector<S<Geometry>> from_json(const Json& j, DeserialSharedAttributeContext& ctx)
     {
-        UIPC_ASSERT(j.is_array(), "To create a Geometries, this json must be an array");
+        UIPC_ASSERT_THROW(j.is_array(), "To create a Geometries, this json must be an array");
 
         vector<S<Geometry>> geometries;
         geometries.reserve(j.size());
@@ -265,7 +265,7 @@ class GeometryFactory::Impl
     {
         auto type = geometry.type();
         auto it   = slot_creators().find(std::string{type});
-        UIPC_ASSERT(it != slot_creators().end(),
+        UIPC_ASSERT_THROW(it != slot_creators().end(),
                     "Geometry<{}> not registered, why can it happen?",
                     type);
         auto creator = it->second;

--- a/src/core/geometry/implicit_geometry.cpp
+++ b/src/core/geometry/implicit_geometry.cpp
@@ -9,7 +9,7 @@ ImplicitGeometry::ImplicitGeometry()
     : Geometry()
 {
     auto meta = find("meta");  // in base class
-    UIPC_ASSERT(meta, "Meta attribute collection not found, why can it happen?");
+    UIPC_ASSERT_THROW(meta, "Meta attribute collection not found, why can it happen?");
 
     // Set the implicit geometry UID to 0 (Empty).
     meta->create<U64>(builtin::implicit_geometry_uid,

--- a/src/core/geometry/simplicial_complex.cpp
+++ b/src/core/geometry/simplicial_complex.cpp
@@ -10,7 +10,7 @@ namespace uipc::geometry
 SimplicialComplex::SimplicialComplex(const CreateInfo& info)
     : Geometry()
 {
-    UIPC_ASSERT(find("meta") && find("instances"),
+    UIPC_ASSERT_THROW(find("meta") && find("instances"),
                 "SimplicialComplex should have meta and instance attributes.");
 
     // create attribute collections and setup shortcuts

--- a/src/geometry/affine_body/compute_body_force.cpp
+++ b/src/geometry/affine_body/compute_body_force.cpp
@@ -148,7 +148,7 @@ static Vector12 compute_codim_trimesh_body_force(
     auto tri_view = sc.triangles().topo().view();
 
     auto thickness_attr = sc.vertices().find<Float>(builtin::thickness);
-    UIPC_ASSERT(thickness_attr,
+    UIPC_ASSERT_THROW(thickness_attr,
                 "Codim shell body force: `thickness` attribute not found on vertices.");
     Float r    = thickness_attr->view()[0];
     Float twor = 2.0 * r;
@@ -199,7 +199,7 @@ static Vector12 compute_segment_body_force(const SimplicialComplex& sc,
     auto edge_view = sc.edges().topo().view();
 
     auto thickness_attr = sc.vertices().find<Float>(builtin::thickness);
-    UIPC_ASSERT(thickness_attr,
+    UIPC_ASSERT_THROW(thickness_attr,
                 "Codim rod body force: `thickness` attribute not found on vertices.");
     Float r  = thickness_attr->view()[0];
     Float S  = std::numbers::pi_v<Float> * r * r;
@@ -241,7 +241,7 @@ UIPC_GEOMETRY_API Vector12 compute_body_force(const SimplicialComplex& sc,
         else if(sc.dim() == 1)
             return compute_segment_body_force(sc, body_force_density);
         else
-            UIPC_ASSERT(false, "Codim body force: unsupported dim {}.", sc.dim());
+            UIPC_ASSERT_THROW(false, "Codim body force: unsupported dim {}.", sc.dim());
     }
 
     if(sc.dim() == 3)
@@ -254,7 +254,7 @@ UIPC_GEOMETRY_API Vector12 compute_body_force(const SimplicialComplex& sc,
     }
     else
     {
-        UIPC_ASSERT(false, "Only 2D and 3D SimplicialComplex is supported.");
+        UIPC_ASSERT_THROW(false, "Only 2D and 3D SimplicialComplex is supported.");
     }
     return Vector12::Zero();
 }

--- a/src/geometry/affine_body/compute_dyadic_mass.cpp
+++ b/src/geometry/affine_body/compute_dyadic_mass.cpp
@@ -271,12 +271,12 @@ UIPC_GEOMETRY_API void compute_dyadic_mass(const SimplicialComplex& sc,
     }
     else if(sc.dim() == 2)
     {
-        // UIPC_ASSERT(is_trimesh_closed(sc), "Only closed trimesh is supported.");
+        // UIPC_ASSERT_THROW(is_trimesh_closed(sc), "Only closed trimesh is supported.");
         compute_trimesh_dyadic_mass(sc, rho, m, m_x_bar, m_x_bar_x_bar);
     }
     else
     {
-        UIPC_ASSERT(false, "Unsupported dimension");
+        UIPC_ASSERT_THROW(false, "Unsupported dimension");
     }
 }
 
@@ -457,7 +457,7 @@ UIPC_GEOMETRY_API void compute_dyadic_mass(const SimplicialComplex& sc,
     }
     else
     {
-        UIPC_ASSERT(false,
+        UIPC_ASSERT_THROW(false,
                     "Codim compute_dyadic_mass only supports dim==2 (shell) and dim==1 (rod), got dim={}.",
                     sc.dim());
     }

--- a/src/geometry/apply_region.cpp
+++ b/src/geometry/apply_region.cpp
@@ -34,7 +34,7 @@ vector<SimplicialComplex> apply_region(const SimplicialComplex& sc)
 {
     auto region_count = sc.meta().find<IndexT>("region_count");
 
-    UIPC_ASSERT(region_count,
+    UIPC_ASSERT_THROW(region_count,
                 "The `region_count` attribute is not found in the complex. "
                 "You need to call label_region() to label the region of the geometry");
 
@@ -45,7 +45,7 @@ vector<SimplicialComplex> apply_region(const SimplicialComplex& sc)
     if(Dim >= 1)
     {
         auto edge_region = sc.edges().find<IndexT>("region");
-        UIPC_ASSERT(edge_region,
+        UIPC_ASSERT_THROW(edge_region,
                     "The `region` attribute is not found in the edges. "
                     "You need to call label_region() to label the region of the geometry");
     }

--- a/src/geometry/closure.cpp
+++ b/src/geometry/closure.cpp
@@ -100,20 +100,20 @@ static void facet_closure_dim_3(SimplicialComplex& R)
 
 static void check_facet_closure_input(const SimplicialComplex& O)
 {
-    UIPC_ASSERT(O.dim() >= 0 && O.dim() <= 3,
+    UIPC_ASSERT_THROW(O.dim() >= 0 && O.dim() <= 3,
                 "When calling `facet_closure()`, your simplicial complex should be in dimension [0, 3], your dimension ({}).",
                 O.dim());
 
     switch(O.dim())
     {
         case 2: {
-            UIPC_ASSERT(O.edges().size() == 0,
+            UIPC_ASSERT_THROW(O.edges().size() == 0,
                         "When calling `facet_closure()`, your lower dimensional simplicial should be empty, your edge count ({}).",
                         O.edges().size());
         }
         break;
         case 3: {
-            UIPC_ASSERT(O.triangles().size() == 0 && O.edges().size() == 0,
+            UIPC_ASSERT_THROW(O.triangles().size() == 0 && O.edges().size() == 0,
                         "When calling `facet_closure()`, your lower dimensional simplicial should be empty, your face count ({}), yout edge count ({}).",
                         O.triangles().size(),
                         O.edges().size());

--- a/src/geometry/compute_mesh_area.cpp
+++ b/src/geometry/compute_mesh_area.cpp
@@ -7,7 +7,7 @@ namespace uipc::geometry
 UIPC_GEOMETRY_API Float compute_shell_volume(const SimplicialComplex& sc,
                                              Float                    thickness)
 {
-    UIPC_ASSERT(sc.dim() == 2,
+    UIPC_ASSERT_THROW(sc.dim() == 2,
                 "compute_mesh_area requires a 2D simplicial complex (triangle mesh), got dim={}.",
                 sc.dim());
 

--- a/src/geometry/compute_mesh_length.cpp
+++ b/src/geometry/compute_mesh_length.cpp
@@ -7,7 +7,7 @@ namespace uipc::geometry
 UIPC_GEOMETRY_API Float compute_rod_volume(const SimplicialComplex& sc,
                                            Float                    thickness)
 {
-    UIPC_ASSERT(sc.dim() == 1,
+    UIPC_ASSERT_THROW(sc.dim() == 1,
                 "compute_mesh_length requires a 1D simplicial complex (edge mesh), got dim={}.",
                 sc.dim());
 

--- a/src/geometry/compute_mesh_volume.cpp
+++ b/src/geometry/compute_mesh_volume.cpp
@@ -75,13 +75,13 @@ UIPC_GEOMETRY_API Float compute_mesh_volume(SimplicialComplex& R)
     }
     else if(R.dim() == 2)
     {
-        UIPC_ASSERT(is_trimesh_closed(R), "Calculating volume of open trimesh is meaningless.");
+        UIPC_ASSERT_THROW(is_trimesh_closed(R), "Calculating volume of open trimesh is meaningless.");
 
         volume = compute_trimesh_volume(R);
     }
     else
     {
-        UIPC_ASSERT(false, "Only tetmesh and closed trimesh are supported.");
+        UIPC_ASSERT_THROW(false, "Only tetmesh and closed trimesh are supported.");
     }
 
     return volume;

--- a/src/geometry/compute_vertex_volume.cpp
+++ b/src/geometry/compute_vertex_volume.cpp
@@ -26,7 +26,7 @@ static S<AttributeSlot<Float>> compute_vertex_volume_from_tet(SimplicialComplex&
                                A.col(1) = p2 - p0;
                                A.col(2) = p3 - p0;
                                auto D   = A.determinant();
-                               UIPC_ASSERT(D > 0.0,
+                               UIPC_ASSERT_THROW(D > 0.0,
                                            "The determinant of the tetrahedron is non-positive ({}), which means the tetrahedron is inverted.",
                                            D);
                                auto volume = D / 6.0;
@@ -76,7 +76,7 @@ static S<AttributeSlot<Float>> compute_vertex_volume_from_tri(SimplicialComplex&
             {
                 auto thickness_view = thickness->view();
                 // check if all vertices have the same thickness
-                UIPC_ASSERT(thickness_view[t[0]] == thickness_view[t[1]]
+                UIPC_ASSERT_THROW(thickness_view[t[0]] == thickness_view[t[1]]
                                 && thickness_view[t[1]] == thickness_view[t[2]],
                             "The thickness of the triangle ({},{},{}) is not consistent, thickness = ({}, {}, {})",
                             t[0],
@@ -145,7 +145,7 @@ static S<AttributeSlot<Float>> compute_vertex_volume_from_edge(SimplicialComplex
             {
                 auto thickness_view = thickness->view();
                 // check if all vertices have the same thickness
-                UIPC_ASSERT(thickness_view[e[0]] == thickness_view[e[1]],
+                UIPC_ASSERT_THROW(thickness_view[e[0]] == thickness_view[e[1]],
                             "The thickness of the edge ({},{}) is not consistent, thickness = ({}, {})",
                             e[0],
                             e[1],
@@ -234,7 +234,7 @@ S<AttributeSlot<Float>> compute_vertex_volume(SimplicialComplex& R)
         case 3:
             return compute_vertex_volume_from_tet(R);
         default: {
-            UIPC_ASSERT(false, "Unsupported dimension: {}", R.dim());
+            UIPC_ASSERT_THROW(false, "Unsupported dimension: {}", R.dim());
             return nullptr;
         }
     }

--- a/src/geometry/distance.cpp
+++ b/src/geometry/distance.cpp
@@ -51,7 +51,7 @@ namespace detail
 
     static Vector2i pp_from_pe(const Vector<IndexT, 3>& flag)
     {
-        UIPC_ASSERT(active_count(flag) == 2, "active count mismatch");
+        UIPC_ASSERT_THROW(active_count(flag) == 2, "active count mismatch");
 
         Vector<IndexT, 2> offsets;
         if(flag[0] == 0)
@@ -75,7 +75,7 @@ namespace detail
 
     static Vector3i pe_from_pt(const Vector<IndexT, 4>& flag)
     {
-        UIPC_ASSERT(active_count(flag) == 3,
+        UIPC_ASSERT_THROW(active_count(flag) == 3,
                     "active count mismatch, yours=({},{},{},{})",
                     flag[0],
                     flag[1],
@@ -109,7 +109,7 @@ namespace detail
 
     static Vector2i pp_from_pt(const Vector<IndexT, 4>& flag)
     {
-        UIPC_ASSERT(active_count(flag) == 2,
+        UIPC_ASSERT_THROW(active_count(flag) == 2,
                     "active count mismatch, yours=({},{},{},{})",
                     flag[0],
                     flag[1],
@@ -125,7 +125,7 @@ namespace detail
         {
             if(flag[iN])
             {
-                UIPC_ASSERT(iM < M, "active mismatch");
+                UIPC_ASSERT_THROW(iM < M, "active mismatch");
                 offsets[iM] = iN;
                 ++iM;
             }
@@ -135,7 +135,7 @@ namespace detail
 
     static Vector3i pe_from_ee(const Vector<IndexT, 4>& flag)
     {
-        UIPC_ASSERT(active_count(flag) == 3,
+        UIPC_ASSERT_THROW(active_count(flag) == 3,
                     "active count mismatch, yours=({},{},{},{})",
                     flag[0],
                     flag[1],
@@ -164,7 +164,7 @@ namespace detail
 
     static Vector2i pp_from_ee(const Vector4i& flag)
     {
-        UIPC_ASSERT(active_count(flag) == 2,
+        UIPC_ASSERT_THROW(active_count(flag) == 2,
                     "active count mismatch, yours=({},{},{},{})",
                     flag[0],
                     flag[1],
@@ -180,7 +180,7 @@ namespace detail
         {
             if(flag[iN])
             {
-                UIPC_ASSERT(iM < M, "active mismatch");
+                UIPC_ASSERT_THROW(iM < M, "active mismatch");
                 offsets[iM] = iN;
                 ++iM;
             }

--- a/src/geometry/extract_surface.cpp
+++ b/src/geometry/extract_surface.cpp
@@ -13,7 +13,7 @@ constexpr std::string_view hint =
 
 SimplicialComplex extract_surface(const SimplicialComplex& src)
 {
-    UIPC_ASSERT(src.dim() == 3,
+    UIPC_ASSERT_THROW(src.dim() == 3,
                 "The input mesh must be a tetrahedral mesh. Your dim={}.",
                 src.dim());
 
@@ -23,9 +23,9 @@ SimplicialComplex extract_surface(const SimplicialComplex& src)
     auto e_is_surf = src.edges().find<IndexT>(builtin::is_surf);
     auto f_is_surf = src.triangles().find<IndexT>(builtin::is_surf);
 
-    UIPC_ASSERT(v_is_surf, "`is_surf` attribute not found in the mesh vertices. {}", hint);
-    UIPC_ASSERT(e_is_surf, "`is_surf` attribute not found in the mesh edges. {}", hint);
-    UIPC_ASSERT(f_is_surf, "`is_surf` attribute not found in the mesh triangles. {}", hint);
+    UIPC_ASSERT_THROW(v_is_surf, "`is_surf` attribute not found in the mesh vertices. {}", hint);
+    UIPC_ASSERT_THROW(e_is_surf, "`is_surf` attribute not found in the mesh edges. {}", hint);
+    UIPC_ASSERT_THROW(f_is_surf, "`is_surf` attribute not found in the mesh triangles. {}", hint);
 
     // ---------------------------------------------------------------------
     // copy the meta and instances
@@ -194,7 +194,7 @@ static void extract_surface_check_input(span<const SimplicialComplex*> sc)
 {
     for(auto [I, complex] : enumerate(sc))
     {
-        UIPC_ASSERT(complex != nullptr, "Input[{}] is nullptr", I);
+        UIPC_ASSERT_THROW(complex != nullptr, "Input[{}] is nullptr", I);
     }
 }
 

--- a/src/geometry/flip_inward_triangles.cpp
+++ b/src/geometry/flip_inward_triangles.cpp
@@ -11,8 +11,8 @@ SimplicialComplex flip_inward_triangles(const SimplicialComplex& sc)
     auto f_is_surf = R.triangles().find<IndexT>(builtin::is_surf);
     auto f_orient  = R.triangles().find<IndexT>(builtin::orient);
 
-    UIPC_ASSERT(f_is_surf, "Cannot find attribute `is_surf` on triangles. You may need to call `label_surface()` first");
-    UIPC_ASSERT(f_orient, "Cannot find attribute `orient` on triangles. You may need to call `label_triangle_orient()` first");
+    UIPC_ASSERT_THROW(f_is_surf, "Cannot find attribute `is_surf` on triangles. You may need to call `label_surface()` first");
+    UIPC_ASSERT_THROW(f_orient, "Cannot find attribute `orient` on triangles. You may need to call `label_triangle_orient()` first");
 
     auto src_Fs = R.triangles().topo().view();
     auto dst_Fs = view(R.triangles().topo());

--- a/src/geometry/graph_coloring/coloring_algorithm.cpp
+++ b/src/geometry/graph_coloring/coloring_algorithm.cpp
@@ -33,7 +33,7 @@ void GraphColor::build(SizeT                       node_count,
                            edges.begin(),
                            [node_count](NodeIndexT i, NodeIndexT j)
                            {
-                               UIPC_ASSERT(i < node_count && j < node_count,
+                               UIPC_ASSERT_THROW(i < node_count && j < node_count,
                                            "Node index out of bounds ({},{}), node count = {}",
                                            i,
                                            j,
@@ -71,7 +71,7 @@ void GraphColor::build(SizeT                       node_count,
 
 std::span<const NodeIndexT> GraphColor::node_adjacency(NodeIndexT node) const
 {
-    UIPC_ASSERT(node < num_node(),
+    UIPC_ASSERT_THROW(node < num_node(),
                 "Node index out of bounds, num_node = {}, yours {}.",
                 num_node(),
                 node);

--- a/src/geometry/graph_coloring/dsatur.cpp
+++ b/src/geometry/graph_coloring/dsatur.cpp
@@ -86,7 +86,7 @@ void Dsatur::do_solve()
         const auto unused_color_iter = std::ranges::find(color_usage, 0);
         const auto unused_color_i =
             static_cast<int64_t>(std::distance(color_usage.begin(), unused_color_iter));
-        UIPC_ASSERT(unused_color_i >= 0, "There should be at least one unused color");
+        UIPC_ASSERT_THROW(unused_color_i >= 0, "There should be at least one unused color");
 
         // Reset the color usage for the next iteration
         for(auto&& v : adj_u)

--- a/src/geometry/is_trimesh_closed.cpp
+++ b/src/geometry/is_trimesh_closed.cpp
@@ -4,7 +4,7 @@ namespace uipc::geometry
 {
 UIPC_GEOMETRY_API bool is_trimesh_closed(const SimplicialComplex& R)
 {
-    UIPC_ASSERT(R.dim() == 2, "Only 2D SimplicialComplex is supported.");
+    UIPC_ASSERT_THROW(R.dim() == 2, "Only 2D SimplicialComplex is supported.");
 
     auto pos_view = R.positions().view();
     auto tri_view = R.triangles().topo().view();

--- a/src/geometry/label_connected_vertices.cpp
+++ b/src/geometry/label_connected_vertices.cpp
@@ -18,7 +18,7 @@ S<AttributeSlot<IndexT>> label_connected_vertices(SimplicialComplex& complex)
 
     for(auto [i, edge] : enumerate(edge_view))
     {
-        UIPC_ASSERT(edge[0] != edge[1],
+        UIPC_ASSERT_THROW(edge[0] != edge[1],
                     "Self-loop is not allowed. In edge[{}] = ({},{})",
                     i,
                     edge[0],

--- a/src/geometry/label_graph_color.cpp
+++ b/src/geometry/label_graph_color.cpp
@@ -26,7 +26,7 @@ S<AttributeSlot<IndexT>> label_graph_color(SimplicialComplex& sc)
 
     algo.build(node_count, Ni, Nj);
     algo.solve();
-    UIPC_ASSERT(algo.is_valid(), "invalid graph coloring");
+    UIPC_ASSERT_THROW(algo.is_valid(), "invalid graph coloring");
     auto colors = algo.colors();
 
     auto color_attr = sc.vertices().find<IndexT>("graph/color");

--- a/src/geometry/label_open_edge.cpp
+++ b/src/geometry/label_open_edge.cpp
@@ -17,7 +17,7 @@ struct Vector2iHash
 
 UIPC_GEOMETRY_API S<AttributeSlot<IndexT>> label_open_edge(SimplicialComplex& R)
 {
-    UIPC_ASSERT(R.dim() == 2, "Only 2D SimplicialComplex is supported.");
+    UIPC_ASSERT_THROW(R.dim() == 2, "Only 2D SimplicialComplex is supported.");
 
     auto tri_view = R.triangles().topo().view();
     auto edge_view = R.edges().topo().view();
@@ -69,7 +69,7 @@ UIPC_GEOMETRY_API S<AttributeSlot<IndexT>> label_open_edge(SimplicialComplex& R)
     for(const auto& [edge, count] : edge_count)
     {
         // Check for invalid edges (shared by >=3 triangles)
-        UIPC_ASSERT(count < 3,
+        UIPC_ASSERT_THROW(count < 3,
                     "Edge ({},{}) is shared by {} triangles, which is invalid. "
                     "An edge can only be shared by 1 (open) or 2 (closed) triangles.",
                     edge[0],

--- a/src/geometry/label_region.cpp
+++ b/src/geometry/label_region.cpp
@@ -26,7 +26,7 @@ void label_region(SimplicialComplex& complex)
 
         for(auto [i, edge] : enumerate(edge_view))
         {
-            UIPC_ASSERT(vert_region_view[edge[0]] == vert_region_view[edge[1]],
+            UIPC_ASSERT_THROW(vert_region_view[edge[0]] == vert_region_view[edge[1]],
                         "In the edge[{}] = ({},{}), vertices are not in the same region -> ({},{}), which is ill condition.",
                         i,
                         edge[0],
@@ -50,7 +50,7 @@ void label_region(SimplicialComplex& complex)
 
         for(auto [i, tri] : enumerate(tri_view))
         {
-            UIPC_ASSERT(vert_region_view[tri[0]] == vert_region_view[tri[1]]
+            UIPC_ASSERT_THROW(vert_region_view[tri[0]] == vert_region_view[tri[1]]
                             && vert_region_view[tri[1]] == vert_region_view[tri[2]],
                         "In the triangle[{}] = ({},{},{}), vertices are not in the same region -> ({},{},{}), which is ill condition.",
                         i,
@@ -77,7 +77,7 @@ void label_region(SimplicialComplex& complex)
 
         for(auto [i, tet] : enumerate(tet_view))
         {
-            UIPC_ASSERT(vert_region_view[tet[0]] == vert_region_view[tet[1]]
+            UIPC_ASSERT_THROW(vert_region_view[tet[0]] == vert_region_view[tet[1]]
                             && vert_region_view[tet[1]] == vert_region_view[tet[2]]
                             && vert_region_view[tet[2]] == vert_region_view[tet[3]],
                         "In the tetrahedron[{}] = ({},{},{},{}), vertices are not in the same region -> ({},{},{},{}), which is ill condition.",

--- a/src/geometry/label_surface.cpp
+++ b/src/geometry/label_surface.cpp
@@ -141,7 +141,7 @@ void label_surface(SimplicialComplex& R)
 
     // 4) label the surface triangles
     auto Fs = R.triangles().topo().view();
-    UIPC_ASSERT(f_is_surf->view().size() == unique_triangles.size(),
+    UIPC_ASSERT_THROW(f_is_surf->view().size() == unique_triangles.size(),
                 "The input mesh should be a closure, why can't we find the same number of triangles? yours {}, ours {}.",
                 f_is_surf->view().size(),
                 unique_triangles.size());
@@ -158,7 +158,7 @@ void label_surface(SimplicialComplex& R)
             // TODO:
             // if the triangles are not sorted, we need find a mapping from the sorted to the unsorted
             // and then we can label the surface vertices
-            UIPC_ASSERT(sorted, "The triangles are not sorted, now we don't support this case, TODO: need to implement it.");
+            UIPC_ASSERT_THROW(sorted, "The triangles are not sorted, now we don't support this case, TODO: need to implement it.");
 
             if(is_surface_triangle(i))
             {
@@ -233,7 +233,7 @@ void label_surface(SimplicialComplex& R)
 
         // TODO: if the edges_with_flag are not sorted, we need find a mapping from the sorted to the unsorted
         // 	 and then we can label the surface vertices
-        UIPC_ASSERT(sorted, "The edges are not sorted, now we don't support this case, TODO: need to implement it.");
+        UIPC_ASSERT_THROW(sorted, "The edges are not sorted, now we don't support this case, TODO: need to implement it.");
 
         auto offset         = offsets_edges[i];
         auto edge_with_flag = edges_with_flag[offset];

--- a/src/geometry/label_triangle_orient.cpp
+++ b/src/geometry/label_triangle_orient.cpp
@@ -7,15 +7,15 @@ namespace uipc::geometry
 {
 S<AttributeSlot<IndexT>> label_triangle_orient(SimplicialComplex& R)
 {
-    UIPC_ASSERT(R.dim() == 3, "label_triangle_orient() only works on 3D simplicial complex (tetmesh).");
+    UIPC_ASSERT_THROW(R.dim() == 3, "label_triangle_orient() only works on 3D simplicial complex (tetmesh).");
 
     auto f_is_surf   = R.triangles().find<IndexT>(builtin::is_surf);
     auto f_parent_id = R.triangles().find<IndexT>(builtin::parent_id);
     auto v_position  = R.vertices().find<Vector3>(builtin::position);
 
-    UIPC_ASSERT(f_is_surf, "Cannot find attribute `is_surf` on triangles. You may need to call `label_surface()` first");
-    UIPC_ASSERT(f_parent_id, "Cannot find attribute `parent_id` on triangles. You may need to call `label_surface()` first");
-    UIPC_ASSERT(v_position, "Cannot find attribute `position` on vertices. Abstract simplicial complex is not allowed!");
+    UIPC_ASSERT_THROW(f_is_surf, "Cannot find attribute `is_surf` on triangles. You may need to call `label_surface()` first");
+    UIPC_ASSERT_THROW(f_parent_id, "Cannot find attribute `parent_id` on triangles. You may need to call `label_surface()` first");
+    UIPC_ASSERT_THROW(v_position, "Cannot find attribute `position` on vertices. Abstract simplicial complex is not allowed!");
 
     auto f_orient = R.triangles().find<IndexT>(builtin::orient);
     if(!f_orient)

--- a/src/geometry/merge.cpp
+++ b/src/geometry/merge.cpp
@@ -10,8 +10,8 @@ static void check_merge_input(span<const SimplicialComplex*> complexes)
 {
     for(auto [I, complex] : enumerate(complexes))
     {
-        UIPC_ASSERT(complex != nullptr, "complex[{}] is nullptr", I);
-        UIPC_ASSERT(complex->instances().size() == 1,
+        UIPC_ASSERT_THROW(complex != nullptr, "complex[{}] is nullptr", I);
+        UIPC_ASSERT_THROW(complex->instances().size() == 1,
                     "complex[{}] has multiple instances ({}), call `apply_transform()` before merging multiple-instance-geometry",
                     I,
                     complex->instances().size());

--- a/src/geometry/mesh_partition.cpp
+++ b/src/geometry/mesh_partition.cpp
@@ -174,7 +174,7 @@ void mesh_partition(SimplicialComplex& sc, SizeT part_max_size)
         // 1. All vertices must have a non-negative partition ID
         for(SizeT i = 0; i < vert_count; ++i)
         {
-            UIPC_ASSERT(part_view[i] >= 0,
+            UIPC_ASSERT_THROW(part_view[i] >= 0,
                         "mesh_partition: vertex {} has invalid partition ID {}.",
                         i,
                         part_view[i]);
@@ -188,7 +188,7 @@ void mesh_partition(SimplicialComplex& sc, SizeT part_max_size)
 
         for(IndexT p = 0; p <= max_id; ++p)
         {
-            UIPC_ASSERT(sizes[p] <= part_max_size,
+            UIPC_ASSERT_THROW(sizes[p] <= part_max_size,
                         "mesh_partition: partition {} has {} vertices, exceeding the limit {}.",
                         p,
                         sizes[p],
@@ -198,7 +198,7 @@ void mesh_partition(SimplicialComplex& sc, SizeT part_max_size)
         // 3. No empty partitions (IDs should be contiguous 0..max)
         for(IndexT p = 0; p <= max_id; ++p)
         {
-            UIPC_ASSERT(sizes[p] > 0,
+            UIPC_ASSERT_THROW(sizes[p] > 0,
                         "mesh_partition: partition {} is empty. "
                         "Partition IDs should be contiguous from 0.",
                         p);

--- a/src/geometry/optimal_transform.cpp
+++ b/src/geometry/optimal_transform.cpp
@@ -9,12 +9,12 @@ static Matrix4x4 optimal_transform(const Matrix4x4&    ST,
                                    const Matrix4x4&    DT,
                                    span<const Vector3> D)
 {
-    UIPC_ASSERT(S.size() == D.size(),
+    UIPC_ASSERT_THROW(S.size() == D.size(),
                 "The number of source points({}) and destination points({}) should be the same.",
                 S.size(),
                 D.size());
 
-    UIPC_ASSERT(S.size() >= 4, "The number of points should be at least 4.");
+    UIPC_ASSERT_THROW(S.size() >= 4, "The number of points should be at least 4.");
 
     bool S_is_identity = ST.isIdentity();
     bool D_is_identity = DT.isIdentity();
@@ -74,17 +74,17 @@ Matrix4x4 optimal_transform(span<const Vector3> S, span<const Vector3> D)
 
 Matrix4x4 optimal_transform(const SimplicialComplex& S, const SimplicialComplex& D)
 {
-    UIPC_ASSERT(S.vertices().size() >= 4,
+    UIPC_ASSERT_THROW(S.vertices().size() >= 4,
                 "The number of points({}) should be at least 4.",
                 S.vertices().size());
-    UIPC_ASSERT(S.vertices().size() == D.vertices().size(),
+    UIPC_ASSERT_THROW(S.vertices().size() == D.vertices().size(),
                 "The number of source points({}) and destination points({}) should be the same.",
                 S.vertices().size(),
                 D.vertices().size());
-    UIPC_ASSERT(S.instances().size() == 1,
+    UIPC_ASSERT_THROW(S.instances().size() == 1,
                 "The number of instances({}) should be 1.",
                 S.instances().size());
-    UIPC_ASSERT(D.instances().size() == 1,
+    UIPC_ASSERT_THROW(D.instances().size() == 1,
                 "The number of instances({}) should be 1.",
                 D.instances().size());
 

--- a/src/geometry/points_from_volume.cpp
+++ b/src/geometry/points_from_volume.cpp
@@ -86,12 +86,12 @@ SimplicialComplex mesh_to_point_cloud(const SimplicialComplex& sc, Float resolut
 
 SimplicialComplex points_from_volume(const SimplicialComplex& sc, Float resolution)
 {
-    UIPC_ASSERT(sc.dim() >= 2 && sc.dim() <= 3,
+    UIPC_ASSERT_THROW(sc.dim() >= 2 && sc.dim() <= 3,
                 "points_from_volume: Only 2D and 3D simplicial complexes are supported.");
 
     if(sc.dim() == 2)
     {
-        UIPC_ASSERT(is_trimesh_closed(sc),
+        UIPC_ASSERT_THROW(is_trimesh_closed(sc),
                     "points_from_volume: The input 2D simplicial complex must be a closed manifold.");
 
         return mesh_to_point_cloud(sc, resolution);

--- a/src/geometry/simplex_utils.cpp
+++ b/src/geometry/simplex_utils.cpp
@@ -101,11 +101,11 @@ bool SimplexUtils::compare_tet(const Vector4i& A, const Vector4i& B) noexcept
            || (SA(0) == SB(0) && SA(1) == SB(1) && SA(2) < SB(2));
 }
 
-void SimplexUtils::outward_tri_from_tet(span<const Vector3, 4> Vs, span<Vector3i, 4> Fs) noexcept
+void SimplexUtils::outward_tri_from_tet(span<const Vector3, 4> Vs, span<Vector3i, 4> Fs)
 {
     auto det = ((Vs[1] - Vs[0]).cross(Vs[2] - Vs[0])).dot(Vs[3] - Vs[0]);
 
-    UIPC_ASSERT(det >= 0, "The tetrahedron is not positive oriented, now we don't support this case. TODO: ...");
+    UIPC_ASSERT_THROW(det >= 0, "The tetrahedron is not positive oriented, now we don't support this case. TODO: ...");
 
     // initial values
     Fs[0] = Vector3i{0, 1, 2};

--- a/src/io/scene_io.cpp
+++ b/src/io/scene_io.cpp
@@ -39,7 +39,7 @@ namespace detail
                 auto simplicial_complex =
                     dynamic_cast<SimplicialComplex*>(&geo->geometry());
 
-                UIPC_ASSERT(simplicial_complex, "type mismatch, why can it happen?");
+                UIPC_ASSERT_THROW(simplicial_complex, "type mismatch, why can it happen?");
 
                 bool allow = false;
 

--- a/src/io/simplicial_complex_io.cpp
+++ b/src/io/simplicial_complex_io.cpp
@@ -174,7 +174,7 @@ bool obj_read_linemesh_(const std::string&                str,
         }
         else if(type == "f")
         {
-            UIPC_ASSERT(false,
+            UIPC_ASSERT_THROW(false,
                         "Found face in line mesh .obj file at line {}. "
                         "This is not a pure line mesh.",
                         line_number);

--- a/src/io/urdf_io.cpp
+++ b/src/io/urdf_io.cpp
@@ -109,7 +109,7 @@ class UrdfController::Impl
     void propagate_transform()
     {
         auto& root_link = model->root_link_;
-        UIPC_ASSERT(root_link != nullptr, "Root link is null, why?");
+        UIPC_ASSERT_THROW(root_link != nullptr, "Root link is null, why?");
         _propagate_transform(*root_link, root_link_transform);
     }
 
@@ -126,7 +126,7 @@ class UrdfController::Impl
     void rotate_to(std::string_view joint_name, Float angle)
     {
         auto it = revolute_joint_infos.find(std::string{joint_name});
-        UIPC_ASSERT(it != revolute_joint_infos.end(),
+        UIPC_ASSERT_THROW(it != revolute_joint_infos.end(),
                     "Joint {} not found in `Revolute Joints`, can't rotate",
                     joint_name);
 
@@ -161,7 +161,7 @@ class UrdfController::Impl
                 continue;
 
             auto it = revolute_joint_infos.find(r_joint.mimic_joint_name);
-            UIPC_ASSERT(it != revolute_joint_infos.end(),
+            UIPC_ASSERT_THROW(it != revolute_joint_infos.end(),
                         "Mimic joint {} not found, can't process mimic, why can it happen?",
                         r_joint.mimic_joint_name);
 
@@ -498,13 +498,13 @@ class UrdfIO::Impl
             }
             else
             {
-                UIPC_ASSERT(false,
+                UIPC_ASSERT_THROW(false,
                             "Unsupported Joint {} <{}>",
                             joint->name,
                             magic_enum::enum_name(joint->type));
             }
 
-            UIPC_ASSERT(joint_infos.find(joint->name) == joint_infos.end(),
+            UIPC_ASSERT_THROW(joint_infos.find(joint->name) == joint_infos.end(),
                         "Joint name {} already exists, invalid urdf",
                         joint->name);
 

--- a/src/pybind/pyuipc/module.cpp
+++ b/src/pybind/pyuipc/module.cpp
@@ -1,6 +1,7 @@
 #include <pyuipc/pyuipc.h>
 #include <uipc/common/uipc.h>
 #include <uipc/common/log.h>
+#include <uipc/common/exception.h>
 #include <pyuipc/common/unit.h>
 #include <pyuipc/common/uipc_type.h>
 #include <pyuipc/common/timer.h>
@@ -49,6 +50,8 @@ py::module& top_module()
 PYBIND11_MODULE(pyuipc, m)
 {
     pyuipc::g_top_module = &m;
+
+    py::register_exception<uipc::Exception>(m, "Exception");
 
     auto unit         = m.def_submodule("unit");
     auto geometry     = m.def_submodule("geometry");

--- a/src/sanity_check/context.cpp
+++ b/src/sanity_check/context.cpp
@@ -32,7 +32,7 @@ namespace detail
                 auto simplicial_complex =
                     dynamic_cast<SimplicialComplex*>(&geo->geometry());
 
-                UIPC_ASSERT(simplicial_complex, "type mismatch, why can it happen?");
+                UIPC_ASSERT_THROW(simplicial_complex, "type mismatch, why can it happen?");
 
                 switch(simplicial_complex->dim())
                 {
@@ -76,7 +76,7 @@ namespace detail
             {
                 auto simplicial_complex = geo.as<SimplicialComplex>();
 
-                UIPC_ASSERT(simplicial_complex, "type mismatch, why can it happen?");
+                UIPC_ASSERT_THROW(simplicial_complex, "type mismatch, why can it happen?");
 
                 // 1) label original_index for each vertex, edge, triangle, tetrahedron
                 {
@@ -209,7 +209,7 @@ namespace detail
             {
                 auto simplicial_complex =
                     dynamic_cast<SimplicialComplex*>(&geo->geometry());
-                UIPC_ASSERT(simplicial_complex, "type mismatch, why can it happen?");
+                UIPC_ASSERT_THROW(simplicial_complex, "type mismatch, why can it happen?");
 
                 // 1) Contact Element ID
                 auto contact_element_id =

--- a/src/sanity_check/half_plane_vertex_distance_check.cpp
+++ b/src/sanity_check/half_plane_vertex_distance_check.cpp
@@ -60,7 +60,7 @@ class HalfPlaneVertexDistanceCheck final : public SanityChecker
             {
                 auto uid = geo.meta().find<U64>(builtin::implicit_geometry_uid);
 
-                UIPC_ASSERT(uid, "ImplicitGeometryUID not found, why can it happen?");
+                UIPC_ASSERT_THROW(uid, "ImplicitGeometryUID not found, why can it happen?");
 
                 if(uid->view()[0] == HalfPlaneUID)
                 {
@@ -154,7 +154,7 @@ class HalfPlaneVertexDistanceCheck final : public SanityChecker
     }
 
     virtual SanityCheckResult do_check(backend::SceneVisitor& scene,
-                                       backend::SanityCheckMessageVisitor& msg) noexcept override
+                                       backend::SanityCheckMessageVisitor& msg) override
     {
         collect_halfplanes(scene);
 
@@ -183,22 +183,22 @@ class HalfPlaneVertexDistanceCheck final : public SanityChecker
 
         auto attr_cids =
             scene_surface.vertices().find<IndexT>("sanity_check/contact_element_id");
-        UIPC_ASSERT(attr_cids, "`sanity_check/contact_element_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_cids, "`sanity_check/contact_element_id` is not found in scene surface");
         auto CIds = attr_cids->view();
 
         auto attr_scids = scene_surface.vertices().find<IndexT>(
             "sanity_check/subscene_contact_element_id");
-        UIPC_ASSERT(attr_scids, "`sanity_check/subscene_contact_element_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_scids, "`sanity_check/subscene_contact_element_id` is not found in scene surface");
         auto SCIds = attr_scids->view();
 
         auto attr_v_geo_ids =
             scene_surface.vertices().find<IndexT>("sanity_check/geometry_id");
-        UIPC_ASSERT(attr_v_geo_ids, "`sanity_check/geometry_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_v_geo_ids, "`sanity_check/geometry_id` is not found in scene surface");
         auto VGeoIds = attr_v_geo_ids->view();
 
         auto attr_v_object_id =
             scene_surface.vertices().find<IndexT>("sanity_check/object_id");
-        UIPC_ASSERT(attr_v_object_id, "`sanity_check/object_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_v_object_id, "`sanity_check/object_id` is not found in scene surface");
         auto VObjectIds = attr_v_object_id->view();
 
         auto attr_thickeness = scene_surface.vertices().find<Float>(builtin::thickness);
@@ -219,21 +219,21 @@ class HalfPlaneVertexDistanceCheck final : public SanityChecker
         {
             auto instance_count = halfplane->instances().size();
             auto attr_N         = halfplane->instances().find<Vector3>("N");
-            UIPC_ASSERT(attr_N, "Normal vector `N` not found in half-plane");
+            UIPC_ASSERT_THROW(attr_N, "Normal vector `N` not found in half-plane");
             auto Ns = attr_N->view();
 
             auto attr_P = halfplane->instances().find<Vector3>("P");
-            UIPC_ASSERT(attr_P, "Origin point `P` not found in half-plane");
+            UIPC_ASSERT_THROW(attr_P, "Origin point `P` not found in half-plane");
             auto Ps = attr_P->view();
 
             auto attr_geo_id =
                 halfplane->instances().find<IndexT>("sanity_check/geometry_id");
-            UIPC_ASSERT(attr_geo_id, "`sanity_check/geometry_id` not found in half-plane");
+            UIPC_ASSERT_THROW(attr_geo_id, "`sanity_check/geometry_id` not found in half-plane");
             auto HGeoIds = attr_geo_id->view();
 
             auto attr_object_id =
                 halfplane->instances().find<IndexT>("sanity_check/object_id");
-            UIPC_ASSERT(attr_object_id, "`sanity_check/object_id` not found in half-plane");
+            UIPC_ASSERT_THROW(attr_object_id, "`sanity_check/object_id` not found in half-plane");
             auto HObjectIds = attr_object_id->view();
 
             auto attr_cid = halfplane->meta().find<IndexT>(builtin::contact_element_id);
@@ -292,8 +292,8 @@ class HalfPlaneVertexDistanceCheck final : public SanityChecker
                 auto obj_0 = objects().find(ObjIds[0]);
                 auto obj_1 = objects().find(ObjIds[1]);
 
-                UIPC_ASSERT(obj_0 != nullptr, "Object[{}] not found", ObjIds[0]);
-                UIPC_ASSERT(obj_1 != nullptr, "Object[{}] not found", ObjIds[1]);
+                UIPC_ASSERT_THROW(obj_0 != nullptr, "Object[{}] not found", ObjIds[0]);
+                UIPC_ASSERT_THROW(obj_1 != nullptr, "Object[{}] not found", ObjIds[1]);
 
                 fmt::format_to(std::back_inserter(buffer),
                                "Geometry({}) in Object[{}({})] is too close (distance <= 0) to HalfPlane({}) in "

--- a/src/sanity_check/mesh_partition_check.cpp
+++ b/src/sanity_check/mesh_partition_check.cpp
@@ -20,7 +20,7 @@ class MeshPartitionCheck final : public SanityChecker
     virtual U64 get_id() const noexcept override { return SanityCheckerUID; }
 
     virtual SanityCheckResult do_check(backend::SceneVisitor& scene,
-                                       backend::SanityCheckMessageVisitor& msg) noexcept override
+                                       backend::SanityCheckMessageVisitor& msg) override
     {
         constexpr IndexT MIN_PART_SIZE = 4;
         constexpr IndexT MAX_PART_SIZE = 32;
@@ -36,7 +36,7 @@ class MeshPartitionCheck final : public SanityChecker
                 continue;
 
             auto sc = geo.as<geometry::SimplicialComplex>();
-            UIPC_ASSERT(sc, "Cannot cast to simplicial complex, why?");
+            UIPC_ASSERT_THROW(sc, "Cannot cast to simplicial complex, why?");
 
             // Only check FEM constitutions
             auto cuid = sc->meta().find<U64>(builtin::constitution_uid);

--- a/src/sanity_check/primtive_contact.h
+++ b/src/sanity_check/primtive_contact.h
@@ -92,7 +92,7 @@ inline Float edge_dcd_expansion(const Float& d_hat_E0, const Float& d_hat_E1)
 {
     if constexpr(RUNTIME_CHECK)
     {
-        UIPC_ASSERT(d_hat_E0 == d_hat_E1, "Edge d_hat should be the same");
+        UIPC_ASSERT_THROW(d_hat_E0 == d_hat_E1, "Edge d_hat should be the same");
     }
 
     return (d_hat_E0 + d_hat_E1) / 2.0;
@@ -105,7 +105,7 @@ inline Float triangle_dcd_expansion(const Float& d_hat_T0, const Float& d_hat_T1
 {
     if constexpr(RUNTIME_CHECK)
     {
-        UIPC_ASSERT(d_hat_T0 == d_hat_T1 && d_hat_T1 == d_hat_T2,
+        UIPC_ASSERT_THROW(d_hat_T0 == d_hat_T1 && d_hat_T1 == d_hat_T2,
                     "Triangle d_hat should be the same");
     }
 
@@ -119,7 +119,7 @@ inline Float PT_d_hat(const Float& d_hat_P, const Float& d_hat_T0, const Float& 
 {
     if constexpr(RUNTIME_CHECK)
     {
-        UIPC_ASSERT(d_hat_T0 == d_hat_T1 && d_hat_T1 == d_hat_T2,
+        UIPC_ASSERT_THROW(d_hat_T0 == d_hat_T1 && d_hat_T1 == d_hat_T2,
                     "Triangle d_hat should be the same");
     }
 
@@ -136,7 +136,7 @@ inline Float EE_d_hat(const Float& d_hat_Ea0,
 {
     if constexpr(RUNTIME_CHECK)
     {
-        UIPC_ASSERT(d_hat_Ea0 == d_hat_Ea1 && d_hat_Eb0 == d_hat_Eb1,
+        UIPC_ASSERT_THROW(d_hat_Ea0 == d_hat_Ea1 && d_hat_Eb0 == d_hat_Eb1,
                     "Edge d_hat should be the same");
     }
 
@@ -150,7 +150,7 @@ inline Float PE_d_hat(const Float& d_hat_P, const Float& d_hat_E0, const Float& 
 {
     if constexpr(RUNTIME_CHECK)
     {
-        UIPC_ASSERT(d_hat_E0 == d_hat_E1, "Edge d_hat should be the same");
+        UIPC_ASSERT_THROW(d_hat_E0 == d_hat_E1, "Edge d_hat should be the same");
     }
 
     return (d_hat_P + d_hat_E0) / 2.0;

--- a/src/sanity_check/sanity_checker_collection.cpp
+++ b/src/sanity_check/sanity_checker_collection.cpp
@@ -48,7 +48,7 @@ void SanityCheckerCollection::build(core::internal::Scene& s)
     }
 
     auto ctx = find<Context>();
-    UIPC_ASSERT(ctx != nullptr, "SanityCheckBuild: Context not found");
+    UIPC_ASSERT_THROW(ctx != nullptr, "SanityCheckBuild: Context not found");
 
     ctx->prepare();
 }
@@ -86,7 +86,7 @@ void SanityCheckerCollection::insert(S<core::ISanityChecker> checker)
 core::ISanityCheckContext& SanityCheckerCollection::context()
 {
     auto ctx = find<Context>();
-    UIPC_ASSERT(ctx != nullptr, "SanityCheckerCollection::context(): Context not found");
+    UIPC_ASSERT_THROW(ctx != nullptr, "SanityCheckerCollection::context(): Context not found");
     return *ctx;
 }
 

--- a/src/sanity_check/simplicial_surface_distance_check.cpp
+++ b/src/sanity_check/simplicial_surface_distance_check.cpp
@@ -66,7 +66,7 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
     void collect_codim_points(const geometry::SimplicialComplex& scene_surface)
     {
         auto attr_dim = scene_surface.vertices().find<IndexT>("sanity_check/dim");
-        UIPC_ASSERT(attr_dim, "`sanity_check/dim` is not found in scene surface, why can it happen?");
+        UIPC_ASSERT_THROW(attr_dim, "`sanity_check/dim` is not found in scene surface, why can it happen?");
         auto dim = attr_dim->view();
         CodimPs.reserve(scene_surface.vertices().size());
         for(auto [I, d] : enumerate(dim))
@@ -153,7 +153,7 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
     }
 
     virtual SanityCheckResult do_check(backend::SceneVisitor& scene,
-                                       backend::SanityCheckMessageVisitor& msg) noexcept override
+                                       backend::SanityCheckMessageVisitor& msg) override
     {
         auto context = find<Context>();
 
@@ -180,33 +180,33 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
 
         auto attr_cids =
             scene_surface.vertices().find<IndexT>("sanity_check/contact_element_id");
-        UIPC_ASSERT(attr_cids, "`sanity_check/contact_element_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_cids, "`sanity_check/contact_element_id` is not found in scene surface");
         auto CIds = attr_cids->view();
 
         auto attr_scids = scene_surface.vertices().find<IndexT>(
             "sanity_check/subscene_contact_element_id");
-        UIPC_ASSERT(attr_scids, "`sanity_check/subscene_contact_element_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_scids, "`sanity_check/subscene_contact_element_id` is not found in scene surface");
         auto SCIds = attr_scids->view();
 
         auto attr_v_geo_ids =
             scene_surface.vertices().find<IndexT>("sanity_check/geometry_id");
-        UIPC_ASSERT(attr_v_geo_ids, "`sanity_check/geometry_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_v_geo_ids, "`sanity_check/geometry_id` is not found in scene surface");
         auto VGeoIds = attr_v_geo_ids->view();
 
         auto attr_v_instance_id =
             scene_surface.vertices().find<IndexT>("sanity_check/instance_id");
-        UIPC_ASSERT(attr_v_instance_id,
+        UIPC_ASSERT_THROW(attr_v_instance_id,
                     "`sanity_check/instance_id` is not found in scene surface");
         auto VInstanceIds = attr_v_instance_id->view();
 
         auto attr_v_object_id =
             scene_surface.vertices().find<IndexT>("sanity_check/object_id");
-        UIPC_ASSERT(attr_v_object_id, "`sanity_check/object_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_v_object_id, "`sanity_check/object_id` is not found in scene surface");
         auto VObjectIds = attr_v_object_id->view();
 
         auto attr_self_collision =
             scene_surface.vertices().find<IndexT>("sanity_check/self_collision");
-        UIPC_ASSERT(attr_self_collision,
+        UIPC_ASSERT_THROW(attr_self_collision,
                     "`sanity_check/self_collision` is not found in scene surface");
         auto SelfCollision = attr_self_collision->view();
 
@@ -215,7 +215,7 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
             attr_v_thickness ? attr_v_thickness->view() : span<const Float>{};
 
         auto attr_v_d_hat = scene_surface.vertices().find<Float>("sanity_check/d_hat");
-        UIPC_ASSERT(attr_v_d_hat, "`sanity_check/d_hat` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_v_d_hat, "`sanity_check/d_hat` is not found in scene surface");
         auto Vd_hats = attr_v_d_hat->view();
 
         vector<geometry::BVH::AABB> codim_point_aabbs(CodimPs.size());
@@ -375,7 +375,7 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
                     return;
 
                 // 2) if this is a self-collision
-                UIPC_ASSERT(VInstanceIds[E[0]] == VInstanceIds[E[1]],
+                UIPC_ASSERT_THROW(VInstanceIds[E[0]] == VInstanceIds[E[1]],
                             "Why Edge({},{}) is not in the same instance?",
                             E[0],
                             E[1]);
@@ -445,7 +445,7 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
                 Vector3i SCIdRs = {SCIds[T[0]], SCIds[T[1]], SCIds[T[2]]};
 
                 // 2) if this is a self-collision
-                UIPC_ASSERT(VInstanceIds[T[0]] == VInstanceIds[T[1]]
+                UIPC_ASSERT_THROW(VInstanceIds[T[0]] == VInstanceIds[T[1]]
                                 && VInstanceIds[T[1]] == VInstanceIds[T[2]],
                             "Why Triangle({},{},{}) is not in the same instance?",
                             T[0],
@@ -512,12 +512,12 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
                 Vector2i SCIdRs = {SCIds[E1[0]], SCIds[E1[1]]};
 
                 // 2) if this is a self-collision
-                UIPC_ASSERT(VInstanceIds[E0[0]] == VInstanceIds[E0[1]],
+                UIPC_ASSERT_THROW(VInstanceIds[E0[0]] == VInstanceIds[E0[1]],
                             "Why Edge({},{}) is not in the same instance?",
                             E0[0],
                             E0[1]);
 
-                UIPC_ASSERT(VInstanceIds[E1[0]] == VInstanceIds[E1[1]],
+                UIPC_ASSERT_THROW(VInstanceIds[E1[0]] == VInstanceIds[E1[1]],
                             "Why Edge({},{}) is not in the same instance?",
                             E1[0],
                             E1[1]);
@@ -574,8 +574,8 @@ class SimplicialSurfaceDistanceCheck final : public SanityChecker
                 auto obj_0 = objects().find(ObjIds[0]);
                 auto obj_1 = objects().find(ObjIds[1]);
 
-                UIPC_ASSERT(obj_0 != nullptr, "Object[{}] not found", ObjIds[0]);
-                UIPC_ASSERT(obj_1 != nullptr, "Object[{}] not found", ObjIds[1]);
+                UIPC_ASSERT_THROW(obj_0 != nullptr, "Object[{}] not found", ObjIds[0]);
+                UIPC_ASSERT_THROW(obj_1 != nullptr, "Object[{}] not found", ObjIds[1]);
 
                 fmt::format_to(std::back_inserter(buffer),
                                "Geometry({}) in Object[{}({})] is too close (distance={}, thickness={}) to Geometry({}) in "

--- a/src/sanity_check/simplicial_surface_intersection_check.cpp
+++ b/src/sanity_check/simplicial_surface_intersection_check.cpp
@@ -121,7 +121,7 @@ class SimplicialSurfaceIntersectionCheck final : public SanityChecker
     }
 
     virtual SanityCheckResult do_check(backend::SceneVisitor& scene,
-                                       backend::SanityCheckMessageVisitor& msg) noexcept override
+                                       backend::SanityCheckMessageVisitor& msg) override
     {
         auto context = find<Context>();
 
@@ -144,33 +144,33 @@ class SimplicialSurfaceIntersectionCheck final : public SanityChecker
 
         auto attr_cids =
             scene_surface.vertices().find<IndexT>("sanity_check/contact_element_id");
-        UIPC_ASSERT(attr_cids, "`sanity_check/contact_element_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_cids, "`sanity_check/contact_element_id` is not found in scene surface");
         auto CIds = attr_cids->view();
 
         auto attr_scids = scene_surface.vertices().find<IndexT>(
             "sanity_check/subscene_contact_element_id");
-        UIPC_ASSERT(attr_scids, "`sanity_check/subscene_contact_element_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_scids, "`sanity_check/subscene_contact_element_id` is not found in scene surface");
         auto SCIds = attr_scids->view();
 
         auto attr_v_geo_ids =
             scene_surface.vertices().find<IndexT>("sanity_check/geometry_id");
-        UIPC_ASSERT(attr_v_geo_ids, "`sanity_check/geometry_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_v_geo_ids, "`sanity_check/geometry_id` is not found in scene surface");
         auto VGeoIds = attr_v_geo_ids->view();
 
         auto attr_v_instance_id =
             scene_surface.vertices().find<IndexT>("sanity_check/instance_id");
-        UIPC_ASSERT(attr_v_instance_id,
+        UIPC_ASSERT_THROW(attr_v_instance_id,
                     "`sanity_check/instance_id` is not found in scene surface");
         auto VInstanceIds = attr_v_instance_id->view();
 
         auto attr_v_object_id =
             scene_surface.vertices().find<IndexT>("sanity_check/object_id");
-        UIPC_ASSERT(attr_v_object_id, "`sanity_check/object_id` is not found in scene surface");
+        UIPC_ASSERT_THROW(attr_v_object_id, "`sanity_check/object_id` is not found in scene surface");
         auto VObjectIds = attr_v_object_id->view();
 
         auto attr_self_collision =
             scene_surface.vertices().find<IndexT>("sanity_check/self_collision");
-        UIPC_ASSERT(attr_self_collision,
+        UIPC_ASSERT_THROW(attr_self_collision,
                     "`sanity_check/self_collision` is not found in scene surface");
         auto SelfCollision = attr_self_collision->view();
 
@@ -224,11 +224,11 @@ class SimplicialSurfaceIntersectionCheck final : public SanityChecker
                 }
 
                 // 2) if this is a self-collision
-                UIPC_ASSERT(VInstanceIds[E[0]] == VInstanceIds[E[1]],
+                UIPC_ASSERT_THROW(VInstanceIds[E[0]] == VInstanceIds[E[1]],
                             "Why Edge({},{}) is not in the same instance?",
                             E[0],
                             E[1]);
-                UIPC_ASSERT(VInstanceIds[F[0]] == VInstanceIds[F[1]]
+                UIPC_ASSERT_THROW(VInstanceIds[F[0]] == VInstanceIds[F[1]]
                                 && VInstanceIds[F[1]] == VInstanceIds[F[2]],
                             "Why Triangle({},{},{}) is not in the same instance?",
                             F[0],
@@ -324,8 +324,8 @@ class SimplicialSurfaceIntersectionCheck final : public SanityChecker
                 auto obj_0 = objects().find(ObjIds[0]);
                 auto obj_1 = objects().find(ObjIds[1]);
 
-                UIPC_ASSERT(obj_0 != nullptr, "Object[{}] not found", ObjIds[0]);
-                UIPC_ASSERT(obj_1 != nullptr, "Object[{}] not found", ObjIds[1]);
+                UIPC_ASSERT_THROW(obj_0 != nullptr, "Object[{}] not found", ObjIds[0]);
+                UIPC_ASSERT_THROW(obj_1 != nullptr, "Object[{}] not found", ObjIds[1]);
 
                 fmt::format_to(std::back_inserter(buffer),
                                "Geometry({}) in Object[{}({})] intersects with Geometry({}) in "

--- a/src/sanity_check/simplicial_volume_check.cpp
+++ b/src/sanity_check/simplicial_volume_check.cpp
@@ -40,7 +40,7 @@ class SimplicialVolumeCheck final : public SanityChecker
     virtual U64 get_id() const noexcept override { return SanityCheckerUID; }
 
     virtual SanityCheckResult do_check(backend::SceneVisitor& scene,
-                                       backend::SanityCheckMessageVisitor& msg) noexcept override
+                                       backend::SanityCheckMessageVisitor& msg) override
     {
         auto context = find<Context>();
 
@@ -56,7 +56,7 @@ class SimplicialVolumeCheck final : public SanityChecker
                 continue;
 
             auto sc = geo.as<geometry::SimplicialComplex>();
-            UIPC_ASSERT(sc, "Cannot cast to simplicial complex, why can this happen?");
+            UIPC_ASSERT_THROW(sc, "Cannot cast to simplicial complex, why can this happen?");
 
             auto cuid = sc->meta().find<U64>(builtin::constitution_uid);
             if(!cuid)


### PR DESCRIPTION
## Summary

Replace all `UIPC_ASSERT` calls in **frontend** code with a new `UIPC_ASSERT_THROW` macro that throws `uipc::Exception` instead of calling `std::abort()`. This enables Python users and automation agents to catch validation errors as exceptions with full C++ stack traces, rather than experiencing a hard process termination.

### What changed

- **New macro `UIPC_ASSERT_THROW`** in `include/uipc/common/log.h` — drop-in replacement for `UIPC_ASSERT` that throws `uipc::Exception` with file/line info and a formatted message.
- **~307 replacements across 100+ frontend files** in `src/core/`, `src/constitution/`, `src/geometry/`, `src/io/`, `src/sanity_check/`, and `include/uipc/` (inline templates).
- **Removed `noexcept`** from function declarations/definitions that now may throw due to the replacement (e.g., `IAttribute::from_json`, `BufferView` constructor, `Animator::substep`, various sanity check overrides).
- **Registered `uipc::Exception` as a Python exception** via `py::register_exception<uipc::Exception>(m, "Exception")` in `src/pybind/pyuipc/module.cpp`, so Python users can catch it as `uipc.Exception`.

### Motivation

`UIPC_ASSERT` calls `uipc::abort()` → `std::abort()`, which immediately terminates the process. This is appropriate for backend invariant checks, but for frontend validation (user-facing input errors), it provides no opportunity for error recovery. Python users in particular need catchable exceptions with informative messages and stack traces to diagnose and fix their scene configurations.

### Scope

- **Frontend only**: All `UIPC_ASSERT` in `src/core`, `src/constitution`, `src/geometry`, `src/io`, `src/sanity_check`, and `include/uipc` inline templates.
- **Backend untouched**: `src/backends/` `UIPC_ASSERT` calls remain as-is — these check internal invariants not related to user input.

### Breaking changes

- Functions that were previously `noexcept` may now throw `uipc::Exception`. Callers that relied on the `noexcept` guarantee should be updated accordingly.
- Invalid user input that previously caused a hard crash will now throw a catchable exception. This is the intended behavior change.
