### PR TITLE
fix(cuda): correct affine joint external-force generalized forces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,38 @@ Modules mirror C++ namespaces:
 - `uipc.geometry` - Geometry operations
 - `uipc.constitution` - Material models
 - `uipc.unit` - Physical units (GPa, MPa, etc.)
+
+## Cursor Rules and Skills
+
+This repo also has Cursor-format rules and skills that apply to Claude Code work:
+
+- **Always-on rules** — read `.cursor/rules/*.mdc` at the start of any coding task and follow them. Treat the prose as authoritative. Ignore Cursor-specific syntax: `mdc:<path>` links are just relative file paths, and the frontmatter (`globs`, `alwaysApply`, etc.) is for Cursor's auto-attach logic — not instructions for you. Currently:
+  - `.cursor/rules/cpp-format.mdc` — C++ formatting rules (clang-format-aligned style). Apply to every `*.h *.hpp *.cpp *.inl *.cu *.cuh` edit.
+  - `.cursor/rules/self-improvement.mdc` — when you notice repeated patterns or rule gaps, propose updates to the rules.
+
+- **Cursor skills** — `.cursor/skills/<name>/SKILL.md`. Each has YAML frontmatter with `name`, `description`, and optional `disable-model-invocation: true` (which means the user must explicitly invoke it; do NOT auto-trigger).
+
+  **How to use them:** when the user's request matches a skill — by name (e.g. "run the `commit` skill", "/format"), by intent matching the description, or by explicit ask — read the full `.cursor/skills/<name>/SKILL.md` with the Read tool and follow its steps. Skills may reference other skills via `[name](./other.md)` links — load those too on demand.
+
+  **Available skills (index):**
+
+  *Auto-triggerable (read whenever the description matches the task):*
+  - `cmake-workflow` — Build and test libuipc via CMake (configure, RelWithDebInfo, Catch2). Trigger on build/test asks.
+  - `commit-convention` — Conventional commit message format and rules for this project.
+  - `cursor-rules` — How to add or edit Cursor rules in this project.
+  - `document` — Documentation style guide and rules.
+  - `gpu-optimization` — GPU profiling/optimization workflow (`uipc.profile`, `uipc.profile.nsight`, Nsight Compute CLI). Trigger when profiling/optimizing CUDA kernels.
+  - `project-structure` — Overview of main directories and important files. Trigger when needing repo layout.
+  - `repository-setup` — Setting up remotes when working with forks.
+  - `review-pr` — End-to-end PR review (checkout, summarize, domain-aware AI review covering physics, backend, C++ style, GPU, pybind). Trigger on PR-review asks.
+  - `simulation-dev` — Simulation dev best practices: correctness, stability, debuggability, index safety, NaN/Inf, diagnostics. Trigger when modifying solvers/constraints/GPU kernels.
+  - `xmake-workflow` — Build/test via XMake (alternate build system).
+
+  *Explicit-invocation only (`disable-model-invocation: true` — only when the user explicitly asks):*
+  - `commit` — Create a conventional commit locally (no push without explicit ask).
+  - `fix-issue` — Fix a GitHub issue with proper branch / testing / PR flow.
+  - `fix-pr` — Fix a PR based on review feedback.
+  - `format` — Run `clang-format` on C++ files changed vs. `main`.
+  - `github-pr` — Create a structured pull request.
+  - `push-tag` — Push a version tag and optionally create a GitHub release.
+  - `run-tests` — Run C++ and Python tests.

--- a/docs/specification/constitutions/affine_body_prismatic_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_prismatic_joint_external_force.md
@@ -6,41 +6,43 @@ The **Affine Body Prismatic Joint External Force** applies a scalar external for
 
 ## Force Application
 
-Given a scalar force $f$ and the joint tangent direction $\hat{\mathbf{t}}$, the external force is applied as a 12D generalized force to each connected affine body:
+Given a scalar force $f$ and the per-body joint tangent $\hat{\mathbf{t}}_k$, the external force enters as a translational generalized force on each body's affine origin DOF:
 
 $$
-\mathbf{F}_i = \begin{bmatrix} +f \, \hat{\mathbf{t}}_i \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12}, \quad
-\mathbf{F}_j = \begin{bmatrix} -f \, \hat{\mathbf{t}}_j \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12},
+\mathbf{F}_k = \begin{bmatrix} +f \, \hat{\mathbf{t}}_k \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12}, \quad k \in \{i, j\},
 $$
 
 where:
 
 - $f$ is the scalar force magnitude (per edge)
-- $\hat{\mathbf{t}}_i = \mathring{\mathbf{J}}^{\hat{t}}_i \mathbf{q}_i$ is the joint tangent direction in body $i$'s current frame
-- $\hat{\mathbf{t}}_j = \mathring{\mathbf{J}}^{\hat{t}}_j \mathbf{q}_j$ is the joint tangent direction in body $j$'s current frame
-- $\mathbf{0}_9$ denotes the nine-dimensional zero vector (no affine force component)
+- $\hat{\mathbf{t}}_k$ is the joint tangent direction on body $k$ in world space
+- $\mathbf{0}_9$ is the nine-dimensional zero vector (no rotational generalized force)
 
-The tangent directions $\hat{\mathbf{t}}_i$ and $\hat{\mathbf{t}}_j$ are extracted from the current affine body states using the rest-space tangent coordinates, following the same conventions as the [Prismatic Joint](./affine_body_prismatic_joint.md).
+The same $+f$ is applied to both bodies; Newton's third law is encoded geometrically by $\hat{\mathbf{t}}_i \approx -\hat{\mathbf{t}}_j$ (see [below](#parent-vs-child-tangent-and-positive-force)).
 
-A positive $f$ pushes body $i$ along $+\hat{\mathbf{t}}$ and body $j$ along $-\hat{\mathbf{t}}$, effectively driving the two bodies apart along the joint axis.
+### Tangent Direction
 
-## Energy Integration
-
-The external forces are incorporated into each affine body's kinetic energy term through the predicted position $\tilde{\mathbf{q}}$, following the same mechanism as [AffineBodyExternalForce](./affine_body_external_force.md):
+The joint tangent on body $k$ is defined by two anchor points $\mathbf{x}^0_k$ and $\mathbf{x}^1_k$ in world space, following the base [Prismatic Joint](./affine_body_prismatic_joint.md) convention. The tangent direction is the normalized chord between them:
 
 $$
-E = \frac{1}{2} \left(\mathbf{q} - \tilde{\mathbf{q}}\right)^T \mathbf{M} \left(\mathbf{q} - \tilde{\mathbf{q}}\right),
+\hat{\mathbf{t}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\bigl\|\mathbf{x}^1_k - \mathbf{x}^0_k\bigr\|}, \quad k \in \{i, j\}.
 $$
 
-where $\tilde{\mathbf{q}}$ is updated each time step to include the acceleration from the external force:
+<a id="parent-vs-child-tangent-and-positive-force"></a>
+
+### Parent vs. child tangent and positive force
+
+**Parent** $=$ left $(i)$, **child** $=$ right $(j)$, matching the base joint. The two anchor pairs are laid out in opposite order on the two bodies, so the per-body tangents point opposite ways: $\hat{\mathbf{t}}_i \approx -\hat{\mathbf{t}}_j$.
+
+A positive `external_force` applies $+f\,\hat{\mathbf{t}}_i$ to the parent and $+f\,\hat{\mathbf{t}}_j$ to the child; because $\hat{\mathbf{t}}_i = -\hat{\mathbf{t}}_j$, this drives the two bodies apart along the joint axis (or together when $f < 0$). This polarity applies only to this constitution (UID 667); the shared `distance` frame for limits and driving targets follows the base [Prismatic Joint](./affine_body_prismatic_joint.md#distance-state).
+
+## Time Integration
+
+`external_force` contributes **no potential energy of its own**. The generalized force $\mathbf{F}_k$ from § [Force Application](#force-application) enters the time step only through the predicted position $\tilde{\mathbf{q}}_k$ (i.e. as an inertial shift), in the same way as [AffineBodyExternalForce](./affine_body_external_force.md):
 
 $$
-\mathbf{a}_{ext} = \mathbf{M}^{-1} \mathbf{F}_{ext}.
+\mathbf{a}_{\text{ext},k} = \mathbf{M}_k^{-1} \mathbf{F}_k.
 $$
-
-## State Update
-
-The current signed displacement $d_{\text{current}}$ is tracked and written back to the `distance` edge attribute by the **base** [AffineBodyPrismaticJoint](./affine_body_prismatic_joint.md) — not by this external-force constitution. See [Distance State](./affine_body_prismatic_joint.md#distance-state) for the formulation.
 
 ## Runtime Control
 
@@ -55,9 +57,7 @@ This constitution must be applied to a geometry that already has an [AffineBodyP
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). The edge inherits all linking and state fields of the base [Affine Body Prismatic Joint](./affine_body_prismatic_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, `strength_ratio`, `distance`, `init_distance`, and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
-
-External-force-specific attributes on **edges**:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). Linking and state fields are inherited from the base [Affine Body Prismatic Joint](./affine_body_prismatic_joint.md). The fields owned by this constitution are:
 
 - `external_force`: $f$ in the formulae above, scalar force along the joint axis (one per edge)
 - `external_force/is_constrained`: enables (`1`) or disables (`0`) the external force

--- a/docs/specification/constitutions/affine_body_prismatic_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_prismatic_joint_external_force.md
@@ -15,24 +15,36 @@ $$
 where:
 
 - $f$ is the scalar force magnitude (per edge)
-- $\hat{\mathbf{t}}_k$ is the joint tangent direction on body $k$ in world space
+- $\hat{\mathbf{t}}_k$ is the joint tangent direction on body $k$ in world space (see [Tangent Direction](#tangent-direction))
 - $\mathbf{0}_9$ is the nine-dimensional zero vector (no rotational generalized force)
 
-The same $+f$ is applied to both bodies; Newton's third law is encoded geometrically by $\hat{\mathbf{t}}_i \approx -\hat{\mathbf{t}}_j$ (see [below](#parent-vs-child-tangent-and-positive-force)).
+The same $+f$ is applied to both bodies; Newton's third law is encoded by the strict antisymmetry $\hat{\mathbf{t}}_i = -\hat{\mathbf{t}}_j$ that is enforced numerically in § [Tangent Direction](#tangent-direction).
 
 ### Tangent Direction
 
-The joint tangent on body $k$ is defined by two anchor points $\mathbf{x}^0_k$ and $\mathbf{x}^1_k$ in world space, following the base [Prismatic Joint](./affine_body_prismatic_joint.md) convention. The tangent direction is the normalized chord between them:
+The joint tangent on body $k$ is defined by two anchor points $\mathbf{x}^0_k$ and $\mathbf{x}^1_k$ in world space, following the base [Prismatic Joint](./affine_body_prismatic_joint.md) convention. Each body first computes its own raw world-space tangent from its own anchors and current pose:
 
 $$
-\hat{\mathbf{t}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\bigl\|\mathbf{x}^1_k - \mathbf{x}^0_k\bigr\|}, \quad k \in \{i, j\}.
+\tilde{\mathbf{t}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\bigl\|\mathbf{x}^1_k - \mathbf{x}^0_k\bigr\|}, \quad k \in \{i, j\}.
 $$
+
+By construction the two anchor pairs are laid out in opposite order on the two bodies, so $\tilde{\mathbf{t}}_i \approx -\tilde{\mathbf{t}}_j$ whenever the joint constraint is satisfied. To absorb residual numerical drift near the singularity (and to guarantee Newton's third law bit-exactly regardless of the per-body roundoff), the two raw tangents are symmetrized into one strictly antisymmetric pair:
+
+$$
+\hat{\mathbf{t}}_j = \tfrac{1}{2}\bigl(\tilde{\mathbf{t}}_j + \tilde{\mathbf{t}}_i\bigr),
+$$
+
+$$
+\hat{\mathbf{t}}_i = -\hat{\mathbf{t}}_j.
+$$
+
+The averaging step is a first-order denoiser: as long as the joint is well-posed, $\tilde{\mathbf{t}}_i + \tilde{\mathbf{t}}_j$ is roundoff-level and the corrected tangents lie within the same $\mathcal{O}(\varepsilon)$ neighborhood as the raw ones, while strict antisymmetry $\hat{\mathbf{t}}_i = -\hat{\mathbf{t}}_j$ now holds exactly. If the magnitude of $\tilde{\mathbf{t}}_i + \tilde{\mathbf{t}}_j$ is non-trivial, the joint constraint itself has drifted and the upstream constraint solver — not this symmetrization — is responsible for the fix.
 
 <a id="parent-vs-child-tangent-and-positive-force"></a>
 
 ### Parent vs. child tangent and positive force
 
-**Parent** $=$ left $(i)$, **child** $=$ right $(j)$, matching the base joint. The two anchor pairs are laid out in opposite order on the two bodies, so the per-body tangents point opposite ways: $\hat{\mathbf{t}}_i \approx -\hat{\mathbf{t}}_j$.
+**Parent** $=$ left $(i)$, **child** $=$ right $(j)$, matching the base joint. The two anchor pairs are laid out in opposite order on the two bodies, so the raw per-body tangents point opposite ways: $\tilde{\mathbf{t}}_i \approx -\tilde{\mathbf{t}}_j$. After the symmetrization in § [Tangent Direction](#tangent-direction) this becomes the exact identity $\hat{\mathbf{t}}_i = -\hat{\mathbf{t}}_j$.
 
 A positive `external_force` applies $+f\,\hat{\mathbf{t}}_i$ to the parent and $+f\,\hat{\mathbf{t}}_j$ to the child; because $\hat{\mathbf{t}}_i = -\hat{\mathbf{t}}_j$, this drives the two bodies apart along the joint axis (or together when $f < 0$). This polarity applies only to this constitution (UID 667); the shared `distance` frame for limits and driving targets follows the base [Prismatic Joint](./affine_body_prismatic_joint.md#distance-state).
 

--- a/docs/specification/constitutions/affine_body_revolute_joint.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint.md
@@ -40,14 +40,7 @@ where $K$ is the stiffness constant of the joint, we choose $K=\gamma (m_i + m_j
 
 ## Angle State
 
-The revolute joint tracks a scalar joint angle $\theta$ that extra-per-joint constitutions (driving joint, angle limit, external torque) share. The backend builds, for each body $k \in \{i,j\}$, an orthonormal basis $(\hat{\mathbf{t}}_k, \hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k)$ aligned with the joint axis at setup, where
-
-$$
-\hat{\mathbf{t}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\|\mathbf{x}^1_k - \mathbf{x}^0_k\|}, \quad
-\hat{\mathbf{b}}_k = \hat{\mathbf{t}}_k \times \hat{\mathbf{n}}_k,
-$$
-
-and the $(\hat{\mathbf{n}}, \hat{\mathbf{b}})$ pair is stored per body in the layout $[\hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k]$. The current relative angle between the two bodies is extracted as
+The revolute joint tracks a scalar joint angle $\theta$ that extra-per-joint constitutions (driving joint, angle limit, external torque) share. The backend constructs per body $k \in \{i,j\}$ an orthonormal basis $(\hat{\mathbf{t}}_k, \hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k)$ from the hinge geometry embedded in symbolic generation and Jacobian layout for this constitution (see `sym/affine_body_revolute_joint` alongside deployed kernels): $\hat{\mathbf{t}}_k$ is the **unit tangent** along body $k$’s hinge segment; $\hat{\mathbf{b}}_k = \hat{\mathbf{t}}_k \times \hat{\mathbf{n}}_k$. Pair $[\hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k]$ is the rotating perpendicular frame used downstream. Current relative angle is
 
 $$
 \cos\theta = \frac{\hat{\mathbf{n}}_i \cdot \hat{\mathbf{n}}_j + \hat{\mathbf{b}}_i \cdot \hat{\mathbf{b}}_j}{2}, \quad
@@ -70,9 +63,9 @@ $$
 \hat{\mathbf{t}}_{\mathrm{parent}} = \hat{\mathbf{t}}_i = -\,\hat{\mathbf{t}}_{\mathrm{child}} = -\,\hat{\mathbf{t}}_j,
 $$
 
-because each body carries its edge from attachment point \(\mathbf{x}^0_k\) to \(\mathbf{x}^1_k\) while the pairing links endpoints across bodies along the same physical axis.
+because each body carries its edge from attachment point $\mathbf{x}^0_k$ to $\mathbf{x}^1_k$ while the pairing links endpoints across bodies along the same physical axis.
 
-Angular state $\theta$, `angle`, limits, and driving use **both** bodies’ bases symmetrically via the formulas above. Which ray defines **positive external torque** is specified **only** for constitution **Affine Body Revolute Joint External Force** (UID 668): actuator torque follows **child-positive** \(+\hat{\mathbf{t}}_{\mathrm{child}}\); see [Parent vs. child axis and positive torque](./affine_body_revolute_joint_external_force.md#parent-vs-child-axis-and-positive-torque).
+Angular state $\theta$, `angle`, limits, and driving use **both** bodies’ bases symmetrically via the formulas above. Which ray defines **positive external torque** is specified **only** for constitution **Affine Body Revolute Joint External Force** (UID 668): actuator torque follows **child-positive** $+\hat{\mathbf{t}}_{\mathrm{child}}$; see [Parent vs. child axis and positive torque](./affine_body_revolute_joint_external_force.md#parent-vs-child-axis-and-positive-torque).
 
 ### State Update
 

--- a/docs/specification/constitutions/affine_body_revolute_joint.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint.md
@@ -58,7 +58,21 @@ $$
 \theta = \operatorname{atan2}(\sin\theta,\; \cos\theta) \in (-\pi, \pi].
 $$
 
-The sign follows the right-hand rule around $+\hat{\mathbf{t}}$ (counterclockwise when viewed along $+\hat{\mathbf{t}}$).
+The sign follows the right-hand rule **about the child tangent** $+\hat{\mathbf{t}}_{\mathrm{child}}$ (see below): counterclockwise when viewed along $+\hat{\mathbf{t}}_{\mathrm{child}}$.
+
+### Parent vs. child along the axis
+
+Map **left geometry** (`l_*`, body $i$) to **parent** and **right geometry** (`r_*`, body $j$) to **child**, matching typical kinematic-tree layout.
+
+At a valid configuration, the mapped joint axis rays are **anti-parallel** on the shared line:
+
+$$
+\hat{\mathbf{t}}_{\mathrm{parent}} = \hat{\mathbf{t}}_i = -\,\hat{\mathbf{t}}_{\mathrm{child}} = -\,\hat{\mathbf{t}}_j,
+$$
+
+because each body carries its edge from attachment point \(\mathbf{x}^0_k\) to \(\mathbf{x}^1_k\) while the pairing links endpoints across bodies along the same physical axis.
+
+Angular state $\theta$, `angle`, limits, and driving use **both** bodies’ bases symmetrically via the formulas above. Which ray defines **positive external torque** is specified **only** for constitution **Affine Body Revolute Joint External Force** (UID 668): actuator torque follows **child-positive** \(+\hat{\mathbf{t}}_{\mathrm{child}}\); see [Parent vs. child axis and positive torque](./affine_body_revolute_joint_external_force.md#parent-vs-child-axis-and-positive-torque).
 
 ### State Update
 

--- a/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
@@ -6,93 +6,52 @@ The **Affine Body Revolute Joint External Force** applies a scalar external torq
 
 ## Torque Application
 
-Given a scalar torque $\tau$ and the joint axis direction $\hat{\mathbf{e}}$, the external torque is converted into a translational force at each body's center of mass. The torque produces equal-and-opposite tangential forces on the two bodies:
+Given a scalar torque $\tau$ and the joint axis direction $\hat{\mathbf{e}}$, the external torque is mapped via the principle of virtual work directly to an equivalent **generalized force on the affine rotational DOF** of each body — without forming a translational force or evaluating a center-of-mass lever arm. For each body $k \in \{i, j\}$ with affine matrix $\mathbf{A}_k \in \mathbb{R}^{3 \times 3}$ extracted from $\mathbf{q}_k$:
 
 $$
-\mathbf{F}_i = \begin{bmatrix} -\tau \, \dfrac{\hat{\mathbf{e}}_i \times \mathbf{r}_i}{\|\mathbf{r}_i\|^2} \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12}, \quad
-\mathbf{F}_j = \begin{bmatrix} +\tau \, \dfrac{\hat{\mathbf{e}}_j \times \mathbf{r}_j}{\|\mathbf{r}_j\|^2} \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12},
+\mathbf{F}_k = \begin{bmatrix} \mathbf{0}_3 \\ \operatorname{vec}\!\bigl(\mathbf{F}^A_k\bigr) \end{bmatrix} \in \mathbb{R}^{12},
+\qquad
+\mathbf{F}^A_k = \frac{\tau}{2} \, [\hat{\mathbf{e}}_k]_\times \, \mathbf{A}_k^{-T},
 $$
 
 where:
 
 - $\tau$ is the scalar torque magnitude (per edge)
-- $\hat{\mathbf{e}}_k$ is the normalized joint axis direction in body $k$'s current frame
-- $\mathbf{r}_k$ is the lever arm vector from the joint axis to body $k$'s center of mass, perpendicular to the axis
-- $\mathbf{0}_9$ denotes the nine-dimensional zero vector (no affine force component)
+- $\hat{\mathbf{e}}_k$ is the normalized joint axis direction in body $k$'s current world frame
+- $[\hat{\mathbf{e}}_k]_\times \in \mathbb{R}^{3 \times 3}$ is the skew-symmetric matrix satisfying $[\hat{\mathbf{e}}_k]_\times \mathbf{w} = \hat{\mathbf{e}}_k \times \mathbf{w}$
+- $\mathbf{A}_k^{-T}$ is the inverse-transpose of body $k$'s current affine matrix
+- $\operatorname{vec}(\cdot)$ packs a $3 \times 3$ matrix into the $9$ components of $\mathbf{q}_k[3{:}12]$ in **row-major** order, matching the row-major layout used for the rows of $\mathbf{A}_k$ in $\mathbf{q}_k$
+- $\mathbf{0}_3$ denotes the three-dimensional zero vector — a pure torque produces no translational generalized force, regardless of whether $\mathbf{x}_k$ is the COM or a mesh anchor
+
+The same factor $\tau$ is applied to both bodies; Newton's third law is encoded geometrically by $\hat{\mathbf{e}}_j \approx -\hat{\mathbf{e}}_i$ (see [below](#parent-vs-child-axis-and-positive-torque)), so the opposite axis direction supplies the opposite-sign reaction.
+
+### Reduction to rigid body
+
+When $\mathbf{A}_k \in SO(3)$ (no shear or scale, i.e. an undeformed rigid body), $\mathbf{A}_k^{-T} = \mathbf{A}_k$ and the formula reduces to the familiar rigid-body torque-on-rotation generalized force $\mathbf{F}^A_k = \tfrac{1}{2}[\hat{\mathbf{e}}_k]_\times \mathbf{A}_k$. The factor $\mathbf{A}_k^{-T}$ is the affine-body correction for shear/scale; it vanishes in the rigid limit.
 
 ### Axis Direction
 
-The joint axis is defined by two points $\mathbf{x}^0$ and $\mathbf{x}^1$ on each body, following the [Revolute Joint](./affine_body_revolute_joint.md) convention. The axis direction in world space is:
+The joint axis on body $k$ is defined by two anchor points $\mathbf{x}^0_k$ and $\mathbf{x}^1_k$ in world space, following the base [Revolute Joint](./affine_body_revolute_joint.md) convention. The axis direction is the normalized chord between them:
 
 $$
-\hat{\mathbf{e}}_k = \frac{\mathring{\mathbf{J}}^{\hat{e}}_k \mathbf{q}_k}{\|\mathring{\mathbf{J}}^{\hat{e}}_k \mathbf{q}_k\|}, \quad k \in \{i, j\},
+\hat{\mathbf{e}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\bigl\|\mathbf{x}^1_k - \mathbf{x}^0_k\bigr\|}, \quad k \in \{i, j\}.
 $$
-
-where $\mathring{\mathbf{J}}^{\hat{e}}_k$ maps the rest-space axis direction through the current affine transform.
 
 <a id="parent-vs-child-axis-and-positive-torque"></a>
 
 ### Parent vs. child axis and positive torque
 
-Indexing matches the base joint: **parent** $=$ left $(i)$, **child** $=$ right $(j)$. For each joint, the CUDA backend builds two normalized axis vectors from rest segments $(\bar{\mathbf{x}}^1-\bar{\mathbf{x}}^0)$ **per body**; they coincide as a geometric line but point **opposite** directions,
+**Parent** $=$ left $(i)$, **child** $=$ right $(j)$, matching the base joint. The two anchor pairs are laid out in opposite order on the two bodies, so the axes point opposite ways: $\hat{\mathbf{e}}_i \approx -\hat{\mathbf{e}}_j$.
+
+`external_torque` is **child-positive**: a positive $\tau$ applies a right-hand torque about $\hat{\mathbf{e}}_j$ (the child axis); the parent receives the equal-and-opposite reaction automatically because $\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j$. This polarity applies only to this constitution (UID 668); the shared `angle` frame for limits and driving targets follows the base [Revolute Joint](./affine_body_revolute_joint.md#angle-state).
+
+## Time Integration
+
+`external_torque` contributes **no potential energy of its own**. The generalized force $\mathbf{F}_k$ from § [Torque Application](#torque-application) enters the time step only through the predicted position $\tilde{\mathbf{q}}_k$ (i.e. as an inertial shift), in the same way as [AffineBodyExternalForce](./affine_body_external_force.md):
 
 $$
-\hat{\mathbf{e}}_i \approx -\,\hat{\mathbf{e}}_j \qquad\text{(parent axis opposite child axis)}.
+\mathbf{a}_{\text{ext},k} = \mathbf{M}_k^{-1} \mathbf{F}_k.
 $$
-
-The scalar attribute `external_torque` is **child-positive**: a **positive** $\tau$ applies a right-hand torque about **the child’s** axis direction $\hat{\mathbf{e}}_{\mathrm{child}} = \hat{\mathbf{e}}_j$ (equivalently, about $-\hat{\mathbf{e}}_i$ on the parent). The force kernel uses each body’s own $\hat{\mathbf{e}}_k$ and lever arm $\mathbf{r}_k$ so the pair is consistent with this convention.
-
-This parent/child polarity matters for interpreting **only** this external-force constitution (UID 668), not for renaming $\theta$ or for limit/driving targets, which follow the shared `angle` frame in [Angle State](./affine_body_revolute_joint.md#angle-state).
-
-### Center of mass (reference configuration)
-
-For each body $k \in \{i, j\}$, let $\bar{\mathbf{c}}_k \in \mathbb{R}^3$ be the center of mass in the **reference configuration** — the same frame as the rest vertices and $m\bar{\mathbf{x}}$ in the dyadic mass on the affine body geometry ([Affine Body](./affine_body.md)). It is
-
-$$
-\bar{\mathbf{c}}_k = \frac{(m\bar{\mathbf{x}})_k}{m_k},
-$$
-
-using that body’s $m_k$, $(m\bar{\mathbf{x}})_k$ from `abd_mass` / `abd_mass_x_bar` (equivalently `mass_center` in meta).
-
-### Lever Arm
-
-Let $\bar{\mathbf{x}}^0_k$ be the rest-frame anchor point on body $k$ for the joint (paired with the axis segment as in [Revolute Joint](./affine_body_revolute_joint.md)). Write $\mathbf{T}_k(\bar{\mathbf{x}})$ for the world-space position of a rest point under body $k$’s current affine coordinates $\mathbf{q}_k$. The vector from the anchor to the center of mass in world space is
-
-$$
-\mathbf{d}_k = \mathbf{T}_k(\bar{\mathbf{c}}_k) - \mathbf{T}_k(\bar{\mathbf{x}}^0_k),
-$$
-
-equivalently the linear map applied to $\bar{\mathbf{c}}_k - \bar{\mathbf{x}}^0_k$ (translation drops out along this displacement). The lever arm orthogonal to the axis is
-
-$$
-\mathbf{r}_k = \mathbf{d}_k - (\mathbf{d}_k \cdot \hat{\mathbf{e}}_k) \hat{\mathbf{e}}_k.
-$$
-
-If $\bar{\mathbf{c}}_k = \mathbf{0}$ (reference origin at COM), $\mathbf{d}_k = -\mathbf{T}_k(\bar{\mathbf{x}}^0_k) = \mathbf{T}_k(\mathbf{0}) - \mathbf{T}_k(\bar{\mathbf{x}}^0_k)$, recovering the chord from anchor to origin.
-
-When $\|\mathbf{r}_k\|^2 < \epsilon$ (within a numerical cutoff), that body contributes no coupling force from this step.
-
-### Sign Convention
-
-Let $\hat{\mathbf{e}}_{\mathrm{child}}=\hat{\mathbf{e}}_j$ and $\hat{\mathbf{e}}_{\mathrm{parent}}=\hat{\mathbf{e}}_i=-\hat{\mathbf{e}}_j$. A positive $\tau$ applies a right-hand torque about $+\hat{\mathbf{e}}_{\mathrm{child}}$ (child-positive; see [above](#parent-vs-child-axis-and-positive-torque)). The two bodies receive tangential impulse at their centers of mass via the per-body $\hat{\mathbf{e}}_k\times\mathbf{r}_k$ terms in § [Torque Application](#torque-application).
-
-## Energy Integration
-
-The external forces are incorporated into each affine body's kinetic energy term through the predicted position $\tilde{\mathbf{q}}$, following the same mechanism as [AffineBodyExternalForce](./affine_body_external_force.md):
-
-$$
-E = \frac{1}{2} \left(\mathbf{q} - \tilde{\mathbf{q}}\right)^T \mathbf{M} \left(\mathbf{q} - \tilde{\mathbf{q}}\right),
-$$
-
-where $\tilde{\mathbf{q}}$ is updated each time step to include the acceleration from the external force:
-
-$$
-\mathbf{a}_{ext} = \mathbf{M}^{-1} \mathbf{F}_{ext}.
-$$
-
-## State Update
-
-The current joint angle $\theta_{\text{current}}$ is tracked and written back to the `angle` edge attribute by the **base** [AffineBodyRevoluteJoint](./affine_body_revolute_joint.md) — not by this external-force constitution. See [Angle State](./affine_body_revolute_joint.md#angle-state) for the formulation.
 
 ## Runtime Control
 
@@ -107,9 +66,7 @@ This constitution must be applied to a geometry that already has an [AffineBodyR
 
 ## Attributes
 
-On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). The edge inherits all linking and state fields of the base [Affine Body Revolute Joint](./affine_body_revolute_joint.md): `l_geo_id`, `r_geo_id`, `l_inst_id`, `r_inst_id`, `strength_ratio`, `angle`, `init_angle`, and optional `l_position0`, `l_position1`, `r_position0`, `r_position1` when created via Local `create_geometry`.
-
-External-force-specific attributes on **edges**:
+On the joint geometry (1D simplicial complex), on **edges** (one edge per joint). Linking and state fields are inherited from the base [Affine Body Revolute Joint](./affine_body_revolute_joint.md). The fields owned by this constitution are:
 
 - `external_torque`: $\tau$ in the formulae above, scalar torque around the joint axis (one per edge)
 - `external_torque/is_constrained`: enables (`1`) or disables (`0`) the external torque

--- a/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
@@ -30,22 +30,51 @@ $$
 
 where $\mathring{\mathbf{J}}^{\hat{e}}_k$ maps the rest-space axis direction through the current affine transform.
 
+<a id="parent-vs-child-axis-and-positive-torque"></a>
+
+### Parent vs. child axis and positive torque
+
+Indexing matches the base joint: **parent** \(=\) left \((i)\), **child** \(=\) right \((j)\). For each joint, the CUDA backend builds two normalized axis vectors from rest segments \((\bar{\mathbf{x}}^1-\bar{\mathbf{x}}^0)\) **per body**; they coincide as a geometric line but point **opposite** directions,
+
+$$
+\hat{\mathbf{e}}_i \approx -\,\hat{\mathbf{e}}_j \qquad\text{(parent axis opposite child axis)}.
+$$
+
+The scalar attribute `external_torque` is **child-positive**: a **positive** \(\tau\) applies a right-hand torque about **the child’s** axis direction \(\hat{\mathbf{e}}_{\mathrm{child}} = \hat{\mathbf{e}}_j\) (equivalently, about \(-\hat{\mathbf{e}}_i\) on the parent). The force kernel uses each body’s own \(\hat{\mathbf{e}}_k\) and lever arm \(\mathbf{r}_k\) so the pair is consistent with this convention.
+
+This parent/child polarity matters for interpreting **only** this external-force constitution (UID 668), not for renaming \(\theta\) or for limit/driving targets, which follow the shared `angle` frame in [Angle State](./affine_body_revolute_joint.md#angle-state).
+
+### Center of mass (reference configuration)
+
+For each body $k \in \{i, j\}$, let $\bar{\mathbf{c}}_k \in \mathbb{R}^3$ be the center of mass in the **reference configuration** — the same frame as the rest vertices and $m\bar{\mathbf{x}}$ in the dyadic mass on the affine body geometry ([Affine Body](./affine_body.md)). It is
+
+$$
+\bar{\mathbf{c}}_k = \frac{(m\bar{\mathbf{x}})_k}{m_k},
+$$
+
+using that body’s $m_k$, $(m\bar{\mathbf{x}})_k$ from `abd_mass` / `abd_mass_x_bar` (equivalently `mass_center` in meta).
+
 ### Lever Arm
 
-The lever arm $\mathbf{r}_k$ is the perpendicular distance from the joint axis to the center of mass of body $k$:
+Let $\bar{\mathbf{x}}^0_k$ be the rest-frame anchor point on body $k$ for the joint (paired with the axis segment as in [Revolute Joint](./affine_body_revolute_joint.md)). Write $\mathbf{T}_k(\bar{\mathbf{x}})$ for the world-space position of a rest point under body $k$’s current affine coordinates $\mathbf{q}_k$. The vector from the anchor to the center of mass in world space is
 
 $$
-\mathbf{d}_k = -\mathring{\mathbf{J}}^{\mathbf{x}^0_k} \mathbf{q}_k, \quad
-\mathbf{r}_k = \mathbf{d}_k - (\mathbf{d}_k \cdot \hat{\mathbf{e}}_k) \hat{\mathbf{e}}_k,
+\mathbf{d}_k = \mathbf{T}_k(\bar{\mathbf{c}}_k) - \mathbf{T}_k(\bar{\mathbf{x}}^0_k),
 $$
 
-where $\mathbf{d}_k$ is the vector from the axis point to the center of mass in world space.
+equivalently the linear map applied to $\bar{\mathbf{c}}_k - \bar{\mathbf{x}}^0_k$ (translation drops out along this displacement). The lever arm orthogonal to the axis is
 
-When $\|\mathbf{r}_k\|^2 < \epsilon$ (the center of mass lies on the axis), the force contribution for that body is zero.
+$$
+\mathbf{r}_k = \mathbf{d}_k - (\mathbf{d}_k \cdot \hat{\mathbf{e}}_k) \hat{\mathbf{e}}_k.
+$$
+
+If $\bar{\mathbf{c}}_k = \mathbf{0}$ (reference origin at COM), $\mathbf{d}_k = -\mathbf{T}_k(\bar{\mathbf{x}}^0_k) = \mathbf{T}_k(\mathbf{0}) - \mathbf{T}_k(\bar{\mathbf{x}}^0_k)$, recovering the chord from anchor to origin.
+
+When $\|\mathbf{r}_k\|^2 < \epsilon$ (within a numerical cutoff), that body contributes no coupling force from this step.
 
 ### Sign Convention
 
-A positive $\tau$ applies torque to body $j$ in the $+\hat{\mathbf{e}}$ direction (counterclockwise when viewed along $+\hat{\mathbf{e}}$, right-hand rule) and an equal-and-opposite reaction torque to body $i$.
+Let \(\hat{\mathbf{e}}_{\mathrm{child}}=\hat{\mathbf{e}}_j\) and \(\hat{\mathbf{e}}_{\mathrm{parent}}=\hat{\mathbf{e}}_i=-\hat{\mathbf{e}}_j\). A positive \(\tau\) applies a right-hand torque about \(+\hat{\mathbf{e}}_{\mathrm{child}}\) (child-positive; see [above](#parent-vs-child-axis-and-positive-torque)). The two bodies receive consistent tangential forces at their centers of mass via the per-body \(\hat{\mathbf{e}}_k\times\mathbf{r}_k\) terms in § [Torque Application](#torque-application).
 
 ## Energy Integration
 

--- a/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
@@ -6,24 +6,26 @@ The **Affine Body Revolute Joint External Force** applies a scalar external torq
 
 ## Torque Application
 
-Given a scalar torque $\tau$ and the joint axis direction $\hat{\mathbf{e}}$, the external torque is mapped via the principle of virtual work directly to an equivalent **generalized force on the affine rotational DOF** of each body — without forming a translational force or evaluating a center-of-mass lever arm. For each body $k \in \{i, j\}$ with affine matrix $\mathbf{A}_k \in \mathbb{R}^{3 \times 3}$ extracted from $\mathbf{q}_k$:
+Given a scalar torque $\tau$ and the per-body joint axis $\hat{\mathbf{e}}_k$, the external torque is mapped via the principle of virtual work directly to an equivalent **generalized force on the affine rotational DOF** of each body — without forming a translational force or evaluating a center-of-mass lever arm. For each body $k \in \{i, j\}$ with affine matrix $\mathbf{A}_k \in \mathbb{R}^{3 \times 3}$ extracted from $\mathbf{q}_k$:
 
 $$
 \mathbf{F}_k = \begin{bmatrix} \mathbf{0}_3 \\ \operatorname{vec}\!\bigl(\mathbf{F}^A_k\bigr) \end{bmatrix} \in \mathbb{R}^{12},
-\qquad
+$$
+
+$$
 \mathbf{F}^A_k = \frac{\tau}{2} \, [\hat{\mathbf{e}}_k]_\times \, \mathbf{A}_k^{-T},
 $$
 
 where:
 
 - $\tau$ is the scalar torque magnitude (per edge)
-- $\hat{\mathbf{e}}_k$ is the normalized joint axis direction in body $k$'s current world frame
+- $\hat{\mathbf{e}}_k$ is the normalized joint axis on body $k$ in world space (see [Axis Direction](#axis-direction))
 - $[\hat{\mathbf{e}}_k]_\times \in \mathbb{R}^{3 \times 3}$ is the skew-symmetric matrix satisfying $[\hat{\mathbf{e}}_k]_\times \mathbf{w} = \hat{\mathbf{e}}_k \times \mathbf{w}$
 - $\mathbf{A}_k^{-T}$ is the inverse-transpose of body $k$'s current affine matrix
 - $\operatorname{vec}(\cdot)$ packs a $3 \times 3$ matrix into the $9$ components of $\mathbf{q}_k[3{:}12]$ in **row-major** order, matching the row-major layout used for the rows of $\mathbf{A}_k$ in $\mathbf{q}_k$
 - $\mathbf{0}_3$ denotes the three-dimensional zero vector — a pure torque produces no translational generalized force, regardless of whether $\mathbf{x}_k$ is the COM or a mesh anchor
 
-The same factor $\tau$ is applied to both bodies; Newton's third law is encoded geometrically by $\hat{\mathbf{e}}_j \approx -\hat{\mathbf{e}}_i$ (see [below](#parent-vs-child-axis-and-positive-torque)), so the opposite axis direction supplies the opposite-sign reaction.
+The same factor $\tau$ is applied to both bodies; Newton's third law is encoded by the strict antisymmetry $\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j$ that is enforced numerically in § [Axis Direction](#axis-direction), so the opposite axis direction supplies the opposite-sign reaction.
 
 ### Reduction to rigid body
 
@@ -31,17 +33,29 @@ When $\mathbf{A}_k \in SO(3)$ (no shear or scale, i.e. an undeformed rigid body)
 
 ### Axis Direction
 
-The joint axis on body $k$ is defined by two anchor points $\mathbf{x}^0_k$ and $\mathbf{x}^1_k$ in world space, following the base [Revolute Joint](./affine_body_revolute_joint.md) convention. The axis direction is the normalized chord between them:
+The joint axis on body $k$ is defined by two anchor points $\mathbf{x}^0_k$ and $\mathbf{x}^1_k$ in world space, following the base [Revolute Joint](./affine_body_revolute_joint.md) convention. Each body first computes its own raw world-space axis from its own anchors and current pose:
 
 $$
-\hat{\mathbf{e}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\bigl\|\mathbf{x}^1_k - \mathbf{x}^0_k\bigr\|}, \quad k \in \{i, j\}.
+\tilde{\mathbf{e}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\bigl\|\mathbf{x}^1_k - \mathbf{x}^0_k\bigr\|}, \quad k \in \{i, j\}.
 $$
+
+By construction the two anchor pairs are laid out in opposite order on the two bodies, so $\tilde{\mathbf{e}}_i \approx -\tilde{\mathbf{e}}_j$ whenever the joint constraint is satisfied. To absorb residual numerical drift near the singularity (and to guarantee Newton's third law bit-exactly regardless of the per-body roundoff), the two raw axes are symmetrized into one strictly antisymmetric pair:
+
+$$
+\hat{\mathbf{e}}_j = \tfrac{1}{2}\bigl(\tilde{\mathbf{e}}_j + \tilde{\mathbf{e}}_i\bigr),
+$$
+
+$$
+\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j.
+$$
+
+The averaging step is a first-order denoiser: as long as the joint is well-posed, $\tilde{\mathbf{e}}_i + \tilde{\mathbf{e}}_j$ is roundoff-level and the corrected axes lie within the same $\mathcal{O}(\varepsilon)$ neighborhood as the raw ones, while strict antisymmetry $\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j$ now holds exactly. If the magnitude of $\tilde{\mathbf{e}}_i + \tilde{\mathbf{e}}_j$ is non-trivial, the joint constraint itself has drifted and the upstream constraint solver — not this symmetrization — is responsible for the fix.
 
 <a id="parent-vs-child-axis-and-positive-torque"></a>
 
 ### Parent vs. child axis and positive torque
 
-**Parent** $=$ left $(i)$, **child** $=$ right $(j)$, matching the base joint. The two anchor pairs are laid out in opposite order on the two bodies, so the axes point opposite ways: $\hat{\mathbf{e}}_i \approx -\hat{\mathbf{e}}_j$.
+**Parent** $=$ left $(i)$, **child** $=$ right $(j)$, matching the base joint. The two anchor pairs are laid out in opposite order on the two bodies, so the raw per-body axes point opposite ways: $\tilde{\mathbf{e}}_i \approx -\tilde{\mathbf{e}}_j$. After the symmetrization in § [Axis Direction](#axis-direction) this becomes the exact identity $\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j$.
 
 `external_torque` is **child-positive**: a positive $\tau$ applies a right-hand torque about $\hat{\mathbf{e}}_j$ (the child axis); the parent receives the equal-and-opposite reaction automatically because $\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j$. This polarity applies only to this constitution (UID 668); the shared `angle` frame for limits and driving targets follows the base [Revolute Joint](./affine_body_revolute_joint.md#angle-state).
 

--- a/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint_external_force.md
@@ -9,8 +9,8 @@ The **Affine Body Revolute Joint External Force** applies a scalar external torq
 Given a scalar torque $\tau$ and the joint axis direction $\hat{\mathbf{e}}$, the external torque is converted into a translational force at each body's center of mass. The torque produces equal-and-opposite tangential forces on the two bodies:
 
 $$
-\mathbf{F}_i = \begin{bmatrix} -\tau \, \dfrac{\hat{\mathbf{e}}_i \times \mathbf{r}_i}{\|\mathbf{r}_i\|^2} \\[6pt] \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12}, \quad
-\mathbf{F}_j = \begin{bmatrix} +\tau \, \dfrac{\hat{\mathbf{e}}_j \times \mathbf{r}_j}{\|\mathbf{r}_j\|^2} \\[6pt] \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12},
+\mathbf{F}_i = \begin{bmatrix} -\tau \, \dfrac{\hat{\mathbf{e}}_i \times \mathbf{r}_i}{\|\mathbf{r}_i\|^2} \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12}, \quad
+\mathbf{F}_j = \begin{bmatrix} +\tau \, \dfrac{\hat{\mathbf{e}}_j \times \mathbf{r}_j}{\|\mathbf{r}_j\|^2} \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12},
 $$
 
 where:
@@ -34,15 +34,15 @@ where $\mathring{\mathbf{J}}^{\hat{e}}_k$ maps the rest-space axis direction thr
 
 ### Parent vs. child axis and positive torque
 
-Indexing matches the base joint: **parent** \(=\) left \((i)\), **child** \(=\) right \((j)\). For each joint, the CUDA backend builds two normalized axis vectors from rest segments \((\bar{\mathbf{x}}^1-\bar{\mathbf{x}}^0)\) **per body**; they coincide as a geometric line but point **opposite** directions,
+Indexing matches the base joint: **parent** $=$ left $(i)$, **child** $=$ right $(j)$. For each joint, the CUDA backend builds two normalized axis vectors from rest segments $(\bar{\mathbf{x}}^1-\bar{\mathbf{x}}^0)$ **per body**; they coincide as a geometric line but point **opposite** directions,
 
 $$
 \hat{\mathbf{e}}_i \approx -\,\hat{\mathbf{e}}_j \qquad\text{(parent axis opposite child axis)}.
 $$
 
-The scalar attribute `external_torque` is **child-positive**: a **positive** \(\tau\) applies a right-hand torque about **the child’s** axis direction \(\hat{\mathbf{e}}_{\mathrm{child}} = \hat{\mathbf{e}}_j\) (equivalently, about \(-\hat{\mathbf{e}}_i\) on the parent). The force kernel uses each body’s own \(\hat{\mathbf{e}}_k\) and lever arm \(\mathbf{r}_k\) so the pair is consistent with this convention.
+The scalar attribute `external_torque` is **child-positive**: a **positive** $\tau$ applies a right-hand torque about **the child’s** axis direction $\hat{\mathbf{e}}_{\mathrm{child}} = \hat{\mathbf{e}}_j$ (equivalently, about $-\hat{\mathbf{e}}_i$ on the parent). The force kernel uses each body’s own $\hat{\mathbf{e}}_k$ and lever arm $\mathbf{r}_k$ so the pair is consistent with this convention.
 
-This parent/child polarity matters for interpreting **only** this external-force constitution (UID 668), not for renaming \(\theta\) or for limit/driving targets, which follow the shared `angle` frame in [Angle State](./affine_body_revolute_joint.md#angle-state).
+This parent/child polarity matters for interpreting **only** this external-force constitution (UID 668), not for renaming $\theta$ or for limit/driving targets, which follow the shared `angle` frame in [Angle State](./affine_body_revolute_joint.md#angle-state).
 
 ### Center of mass (reference configuration)
 
@@ -74,7 +74,7 @@ When $\|\mathbf{r}_k\|^2 < \epsilon$ (within a numerical cutoff), that body cont
 
 ### Sign Convention
 
-Let \(\hat{\mathbf{e}}_{\mathrm{child}}=\hat{\mathbf{e}}_j\) and \(\hat{\mathbf{e}}_{\mathrm{parent}}=\hat{\mathbf{e}}_i=-\hat{\mathbf{e}}_j\). A positive \(\tau\) applies a right-hand torque about \(+\hat{\mathbf{e}}_{\mathrm{child}}\) (child-positive; see [above](#parent-vs-child-axis-and-positive-torque)). The two bodies receive consistent tangential forces at their centers of mass via the per-body \(\hat{\mathbf{e}}_k\times\mathbf{r}_k\) terms in § [Torque Application](#torque-application).
+Let $\hat{\mathbf{e}}_{\mathrm{child}}=\hat{\mathbf{e}}_j$ and $\hat{\mathbf{e}}_{\mathrm{parent}}=\hat{\mathbf{e}}_i=-\hat{\mathbf{e}}_j$. A positive $\tau$ applies a right-hand torque about $+\hat{\mathbf{e}}_{\mathrm{child}}$ (child-positive; see [above](#parent-vs-child-axis-and-positive-torque)). The two bodies receive tangential impulse at their centers of mass via the per-body $\hat{\mathbf{e}}_k\times\mathbf{r}_k$ terms in § [Torque Application](#torque-application).
 
 ## Energy Integration
 

--- a/src/backends/cuda/affine_body/abd_jacobi_matrix.cu
+++ b/src/backends/cuda/affine_body/abd_jacobi_matrix.cu
@@ -190,8 +190,7 @@ MUDA_GENERIC Matrix12x12 ABDJacobiDyadicMass::to_mat() const
 MUDA_GENERIC Vector3 ABDJacobiDyadicMass::center_of_mass() const
 {
     const Float m = static_cast<Float>(m_mass);
-    if(m <= 0)
-        return Vector3::Zero();
+    MUDA_ASSERT(m > 0, "ABDJacobiDyadicMass::center_of_mass requires positive mass");
     return m_mass_times_x_bar / m;
 }
 

--- a/src/backends/cuda/affine_body/abd_jacobi_matrix.cu
+++ b/src/backends/cuda/affine_body/abd_jacobi_matrix.cu
@@ -1,4 +1,5 @@
 #include <affine_body/abd_jacobi_matrix.h>
+#include <muda/tools/debug_log.h>
 
 namespace uipc::backend::cuda
 {

--- a/src/backends/cuda/affine_body/abd_jacobi_matrix.cu
+++ b/src/backends/cuda/affine_body/abd_jacobi_matrix.cu
@@ -187,6 +187,14 @@ MUDA_GENERIC Matrix12x12 ABDJacobiDyadicMass::to_mat() const
     return h;
 }
 
+MUDA_GENERIC Vector3 ABDJacobiDyadicMass::center_of_mass() const
+{
+    const Float m = static_cast<Float>(m_mass);
+    if(m <= 0)
+        return Vector3::Zero();
+    return m_mass_times_x_bar / m;
+}
+
 MUDA_GENERIC Matrix3x3 ABDJacobiDyadicMass::inertia_tensor_cm() const
 {
     const Float m = static_cast<Float>(m_mass);

--- a/src/backends/cuda/affine_body/abd_jacobi_matrix.h
+++ b/src/backends/cuda/affine_body/abd_jacobi_matrix.h
@@ -216,7 +216,7 @@ class ABDJacobiDyadicMass
 
     /**
      * @brief Center of mass in the reference frame.
-     * Returns zero vector if mass is zero.
+     * Requires positive total mass (checked with MUDA_ASSERT in implementations).
      */
     MUDA_GENERIC Vector3 center_of_mass() const;
 

--- a/src/backends/cuda/affine_body/abd_jacobi_matrix.h
+++ b/src/backends/cuda/affine_body/abd_jacobi_matrix.h
@@ -215,6 +215,12 @@ class ABDJacobiDyadicMass
     MUDA_GENERIC double mass() const { return m_mass; }
 
     /**
+     * @brief Center of mass in the reference frame.
+     * Returns zero vector if mass is zero.
+     */
+    MUDA_GENERIC Vector3 center_of_mass() const;
+
+    /**
      * @brief Inertia tensor about center of mass (3x3).
      * Derived from second moment about origin: I_cm = I^O - m(|c|^2 I_3 - c c^T),
      * I^O = tr(S) I_3 - S, with c = m_x_bar/m and S = m_x_bar_x_bar.

--- a/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
@@ -1064,12 +1064,10 @@ class AffineBodyPrismaticJointExternalForce final : public AffineBodyExternalFor
     static constexpr U64 ReporterUID = 667;
     using AffineBodyExternalForceReporter::AffineBodyExternalForceReporter;
 
-    SimSystemSlot<AffineBodyDynamics> affine_body_dynamics;
     SimSystemSlot<AffineBodyPrismaticJointExternalForceConstraint> constraint;
 
     void do_build(BuildInfo& info) override
     {
-        affine_body_dynamics = require<AffineBodyDynamics>();
         constraint = require<AffineBodyPrismaticJointExternalForceConstraint>();
     }
 
@@ -1093,7 +1091,9 @@ class AffineBodyPrismaticJointExternalForce final : public AffineBodyExternalFor
                     rest_tangents =
                         constraint->prismatic_joint->rest_ts.cviewer().name("rest_tangents"),
                     constrained_flags = constraint->is_constrained.cviewer().name("constrained_flags"),
-                    qs = affine_body_dynamics->qs().cviewer().name("qs")] __device__(int i) mutable
+                    qs = constraint->prismatic_joint->affine_body_dynamics->qs()
+                             .cviewer()
+                             .name("qs")] __device__(int i) mutable
                    {
                        if(constrained_flags(i) == 0)
                            return;

--- a/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
@@ -1108,10 +1108,12 @@ class AffineBodyPrismaticJointExternalForce final : public AffineBodyExternalFor
 
                        ABDJacobi JT[2] = {ABDJacobi{t_bar.segment<3>(0)},
                                           ABDJacobi{t_bar.segment<3>(3)}};
-                       Vector3   t_i   = -JT[0].vec_x(q_i);
+                       Vector3   t_i   = JT[0].vec_x(q_i);
                        Vector3   t_j   = JT[1].vec_x(q_j);
 
-                       MUDA_ASSERT((t_i + t_j).squaredNorm() < 1e-6, "t_i + t_j should be zero");
+                       // symmetrize to avoid numerical issues when the joint is near singularity
+                       t_j = 0.5 * (t_i + t_j);
+                       t_i = -t_j;
 
                        // Build 12D force vectors: -f*t to body_i, +f*t to body_j
                        Vector12 F_i      = Vector12::Zero();

--- a/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_prismatic_joint.cu
@@ -1081,6 +1081,8 @@ class AffineBodyPrismaticJointExternalForce final : public AffineBodyExternalFor
         if(force_count == 0)
             return;
 
+        auto abd = constraint->prismatic_joint->affine_body_dynamics;
+
         using namespace muda;
         ParallelFor()
             .file_line(__FILE__, __LINE__)
@@ -1091,9 +1093,7 @@ class AffineBodyPrismaticJointExternalForce final : public AffineBodyExternalFor
                     rest_tangents =
                         constraint->prismatic_joint->rest_ts.cviewer().name("rest_tangents"),
                     constrained_flags = constraint->is_constrained.cviewer().name("constrained_flags"),
-                    qs = constraint->prismatic_joint->affine_body_dynamics->qs()
-                             .cviewer()
-                             .name("qs")] __device__(int i) mutable
+                    qs = abd->qs().cviewer().name("qs")] __device__(int i) mutable
                    {
                        if(constrained_flags(i) == 0)
                            return;
@@ -1108,15 +1108,17 @@ class AffineBodyPrismaticJointExternalForce final : public AffineBodyExternalFor
 
                        ABDJacobi JT[2] = {ABDJacobi{t_bar.segment<3>(0)},
                                           ABDJacobi{t_bar.segment<3>(3)}};
-                       Vector3   t_i   = JT[0].vec_x(q_i);
+                       Vector3   t_i   = -JT[0].vec_x(q_i);
                        Vector3   t_j   = JT[1].vec_x(q_j);
 
-                       // Build 12D force vectors: +f*t to body_i, -f*t to body_j
+                       MUDA_ASSERT((t_i + t_j).squaredNorm() < 1e-6, "t_i + t_j should be zero");
+
+                       // Build 12D force vectors: -f*t to body_i, +f*t to body_j
                        Vector12 F_i      = Vector12::Zero();
                        F_i.segment<3>(0) = f * t_i;
 
                        Vector12 F_j      = Vector12::Zero();
-                       F_j.segment<3>(0) = -f * t_j;
+                       F_j.segment<3>(0) = f * t_j;
 
                        eigen::atomic_add(external_forces(bids(0)), F_i);
                        eigen::atomic_add(external_forces(bids(1)), F_j);

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -1100,12 +1100,10 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        Float r_sq_i = r_i.squaredNorm();
                        Float r_sq_j = r_j.squaredNorm();
 
-                       // Tangential force at center of mass:
-                       //   F = tau * (e × r) / |r|^2
-                       // Body_i receives +tau, body_j receives -tau (reaction).
-                       // Skip when |r|^2 ~ 0: divides by squared perpendicular arm; this
-                       // floor matches the prior 1e-12 threshold (float noise near the axis).
-                       constexpr Float lever_arm_sq_floor = 1e-12f;
+                       // F = tau * (e × r) / |r|^2 ; body_j gets the reaction.
+                       // Floor on |r|^2 ignores FP noise near the axis to avoid
+                       // amplifying round-off into an unphysically large force.
+                       constexpr Float lever_arm_sq_floor = 1e-4;
 
                        Vector12 F_i = Vector12::Zero();
                        if(r_sq_i > lever_arm_sq_floor)

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -1103,17 +1103,18 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        // Tangential force at center of mass:
                        //   F = tau * (e × r) / |r|^2
                        // Body_i receives +tau, body_j receives -tau (reaction).
-
-                       constexpr Float num_eps = 1e-3;
+                       // Skip when |r|^2 ~ 0: divides by squared perpendicular arm; this
+                       // floor matches the prior 1e-12 threshold (float noise near the axis).
+                       constexpr Float lever_arm_sq_floor = 1e-12f;
 
                        Vector12 F_i = Vector12::Zero();
-                       if(r_sq_i >= num_eps)
+                       if(r_sq_i > lever_arm_sq_floor)
                        {
                            F_i.segment<3>(0) = tau * e_world_i.cross(r_i) / r_sq_i;
                        }
 
                        Vector12 F_j = Vector12::Zero();
-                       if(r_sq_j >= num_eps)
+                       if(r_sq_j > lever_arm_sq_floor)
                        {
                            F_j.segment<3>(0) = tau * e_world_j.cross(r_j) / r_sq_j;
                        }

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -1068,21 +1068,13 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        Vector12 q_i = qs(bids(0));
                        Vector12 q_j = qs(bids(1));
 
-                       Vector3 x0_bar = X_bar.segment<3>(0);
-                       Vector3 x1_bar = X_bar.segment<3>(3);
                        Vector3 x2_bar = X_bar.segment<3>(6);
                        Vector3 x3_bar = X_bar.segment<3>(9);
 
-                       // Joint axis in world frame, computed independently per
-                       // body. Rest layout uses reversed order on body j, so
-                       // e_world_j ≈ -e_world_i; the assert below catches drift.
-                       Vector3 e_world_i =
-                           ABDJacobi{x1_bar - x0_bar}.vec_x(q_i).normalized();
                        Vector3 e_world_j =
-                           ABDJacobi{x2_bar - x3_bar}.vec_x(q_j).normalized();
+                           ABDJacobi{x3_bar - x2_bar}.vec_x(q_i).normalized();
 
-                       MUDA_ASSERT((e_world_i + e_world_j).squaredNorm() < 1e-6,
-                                   "e_world_i + e_world_j should be zero");
+                       Vector3 e_world_i = -e_world_j;
 
                        // Equivalent generalized force from a pure torque
                        //     m_b = tau * e_world_b

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -1068,23 +1068,19 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        Vector12 q_i = qs(bids(0));
                        Vector12 q_j = qs(bids(1));
 
-                       Vector3 x2_bar = X_bar.segment<3>(6);
-                       Vector3 x3_bar = X_bar.segment<3>(9);
+                       // position direction of the applied torque on body j (right-hand rule)
+                       ABDJacobi e_bar[2] = {
+                           ABDJacobi{X_bar.segment<3>(3) - X_bar.segment<3>(0)},
+                           ABDJacobi{X_bar.segment<3>(9) - X_bar.segment<3>(6)}};
+                       Vector3 e_i = e_bar[0].vec_x(q_i).normalized();
+                       Vector3 e_j = e_bar[1].vec_x(q_j).normalized();
 
-                       Vector3 e_world_j =
-                           ABDJacobi{x3_bar - x2_bar}.vec_x(q_i).normalized();
+                       // symmetrize to avoid numerical issues when the joint is near singularity
+                       e_j = 0.5 * (e_j + e_i);
+                       e_i = -e_j;
 
-                       Vector3 e_world_i = -e_world_j;
-
-                       // Equivalent generalized force from a pure torque
-                       //     m_b = tau * e_world_b
-                       // on the affine-body rotational DOF (virtual-work form,
-                       // see revolute_joint_affine_body.md):
-                       //     F^x_b  = 0
-                       //     F^A_b  = (tau/2) * [e_world_b]_x * A_b^{-T}    (3x3)
-                       // and vec(F^A_b) is laid out row-major into q[3:12] to
-                       // match the row-major (rows of A) convention of `q`.
-                       // Newton's 3rd law is encoded by e_world_j = -e_world_i.
+                       // affine-body rotational DOF (virtual-work form)
+                       //  F^A_b  = (tau/2) * [e_world_b]_x * A_b^{-T}    (3x3)
                        auto torque_to_F = [](Float tau, const Vector3& e, const Vector12& q)
                        {
                            Matrix3x3 A_inv_T = q_to_A(q).inverse().transpose();
@@ -1095,8 +1091,8 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                            return F;
                        };
 
-                       Vector12 F_i = torque_to_F(tau, e_world_i, q_i);
-                       Vector12 F_j = torque_to_F(tau, e_world_j, q_j);
+                       Vector12 F_i = torque_to_F(tau, e_i, q_i);
+                       Vector12 F_j = torque_to_F(tau, e_j, q_j);
 
                        eigen::atomic_add(external_forces(bids(0)), F_i);
                        eigen::atomic_add(external_forces(bids(1)), F_j);

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -1082,7 +1082,10 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        Vector3 e_world_i =
                            ABDJacobi{x1_bar - x0_bar}.vec_x(q_i).normalized();
                        Vector3 e_world_j =
-                           ABDJacobi{x3_bar - x2_bar}.vec_x(q_j).normalized();
+                           ABDJacobi{x2_bar - x3_bar}.vec_x(q_j).normalized();
+
+                       MUDA_ASSERT((e_world_i + e_world_j).squaredNorm() < 1e-6,
+                                   "e_world_i + e_world_j should be zero");
 
                        // Vector from axis point x0 to center of mass (x_bar=0) in world:
                        //   com_world - x0_world
@@ -1101,19 +1104,20 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        //   F = tau * (e × r) / |r|^2
                        // Body_i receives +tau, body_j receives -tau (reaction).
 
-                       constexpr Float eps = 1e-12;
+                       constexpr Float num_eps = 1e-3;
 
                        Vector12 F_i = Vector12::Zero();
-                       if(r_sq_i > eps)
+                       if(r_sq_i >= num_eps)
                        {
                            F_i.segment<3>(0) = tau * e_world_i.cross(r_i) / r_sq_i;
                        }
 
                        Vector12 F_j = Vector12::Zero();
-                       if(r_sq_j > eps)
+                       if(r_sq_j >= num_eps)
                        {
                            F_j.segment<3>(0) = tau * e_world_j.cross(r_j) / r_sq_j;
                        }
+
 
                        eigen::atomic_add(external_forces(bids(0)), F_i);
                        eigen::atomic_add(external_forces(bids(1)), F_j);

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -1026,12 +1026,10 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
     static constexpr U64 ReporterUID = 668;
     using AffineBodyExternalForceReporter::AffineBodyExternalForceReporter;
 
-    SimSystemSlot<AffineBodyDynamics> affine_body_dynamics;
     SimSystemSlot<AffineBodyRevoluteJointExternalForceConstraint> constraint;
 
     void do_build(BuildInfo& info) override
     {
-        affine_body_dynamics = require<AffineBodyDynamics>();
         constraint = require<AffineBodyRevoluteJointExternalForceConstraint>();
     }
 
@@ -1045,6 +1043,8 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
         if(torque_count == 0)
             return;
 
+        auto abd = constraint->revolute_joint->affine_body_dynamics;
+
         using namespace muda;
         ParallelFor()
             .file_line(__FILE__, __LINE__)
@@ -1055,7 +1055,8 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                     rest_positions =
                         constraint->revolute_joint->rest_positions.cviewer().name("rest_positions"),
                     constrained_flags = constraint->is_constrained.cviewer().name("constrained_flags"),
-                    qs = affine_body_dynamics->qs().cviewer().name("qs")] __device__(int i) mutable
+                    qs = abd->qs().cviewer().name("qs"),
+                    mass = abd->body_masses().cviewer().name("body_masses")] __device__(int i) mutable
                    {
                        if(constrained_flags(i) == 0)
                            return;
@@ -1073,6 +1074,10 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        Vector3 x2_bar = X_bar.segment<3>(6);
                        Vector3 x3_bar = X_bar.segment<3>(9);
 
+
+                       auto com_i_bar = mass(bids(0)).center_of_mass();
+                       auto com_j_bar = mass(bids(1)).center_of_mass();
+
                        // Axis direction in world frame
                        Vector3 e_world_i =
                            ABDJacobi{x1_bar - x0_bar}.vec_x(q_i).normalized();
@@ -1080,9 +1085,9 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                            ABDJacobi{x3_bar - x2_bar}.vec_x(q_j).normalized();
 
                        // Vector from axis point x0 to center of mass (x_bar=0) in world:
-                       //   c - x0_world = c - (c + A * x0_bar) = -A * x0_bar
-                       Vector3 d_i = -ABDJacobi{x0_bar}.vec_x(q_i);
-                       Vector3 d_j = -ABDJacobi{x2_bar}.vec_x(q_j);
+                       //   com_world - x0_world
+                       Vector3 d_i = ABDJacobi{com_i_bar - x0_bar}.vec_x(q_i);
+                       Vector3 d_j = ABDJacobi{com_j_bar - x2_bar}.vec_x(q_j);
 
                        // Project center of mass onto axis, lever arm is the
                        // perpendicular component: r = d - (d·e)*e

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -1055,8 +1055,7 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                     rest_positions =
                         constraint->revolute_joint->rest_positions.cviewer().name("rest_positions"),
                     constrained_flags = constraint->is_constrained.cviewer().name("constrained_flags"),
-                    qs = abd->qs().cviewer().name("qs"),
-                    mass = abd->body_masses().cviewer().name("body_masses")] __device__(int i) mutable
+                    qs = abd->qs().cviewer().name("qs")] __device__(int i) mutable
                    {
                        if(constrained_flags(i) == 0)
                            return;
@@ -1074,11 +1073,9 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        Vector3 x2_bar = X_bar.segment<3>(6);
                        Vector3 x3_bar = X_bar.segment<3>(9);
 
-
-                       auto com_i_bar = mass(bids(0)).center_of_mass();
-                       auto com_j_bar = mass(bids(1)).center_of_mass();
-
-                       // Axis direction in world frame
+                       // Joint axis in world frame, computed independently per
+                       // body. Rest layout uses reversed order on body j, so
+                       // e_world_j ≈ -e_world_i; the assert below catches drift.
                        Vector3 e_world_i =
                            ABDJacobi{x1_bar - x0_bar}.vec_x(q_i).normalized();
                        Vector3 e_world_j =
@@ -1087,36 +1084,27 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        MUDA_ASSERT((e_world_i + e_world_j).squaredNorm() < 1e-6,
                                    "e_world_i + e_world_j should be zero");
 
-                       // Vector from axis point x0 to center of mass (x_bar=0) in world:
-                       //   com_world - x0_world
-                       Vector3 d_i = ABDJacobi{com_i_bar - x0_bar}.vec_x(q_i);
-                       Vector3 d_j = ABDJacobi{com_j_bar - x2_bar}.vec_x(q_j);
-
-                       // Project center of mass onto axis, lever arm is the
-                       // perpendicular component: r = d - (d·e)*e
-                       Vector3 r_i = d_i - d_i.dot(e_world_i) * e_world_i;
-                       Vector3 r_j = d_j - d_j.dot(e_world_j) * e_world_j;
-
-                       Float r_sq_i = r_i.squaredNorm();
-                       Float r_sq_j = r_j.squaredNorm();
-
-                       // F = tau * (e × r) / |r|^2 ; body_j gets the reaction.
-                       // Floor on |r|^2 ignores FP noise near the axis to avoid
-                       // amplifying round-off into an unphysically large force.
-                       constexpr Float lever_arm_sq_floor = 1e-4;
-
-                       Vector12 F_i = Vector12::Zero();
-                       if(r_sq_i > lever_arm_sq_floor)
+                       // Equivalent generalized force from a pure torque
+                       //     m_b = tau * e_world_b
+                       // on the affine-body rotational DOF (virtual-work form,
+                       // see revolute_joint_affine_body.md):
+                       //     F^x_b  = 0
+                       //     F^A_b  = (tau/2) * [e_world_b]_x * A_b^{-T}    (3x3)
+                       // and vec(F^A_b) is laid out row-major into q[3:12] to
+                       // match the row-major (rows of A) convention of `q`.
+                       // Newton's 3rd law is encoded by e_world_j = -e_world_i.
+                       auto torque_to_F = [](Float tau, const Vector3& e, const Vector12& q)
                        {
-                           F_i.segment<3>(0) = tau * e_world_i.cross(r_i) / r_sq_i;
-                       }
+                           Matrix3x3 A_inv_T = q_to_A(q).inverse().transpose();
+                           Matrix3x3 FA      = (0.5 * tau) * skew(e) * A_inv_T;
 
-                       Vector12 F_j = Vector12::Zero();
-                       if(r_sq_j > lever_arm_sq_floor)
-                       {
-                           F_j.segment<3>(0) = tau * e_world_j.cross(r_j) / r_sq_j;
-                       }
+                           Vector12 F      = Vector12::Zero();
+                           F.segment<9>(3) = A_to_q(FA);
+                           return F;
+                       };
 
+                       Vector12 F_i = torque_to_F(tau, e_world_i, q_i);
+                       Vector12 F_j = torque_to_F(tau, e_world_j, q_j);
 
                        eigen::atomic_add(external_forces(bids(0)), F_i);
                        eigen::atomic_add(external_forces(bids(1)), F_j);

--- a/src/backends/cuda/affine_body/utils.cu
+++ b/src/backends/cuda/affine_body/utils.cu
@@ -180,4 +180,11 @@ UIPC_GENERIC void orthonormal_basis(Vector3& t, Vector3& n, Vector3& b)
     n = t.cross(test_vector).normalized();
     b = t.cross(n).normalized();
 }
+
+UIPC_GENERIC Matrix3x3 skew(const Vector3& v)
+{
+    Matrix3x3 S;
+    S << 0, -v(2), v(1), v(2), 0, -v(0), -v(1), v(0), 0;
+    return S;
+}
 }  // namespace uipc::backend::cuda

--- a/src/backends/cuda/affine_body/utils.h
+++ b/src/backends/cuda/affine_body/utils.h
@@ -16,4 +16,7 @@ UIPC_GENERIC Matrix4x4 q_v_to_transform_v(const Vector12& q);
 UIPC_GENERIC Vector12  transform_v_to_q_v(const Matrix4x4& transform_v);
 
 UIPC_GENERIC void orthonormal_basis(Vector3& t, Vector3& n, Vector3& b);
+
+// Skew-symmetric matrix [v]_x such that [v]_x * w = v.cross(w).
+UIPC_GENERIC Matrix3x3 skew(const Vector3& v);
 }  // namespace uipc::backend::cuda


### PR DESCRIPTION
## Summary

This PR reworks the **affine-body joint external-force / external-torque** kernels (UID 667 / 668) so the generalized force on each body is derived directly from a **virtual-work mapping**, and replaces the previous "encoded-by-construction" reliance on geometric antisymmetry with an explicit **per-body computation + numerical symmetrization** step. Specs are rewritten to match.

### Revolute (UID 668) — torque ⟶ rotational DOF via virtual work

For each body $k \in \{i, j\}$ with affine matrix $\mathbf{A}_k \in \mathbb{R}^{3\times 3}$ extracted from $\mathbf{q}_k$:

$$
\\mathbf{F}_k = \begin{bmatrix} 
\mathbf{0}_3 \\ 
\mathrm{vec}\\bigl(\mathbf{F}^A_k\bigr) 
\end{bmatrix} \in \mathbb{R}^{12}
$$

$$
\mathbf{F}^A_k = \frac{\tau}{2} [\hat{\mathbf{e}}_k]_\times \mathbf{A}_k^{-T}.
$$

`vec(·)` is row-major into $\mathbf{q}_k[3{:}12]$, matching the row-major layout of $\mathbf{A}_k$ in $\mathbf{q}_k$. A pure torque contributes **zero** to the translational generalized force regardless of whether $\mathbf{x}_k$ is the COM or a mesh anchor — no $|\mathbf{r}|^2$ lever-arm at COM, no $|\mathbf{r}|^2$ floor heuristic, no `ABDJacobiDyadicMass::center_of_mass()` lookup. 

When $A_k \in \mathrm{SO}(3)$ this reduces to the rigid-body formula $\tfrac{1}{2}[\hat{\mathbf{e}}]_\times \mathbf{A}$.


### Prismatic (UID 667) — force ⟶ translational DOF

$$
\mathbf{F}_k = \begin{bmatrix} f \hat{\mathbf{t}}_k \\ \mathbf{0}_9 \end{bmatrix} \in \mathbb{R}^{12}, \quad k \in \{i, j\}.
$$

### Per-body axis/tangent + symmetrization (new in this PR's last commit)

Each body computes its own raw world-space direction from its own anchors and current pose:

$$
\tilde{\mathbf{e}}_k = \frac{\mathbf{x}^1_k - \mathbf{x}^0_k}{\|\mathbf{x}^1_k - \mathbf{x}^0_k\|}, \qquad k \in \{i, j\}.
$$

Then a closed-form **antisymmetrization** is applied, replacing the previous "trust geometric antisymmetry + assert" approach:

$$
\hat{\mathbf{e}}_j = \tfrac{1}{2}\bigl(\tilde{\mathbf{e}}_j + \tilde{\mathbf{e}}_i\bigr),
$$

$$
\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j.
$$

Same scheme applies to the prismatic tangent $\hat{\mathbf{t}}_k$. This:

- Gives Newton's 3rd law **bit-exactly** $\hat{\mathbf{e}}_i = -\hat{\mathbf{e}}_j$ regardless of per-body roundoff.
- Is robust near singularity (the joint axis becoming ill-defined), where $\tilde{\mathbf{e}}_i$ and $\tilde{\mathbf{e}}_j$ each carry larger relative error.
- Replaces a hard `MUDA_ASSERT((t_i + t_j).squaredNorm() < 1e-6)` in the prismatic kernel that could trip on legitimate joint drift.

### Bug fix in the same commit

The first version of the rewritten revolute kernel built `ABDJacobi e_bar[2]` with body_i's and body_j's local rest axes, but then used `e_bar->vec_x(...)` for both bodies — C-array `->` decays to `&e_bar[0]`, so body_j's pose was applied to **body_i's** local rest axis. Fixed to `e_bar[0].vec_x(q_i)` / `e_bar[1].vec_x(q_j)`.

## Spec updates

`docs/specification/constitutions/affine_body_revolute_joint_external_force.md` and `…/affine_body_prismatic_joint_external_force.md`:

- Distinguish raw per-body $\tilde{\mathbf{e}}_k$ / $\tilde{\mathbf{t}}_k$ from the symmetrized $\hat{\mathbf{e}}_k$ / $\hat{\mathbf{t}}_k$.
- Document the averaging step as a first-order denoiser, with a note that non-roundoff-level $\tilde{\mathbf{e}}_i + \tilde{\mathbf{e}}_j$ indicates upstream constraint drift, not a problem this symmetrization is meant to mask.
- Updated parent-vs-child polarity sections to reference the symmetrization rather than approximate antisymmetry.
- Earlier commits in the branch already: dropped the abstract $\mathring{\mathbf{J}}$ Jacobian wording, added explicit Axis/Tangent Direction and Parent-vs-child sections, renamed *Energy Integration* → *Time Integration* with an explicit "no own potential energy" note, and trimmed attribute lists to constitution-owned fields only.

## Other changes carried in this branch

- **utils.{h,cu}:** added `skew(v)` helper used by the revolute kernel.
- **Diagnostics:** muda `debug_log` added for `ABDJacobiDyadicMass` assertions.
- **External-force reporters:** routed through joint `affine_body_dynamics`; rest-data parent/child axis layout tightened.

## Breaking changes

None at the API level. The revolute torque kernel now produces an exact generalized force from the virtual-work mapping; downstream tests calibrated against the prior approximate $(\hat{\mathbf{e}}\times\mathbf{r})/|\mathbf{r}|^2$ lever-arm-at-COM result may need re-baselining.

## Verification

Recommend CUDA CI / local build for the touched `.cu` / `.h` files.
