### PR TITLE
fix(constitution): meta volume and mass_density not written on first create

### DIFF
--- a/apps/tests/sim_case/72_abd_driving_revolute_joint.cpp
+++ b/apps/tests/sim_case/72_abd_driving_revolute_joint.cpp
@@ -15,7 +15,7 @@ TEST_CASE("72_abd_driving_revolute_joint", "[abd][joint][driving]")
 
     auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
 
-    logger::set_level(Logger::Level::critical);
+    logger::set_level(Logger::Level::warn);
     Engine engine{"cuda", output_path};
     World  world{engine};
 

--- a/src/constitution/affine_body_constitution.cpp
+++ b/src/constitution/affine_body_constitution.cpp
@@ -97,14 +97,12 @@ void AffineBodyConstitution::create_abd_attributes(geometry::SimplicialComplex& 
     auto meta_volume = sc.meta().find<Float>(builtin::volume);
     if(!meta_volume)
         meta_volume = sc.meta().create<Float>(builtin::volume, 0.0);
-    else
-        geometry::view(*meta_volume).front() = volume;
+    geometry::view(*meta_volume).front() = volume;
 
     auto meta_mass = sc.meta().find<Float>(builtin::mass_density);
     if(!meta_mass)
         meta_mass = sc.meta().create<Float>(builtin::mass_density, 0.0);
-    else
-        geometry::view(*meta_mass).front() = mass_density;
+    geometry::view(*meta_mass).front() = mass_density;
 
     auto create_or_update = [&](auto name, const auto& value)
     {


### PR DESCRIPTION
## Summary

- Fix a regression introduced in a6b21c8 where `meta::volume` and `meta::mass_density` were left at `0.0` for any freshly-created ABD geometry.
- In `create_abd_attributes`, the `if(!meta_volume)` branch created the attribute with a hard-coded default of `0.0` but the actual assignment was guarded behind an `else`, so it never ran for new geometry. This caused `SimplicialVolumeCheck` to see a non-positive volume and abort `world.init()`.
- Fix: remove the `else` guard so the view write always executes after create-or-find, for both `volume` and `mass_density`.
- Restore logger level in test `72_abd_driving_revolute_joint` from `critical` to `warn` (consistent with other sim-case tests) so init errors are visible.

## Test plan

- [ ] `uipc_test_sim_case "72_abd_driving_revolute_joint"` passes all 401 assertions across 100 frames
- [ ] Existing ABD sim-case tests unaffected
