### PR TITLE
fix(ci): pin xmake Windows runner to windows-2022

### DIFF
--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2025, ubuntu-24.04]
+        os: [windows-2022, ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}
 
@@ -63,7 +63,7 @@ jobs:
           xmake config --yes --github_actions=y
 
       - name: Xmake configure
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         run: |
           xrepo env -y -v -b cuda "xmake config --yes --github_actions=y"
 


### PR DESCRIPTION
## Summary

Pin the xmake CI Windows runner from `windows-2025` to `windows-2022`.

GitHub recently updated the `windows-2025` runner image, bumping the pre-installed MSVC from **14.44.35207 (VS 2022)** to **14.51.36231 (VS 2026/18)**. This breaks the xmake CI build with two errors:

1. **nvcc `cudafe++` ACCESS_VIOLATION** — CUDA 12.8's frontend crashes when paired with MSVC 14.51 (e.g. on `active_set_reporter.cu`).
2. **`fmt/format.h` warnings promoted to errors** — `fmt 12.1.0` Unicode literals that were benign warnings under MSVC 14.44 become fatal under the new toolchain.

The cmake CI already uses `windows-2022` and is unaffected. This change aligns the xmake CI to the same runner until NVIDIA ships a CUDA toolkit update that supports the newer compiler.

## Evidence

- PR #460 (merged May 19): `windows-2025` used MSVC 14.44 → **CI passed**
- PR #463 (opened Jun 11): `windows-2025` now uses MSVC 14.51 → **CI failed** (same code, different runner image)
