### PR TITLE
fix(abd): correct SoftTransformConstraint strength for off-origin center of mass

### DIFF
--- a/apps/tests/sim_case/92_abd_stc_off_origin_cm.cpp
+++ b/apps/tests/sim_case/92_abd_stc_off_origin_cm.cpp
@@ -1,0 +1,120 @@
+#include <app/app.h>
+#include <uipc/uipc.h>
+#include <uipc/constitution/affine_body_constitution.h>
+#include <uipc/constitution/soft_transform_constraint.h>
+#include <uipc/geometry/utils/affine_body/affine_body_from_rigid_body.h>
+#include <numbers>
+
+TEST_CASE("92_abd_stc_off_origin_cm", "[animation][abd]")
+{
+    // Test: SoftTransformConstraint with translation-only strength (eta_p=100, eta_a=0)
+    // must drive the body's center of mass toward the aim's CM position,
+    // even when the CM is not at the model-space origin (c != 0).
+
+    using namespace uipc;
+    using namespace uipc::core;
+    using namespace uipc::geometry;
+    using namespace uipc::constitution;
+
+    auto output_path = AssetDir::output_path(UIPC_RELATIVE_SOURCE_FILE);
+
+    Engine engine{"cuda", output_path};
+    World  world{engine};
+
+    auto config                         = test::Scene::default_config();
+    config["gravity"]                   = Vector3{0, 0, 0};
+    config["contact"]["enable"]         = false;
+    config["line_search"]["max_iter"]   = 8;
+    config["linear_system"]["tol_rate"] = 1e-3;
+    config["dt"]                        = 0.01;
+    test::Scene::dump_config(config, output_path);
+
+    Scene scene{config};
+
+    AffineBodyConstitution  abd;
+    SoftTransformConstraint stc;
+
+    // Simple tet mesh — geometry shape does not matter since mass is overridden
+    vector<Vector4i> Ts = {Vector4i{0, 1, 2, 3}};
+    vector<Vector3>  Vs = {Vector3{0, 1, 0},
+                           Vector3{0, 0, 1},
+                           Vector3{-std::sqrt(3) / 2, 0, -0.5},
+                           Vector3{std::sqrt(3) / 2, 0, -0.5}};
+
+    auto mesh = tetmesh(Vs, Ts);
+    label_surface(mesh);
+    label_triangle_orient(mesh);
+
+    // Override mass properties: m = 1 kg, CM at (0, 1, 0) in model space
+    Vector3   model_com  = Vector3{0.0, 1.0, 0.0};
+    Float     body_mass  = 1.0;
+    Matrix3x3 inertia_cm = Matrix3x3::Identity();
+    auto      M12        = affine_body::from_rigid_body(body_mass, model_com, inertia_cm);
+
+    // kappa = 100 MPa keeps A ~ I throughout (body behaves rigidly)
+    abd.apply_to(mesh, 100.0_MPa, M12, 0.001);
+    // Translation-only soft constraint: eta_p = 100, eta_a = 0
+    stc.apply_to(mesh, Vector2{100.0, 0.0});
+
+    auto object            = scene.objects().create("body");
+    auto [geo_slot, _body] = object->geometries().create(mesh);
+
+    // Animator: ramp the aim from Identity to Rz(90 deg) over 180 frames.
+    // The aim has p_aim = 0 and A_aim = Rz(theta), so the aim CM is Rz(theta)*c.
+    constexpr Float pi       = std::numbers::pi;
+    constexpr int   ramp_end = 50;
+
+    auto& animator = scene.animator();
+    animator.insert(
+        *object,
+        [](Animation::UpdateInfo& info)
+        {
+            constexpr Float pi_val   = std::numbers::pi;
+            constexpr int   ramp_max = 50;
+
+            auto geo = info.geo_slots()[0]->geometry().as<SimplicialComplex>();
+
+            auto is_constrained = geo->instances().find<IndexT>(builtin::is_constrained);
+            view(*is_constrained)[0] = 1;
+
+            auto aim      = geo->instances().find<Matrix4x4>(builtin::aim_transform);
+            auto aim_view = view(*aim);
+
+            int   t     = std::min((int)info.frame(), ramp_max);
+            Float theta = (pi_val / 2.0) * (Float(t) / Float(ramp_max));
+
+            Transform transform = Transform::Identity();
+            transform.rotate(Eigen::AngleAxisd(theta, Vector3::UnitZ()));
+            aim_view[0] = transform.matrix();
+        });
+
+    world.init(scene);
+    REQUIRE(world.is_valid());
+
+    SceneIO sio{scene};
+    sio.write_surface(fmt::format("{}scene_surface{}.obj", output_path, 0));
+
+    // Run ramp_end frames plus 20 extra for convergence at the final aim
+    while(world.frame() < ramp_end + 20)
+    {
+        world.advance();
+        REQUIRE(world.is_valid());
+        world.retrieve();
+        sio.write_surface(
+            fmt::format("{}scene_surface{}.obj", output_path, world.frame()));
+    }
+
+    // Read back the final body transform and compute the world-space CM position:
+    //   x_cm = p + A * model_com
+    // The 4x4 transform matrix layout (from q_to_transform):
+    //   T[i,j] = A[i,j] for i,j in {0,1,2},   T[i,3] = p[i]
+    auto      T    = view(geo_slot->geometry().as<SimplicialComplex>()->transforms())[0];
+    Vector3   p    = T.block<3, 1>(0, 3);
+    Matrix3x3 A    = T.block<3, 3>(0, 0);
+    Vector3   x_cm = p + A * model_com;
+
+    // Target CM = Rz(90 deg) * (0,1,0) = (-1, 0, 0)
+    Vector3 cm_target = Vector3{-1.0, 0.0, 0.0};
+
+    REQUIRE(x_cm.isApprox(cm_target));
+}

--- a/docs/specification/constitutions/soft_transform_constraint.md
+++ b/docs/specification/constitutions/soft_transform_constraint.md
@@ -35,35 +35,29 @@ $\mathbf{p}$ is the position of the affine body and the $\mathbf{a}_i$ are the r
 
 ## #16 SoftTransformConstraint
 
-The soft transform constraint energy has the form of "Kinetic" defined as
+The constraint energy is
 
 $$
-\Psi = \frac{1}{2} \left( \mathbf{q} - \hat{\mathbf{q}} \right)^T \tilde{\mathbf{M}} \left( \mathbf{q} - \hat{\mathbf{q}} \right),
+\Psi = \frac{1}{2} \delta\mathbf{q}^T \tilde{\mathbf{M}}\, \delta\mathbf{q}, \quad \delta\mathbf{q} = \mathbf{q} - \hat{\mathbf{q}},
 $$
 
-where $\hat{\mathbf{q}}$ is the target state, and $\tilde{\mathbf{M}}$ is the modified mass matrix obtained by scaling the blocks of the original mass matrix $\mathbf{M}$ according to the strength ratios:
+where $\hat{\mathbf{q}}$ is the target state. The constraint mass matrix $\tilde{\mathbf{M}}$ is constructed from the **parallel-axis decomposition** of the physical mass matrix $\mathbf{M}$:
 
 $$
-\tilde{\mathbf{M}} = \begin{bmatrix}
-\eta_p \mathbf{M}^{pp} & \sqrt{\eta_p \eta_a} \mathbf{M}^{pa} \\
-\sqrt{\eta_p \eta_a} \mathbf{M}^{ap} & \eta_a \mathbf{M}^{aa}
-\end{bmatrix},
+\tilde{\mathbf{M}} = \eta_p\,\mathbf{M}_{cm} + \eta_a\,\mathbf{M}_{rot}, \quad \mathbf{M} = \mathbf{M}_{cm} + \mathbf{M}_{rot},
 $$
 
 where:
 
-- $\mathbf{M}^{pp}_{3 \times 3}$ is the position block of $\mathbf{M}$
-- $\mathbf{M}^{pa}_{3 \times 9}$ is the cross-term block of $\mathbf{M}$
-- $\mathbf{M}^{ap}_{9 \times 3}$ is the cross-term block of $\mathbf{M}$
-- $\mathbf{M}^{aa}_{9 \times 9}$ is the affine block of $\mathbf{M}$
-- $\eta_p \in (0,+\infty)$ is the position constraint strength ratio
-- $\eta_a \in (0,+\infty)$ is the affine (or rotation if not so rigorous) constraint strength ratio
+- $\mathbf{c}$ is the center of mass in the reference frame ($m\mathbf{c} = m\bar{\mathbf{x}}$)
+- $\mathbf{M}_{cm} = m\,\mathbf{J}(\mathbf{c})^T\mathbf{J}(\mathbf{c})$ is the ABD mass matrix of a point mass $m$ at $\mathbf{c}$, capturing the kinetic energy of center-of-mass translation
+- $\mathbf{M}_{rot} = \mathbf{M} - \mathbf{M}_{cm}$ captures rotation/deformation *about* the center of mass, with $\mathbf{S}_{cm} = \mathbf{S} - m\mathbf{c}\mathbf{c}^T$ in its affine block, where $\mathbf{S} = \int\rho\,\bar{\mathbf{x}}\bar{\mathbf{x}}^T\,dV$
+- $\eta_p \in [0,+\infty)$: translation (center-of-mass) constraint strength
+- $\eta_a \in [0,+\infty)$: rotation/deformation constraint strength
 
-The cross-terms use the geometric mean $\sqrt{\eta_p \eta_a}$ to maintain consistency between the position and affine constraints.
+Equivalently: $\tilde{\mathbf{M}} = \eta_a\,\mathbf{M} + (\eta_p - \eta_a)\,\mathbf{M}_{cm}$.
 
-The reason we use strength ratio is that the mass matrix $\mathbf{M}$ already contains the mass and inertia information, so that users only need to care about how strong the constraint is compared to the mass and inertia of the body, which is more intuitive.
-
-Because the constraint is "SOFT", we don't allow a too-strong strength which will lead to numerical instability. Normally, $\eta_p$ and $\eta_a$ are better in the range of $[0, 100]$.
+Because the constraint is "SOFT", overly large values will cause numerical instability. Normally $\eta_p$ and $\eta_a$ are better kept in the range $[0, 100]$.
 
 ## Attributes
 

--- a/include/uipc/constitution/soft_transform_constraint.h
+++ b/include/uipc/constitution/soft_transform_constraint.h
@@ -15,11 +15,12 @@ class UIPC_CONSTITUTION_API SoftTransformConstraint final : public Constraint
 
     /**
      * @brief Apply the constraint to the simplicial complex instances.
-     * 
+     *
      * @param sc The simplicial complex to apply the constraint to.
-     * @param strength_ratio The strength ratio of the constraint, strength_ratio[0] is the strength of the translation,
-     * strength_ratio[1] is the strength of the rotation.
-     * @param is_kinematic If the instances' kinetic energy is not considered.
+     * @param strength_ratio Constraint strength ratio (eta_p, eta_a), where:
+     *   strength_ratio[0] = eta_p: center-of-mass translation constraint strength.
+     *   strength_ratio[1] = eta_a: rotation/deformation-about-CM constraint strength.
+     *   Both values must be non-negative. Typical range: [0, 100].
      */
     void apply_to(geometry::SimplicialComplex& sc, const Vector2& strength_ratio) const;
 

--- a/src/backends/cuda/affine_body/abd_jacobi_matrix.h
+++ b/src/backends/cuda/affine_body/abd_jacobi_matrix.h
@@ -214,6 +214,8 @@ class ABDJacobiDyadicMass
 
     MUDA_GENERIC double mass() const { return m_mass; }
 
+    MUDA_GENERIC Vector3 mass_times_x_bar() const { return m_mass_times_x_bar; }
+
     /**
      * @brief Inertia tensor about center of mass (3x3).
      * Derived from second moment about origin: I_cm = I^O - m(|c|^2 I_3 - c c^T),

--- a/src/backends/cuda/affine_body/constraints/soft_transform_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/soft_transform_constraint.cu
@@ -14,9 +14,9 @@ inline UIPC_GENERIC Matrix12x12 compute_constraint_mass(const ABDJacobiDyadicMas
     Float s_r = rotation_strength;
     Float m   = mass.mass();
 
+    MUDA_ASSERT(m > 0.0, "ABDJacobiDyadicMass has non-positive mass (%f), cannot build constraint mass matrix.", m);
+
     Matrix12x12 M = mass.to_mat();
-    if(m <= Float(0))
-        return s_t * M;
 
     // Build M_cm = m*J(c)^T*J(c): the ABD mass matrix of a point mass m
     // concentrated at the center of mass c (where mc = m*c is the first moment).

--- a/src/backends/cuda/affine_body/constraints/soft_transform_constraint.cu
+++ b/src/backends/cuda/affine_body/constraints/soft_transform_constraint.cu
@@ -10,13 +10,27 @@ inline UIPC_GENERIC Matrix12x12 compute_constraint_mass(const ABDJacobiDyadicMas
                                                         Float translation_strength,
                                                         Float rotation_strength)
 {
+    Float s_t = translation_strength;
+    Float s_r = rotation_strength;
+    Float m   = mass.mass();
+
     Matrix12x12 M = mass.to_mat();
-    Float cross_term_strength = std::sqrt(translation_strength * rotation_strength);
-    M.block<3, 3>(0, 0) *= translation_strength;
-    M.block<3, 9>(0, 3) *= cross_term_strength;
-    M.block<9, 3>(3, 0) *= cross_term_strength;
-    M.block<9, 9>(3, 3) *= rotation_strength;
-    return M;
+    if(m <= Float(0))
+        return s_t * M;
+
+    // Build M_cm = m*J(c)^T*J(c): the ABD mass matrix of a point mass m
+    // concentrated at the center of mass c (where mc = m*c is the first moment).
+    // M = M_cm + M_rot  (parallel-axis decomposition)
+    // M_cm captures CM translation kinetics; M_rot captures rotation/deformation about CM.
+    Vector3   mc   = mass.mass_times_x_bar();  // m*c
+    Matrix3x3 mccT = mc * mc.transpose() / m;  // m*c*c^T
+
+    ABDJacobiDyadicMass cm_mass = ABDJacobiDyadicMass::from_dyadic_mass(m, mc, mccT);
+    Matrix12x12 M_cm = cm_mass.to_mat();
+
+    // M_constraint = s_t*M_cm + s_r*(M - M_cm)
+    //              = s_r*M + (s_t - s_r)*M_cm
+    return s_r * M + (s_t - s_r) * M_cm;
 }
 
 class SoftTransformConstraint final : public AffineBodyConstraint
@@ -173,7 +187,7 @@ class SoftTransformConstraint final : public AffineBodyConstraint
                    {
                        auto i = indices(I);
 
-                       Vector12 G;
+                       Vector12    G;
                        Matrix12x12 M;
 
                        if(is_fixed(i))

--- a/src/constitution/soft_transform_constraint.cpp
+++ b/src/constitution/soft_transform_constraint.cpp
@@ -25,7 +25,7 @@ SoftTransformConstraint::SoftTransformConstraint(const Json& config) noexcept
 }
 
 void SoftTransformConstraint::apply_to(geometry::SimplicialComplex& sc,
-                                       const Vector2& strength_rate) const
+                                       const Vector2& strength_ratio) const
 {
     Base::apply_to(sc);
 
@@ -35,7 +35,7 @@ void SoftTransformConstraint::apply_to(geometry::SimplicialComplex& sc,
     auto constraint_strength = sc.instances().find<Vector2>("strength_ratio");
     if(!constraint_strength)
         constraint_strength =
-            sc.instances().create<Vector2>("strength_ratio", strength_rate);
+            sc.instances().create<Vector2>("strength_ratio", strength_ratio);
     else
         UIPC_WARN_WITH_LOCATION("Attribute `strength_ratio` on instances already exists, which may cause ambiguity.");
 

--- a/src/pybind/pyuipc/constitution/soft_transform_constraint.cpp
+++ b/src/pybind/pyuipc/constitution/soft_transform_constraint.cpp
@@ -17,14 +17,16 @@ Args:
     config: Configuration dictionary (optional, uses default if not provided).)")
         .def(
             "apply_to",
-            [](SoftTransformConstraint& self, geometry::SimplicialComplex& sc, py::array_t<Float> strength_rate)
-            { self.apply_to(sc, to_matrix<Vector2>(strength_rate)); },
+            [](SoftTransformConstraint& self, geometry::SimplicialComplex& sc, py::array_t<Float> strength_ratio)
+            { self.apply_to(sc, to_matrix<Vector2>(strength_ratio)); },
             py::arg("sc"),
-            py::arg("strength_rate") = as_numpy(Vector2{100.0, 100}),
+            py::arg("strength_ratio") = as_numpy(Vector2{100.0, 100}),
             R"(Apply soft transform constraint to a simplicial complex.
 Args:
     sc: SimplicialComplex to apply to.
-    strength_rate: 2D vector [translation_strength, rotation_strength] (default: [100.0, 100]).)")
+    strength_ratio: 2D vector (eta_p, eta_a), where eta_p controls center-of-mass
+        translation strength and eta_a controls rotation/deformation-about-CM strength
+        (default: [100.0, 100]).)")
         .def_static("default_config",
                     &SoftTransformConstraint::default_config,
                     R"(Get the default SoftTransformConstraint configuration.


### PR DESCRIPTION
## Summary

- **Fix compute_constraint_mass in SoftTransformConstraint** to correctly separate translation and rotation constraint strengths for bodies whose center of mass (CM) is not at the model-space origin.
- **Add ABDJacobiDyadicMass::mass_times_x_bar() accessor** to expose the first moment mc = m*c.
- **Unify naming** strength_rate -> strength_ratio across the C++ frontend implementation and Python bindings.
- **Update documentation** (soft_transform_constraint.md) with the new physically-grounded formula.
- **Add sim case 92_abd_stc_off_origin_cm** that verifies the fix with a numerical assertion.

## Problem

The old formula scaled the 12x12 physical mass matrix by block partition:

`
M_tilde[pp] *= eta_p
M_tilde[pa] *= sqrt(eta_p * eta_a)   // unphysical geometric mean
M_tilde[aa] *= eta_a                  // uses S (moment about origin), not S_cm
`

This is only correct when c = 0. When c != 0:
1. The coupling blocks arise purely from the CM offset and must scale with eta_p, not sqrt(eta_p * eta_a).
2. The affine block contains a translational contribution m*c*c^T that must scale with eta_p, not eta_a.

## Fix

Apply the **parallel-axis decomposition** M = M_cm + M_rot, where M_cm = m * J(c)^T * J(c) is the ABD mass matrix of a point mass at c:

`
M_tilde = eta_p * M_cm + eta_a * M_rot
        = eta_a * M + (eta_p - eta_a) * M_cm
`

- eta_p weights center-of-mass **translation** kinetics.
- eta_a weights rotation/deformation **about the CM** kinetics.
- Reduces to the old behavior when c = 0.
- Positive semi-definite for any eta_p, eta_a >= 0.

## Test

Sim case 92_abd_stc_off_origin_cm: rigid body with CM at (0, 1, 0) in model space, translation-only constraint (eta_p=100, eta_a=0), aim rotated 90 deg around Z. The body's translation DOF must compensate so that the world-space CM tracks the aim CM. Asserts x_cm.isApprox(Rz(90)*c) at machine precision.
