### PR TITLE
feat(cuda): continuous multi-turn angle tracking and external torque for revolute joint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ vsxmake*/
 # venv
 .venv/
 .omc/
+
+# local dev notes
+docs/development/backend_cuda/

--- a/docs/specification/constitutions/affine_body_driving_revolute_joint.md
+++ b/docs/specification/constitutions/affine_body_driving_revolute_joint.md
@@ -32,6 +32,8 @@ $$
 
 where $\hat{\mathbf{n}}_k$, $\hat{\mathbf{b}}_k$ are the normal and binormal directions in body $k$'s current frame, obtained from the stored rest-space basis via the affine map. The sign follows the right-hand rule around $+\hat{\mathbf{t}}$.
 
+For the energy below, this measurement is used through its continuously-unwrapped counterpart, anchored to the base joint's `current_angles` committed at the step start (see [State Update](./affine_body_revolute_joint.md#state-update)), so it does not jump by $2\pi$ when a Newton trial crosses the $\operatorname{atan2}$ branch cut. It agrees with $\theta$ modulo $2\pi$, exactly so while the rotation since the last commit is below $\pi$.
+
 `aim_angle` is a **user-facing target** expressed in the same frame as the reported `angle` (i.e. $\theta_{\text{current}}$). To translate it into the raw $\theta$-space actually used by the energy, the solver subtracts $\theta_{\text{init}}$ (the base joint's `init_angle`):
 
 $$
@@ -52,7 +54,7 @@ $$
 
 where $K = \gamma (m_i + m_j)$, $\gamma$ is the **user defined** `driving/strength_ratio` parameter, and $m_i$, $m_j$ are the masses of the two affine bodies. Substituting the definitions, the penalty is equivalent to $\tfrac{K}{2}(\theta_{\text{current}} - \theta_{\text{aim}})^2$ in the user-facing frame — the driving joint simply pulls the reported `angle` toward `aim_angle`.
 
-Note that $\theta - \tilde\theta$ is a raw difference of two values each returned by $\operatorname{atan2}$ in $(-\pi, \pi]$; it is **not** wrapped. As a consequence the penalty is only meaningful while $|\theta - \tilde\theta| < \pi$, which is the intended operating range of the driving joint (the controller is expected to deliver a target close to the current angle). Crossing the $\pm\pi$ branch cut makes the energy discontinuous; if larger travel is needed the driving target should be advanced incrementally.
+Because $\theta$ is continuously unwrapped, $\theta - \tilde\theta$ stays smooth across the $\pm\pi$ branch cut, so `aim_angle` is an **unbounded absolute target**: values beyond $\pm\pi$ are reached over multiple steps, not advanced incrementally by the caller. The precondition (per-step rotation below $\pi$; resets need an explicit `angle` write) is that of the base joint's [State Update](./affine_body_revolute_joint.md#state-update).
 
 When `driving/is_constrained = 0`, the energy is zero and the driving effect is disabled.
 

--- a/docs/specification/constitutions/affine_body_revolute_joint.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint.md
@@ -40,7 +40,7 @@ where $K$ is the stiffness constant of the joint, we choose $K=\gamma (m_i + m_j
 
 ## Angle State
 
-The revolute joint tracks a scalar joint angle $\theta$ that extra-per-joint constitutions (driving joint, angle limit, external torque) share. The backend constructs per body $k \in \{i,j\}$ an orthonormal basis $(\hat{\mathbf{t}}_k, \hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k)$ from the hinge geometry embedded in symbolic generation and Jacobian layout for this constitution (see `sym/affine_body_revolute_joint` alongside deployed kernels): $\hat{\mathbf{t}}_k$ is the **unit tangent** along body $k$’s hinge segment; $\hat{\mathbf{b}}_k = \hat{\mathbf{t}}_k \times \hat{\mathbf{n}}_k$. Pair $[\hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k]$ is the rotating perpendicular frame used downstream. Current relative angle is
+The revolute joint tracks a scalar joint angle $\theta$ shared by the extra-per-joint constitutions (driving, limit, external torque). For each body $k \in \{i,j\}$ the backend builds an orthonormal basis $(\hat{\mathbf{t}}_k, \hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k)$ from the hinge geometry (see `sym/affine_body_revolute_joint`): $\hat{\mathbf{t}}_k$ is the **unit tangent** along body $k$’s hinge segment and $\hat{\mathbf{b}}_k = \hat{\mathbf{t}}_k \times \hat{\mathbf{n}}_k$, so $[\hat{\mathbf{n}}_k, \hat{\mathbf{b}}_k]$ is the rotating perpendicular frame used downstream. Current relative angle is
 
 $$
 \cos\theta = \frac{\hat{\mathbf{n}}_i \cdot \hat{\mathbf{n}}_j + \hat{\mathbf{b}}_i \cdot \hat{\mathbf{b}}_j}{2}, \quad
@@ -69,13 +69,18 @@ Angular state $\theta$, `angle`, limits, and driving use **both** bodies’ base
 
 ### State Update
 
-At the end of each time step, the backend writes back the current relative angle, wrapped to $(-\pi, \pi]$, to the `angle` edge attribute:
+At the end of each time step, the backend advances a continuously accumulated (unwrapped) reference angle and writes it back to the `angle` edge attribute:
 
 $$
-\theta_{\text{current}} = \operatorname{map}_{(-\pi,\pi]}\left(\theta(\mathbf{q}) + \alpha_0\right),
+r^{(n)} = r^{(n-1)} + \operatorname{rem}\!\left(\theta(\mathbf{q}^{(n)}) - r^{(n-1)}\right), \qquad
+\theta_{\text{current}}^{(n)} = r^{(n)} + \alpha_0,
 $$
 
-where $\theta(\mathbf{q})$ is extracted from the formulas above and $\alpha_0$ is `init_angle`, a **user-facing offset** that shifts the "zero" of the reported value (default `0.0`). The `angle` attribute is therefore available to any frontend and to all extra-per-joint constitutions built on top of this joint (driving joint, limit, external torque). When an external state write replaces the body DOF $\mathbf{q}$ (e.g. via `AffineBodyStateAccessorFeature`), the backend re-syncs `current_angles` synchronously through the `GlobalJointDofManager`.
+where $\theta(\mathbf{q}^{(n)})$ is the wrapped angle from the formulas above at step $n$, $\operatorname{rem}(x)$ is the representative of $x$ modulo $2\pi$ closest to $0$, and $\alpha_0$ is `init_angle`, a **user-facing offset** shifting the reported "zero" (default `0.0`). Seeded at $r^{(0)} = 0$, so $\theta_{\text{current}}^{(0)} = \alpha_0$.
+
+Thus $\theta_{\text{current}}$ is a **continuous, multi-turn absolute angle** that accumulates across turns instead of wrapping at $\pm\pi$. The unwrap is exact while the per-step rotation stays below $\pi$ — this is an aliasing limit of sampling the wrapped angle at step endpoints, not an implementation choice: from two wrapped samples a $+\Delta$ and a $\Delta-2\pi$ rotation are indistinguishable. Fast *continuous* rotation that would exceed $\pi$ per step is handled by shrinking the time step so each sub-step stays below $\pi$. A genuine *discontinuous* jump (e.g. a reset/teleport) carries no winding information to recover; for it, write the authoritative angle (with winding) into `angle` **before** pushing the new body state through the accessor — the backend adopts the modified entries on re-sync and republishes; untouched joints are unaffected.
+
+The `angle` attribute is thus available to any frontend and to all extra-per-joint constitutions (driving, limit, external torque). On an external DOF write (e.g. `AffineBodyStateAccessorFeature`), the backend re-syncs `current_angles` synchronously via `GlobalJointDofManager`.
 
 #### Convention for all user-facing bounds
 
@@ -90,7 +95,7 @@ On the joint geometry (1D simplicial complex), on **edges** (one edge per joint)
 - `l_inst_id` (`IndexT`): instance index within the left geometry
 - `r_inst_id` (`IndexT`): instance index within the right geometry
 - `strength_ratio`: $\gamma$ in $K = \gamma(m_i + m_j)$ above
-- `angle` (`Float`): $\theta_{\text{current}}$, current relative joint angle in radians, wrapped to $(-\pi, \pi]$. Written by the backend every time step (read-only for the user).
+- `angle` (`Float`): $\theta_{\text{current}}$, current relative joint angle in radians. A continuous, unbounded, multi-turn absolute angle (not wrapped to $(-\pi, \pi]$) — see [State Update](#state-update). Written by the backend every time step (read-only for the user).
 - `init_angle` (`Float`): $\alpha_0$, initial angle offset added to the extracted relative angle. Default `0.0`.
 
 When the joint is created via Local `create_geometry`, optional **edge** attributes (each `Vector3`) supply local joint geometry: `l_position0`, `l_position1` (left body local frame), `r_position0`, `r_position1` (right body local frame).

--- a/docs/specification/constitutions/affine_body_revolute_joint_limit.md
+++ b/docs/specification/constitutions/affine_body_revolute_joint_limit.md
@@ -16,7 +16,7 @@ $$
 
 where $l_{\text{user}}, u_{\text{user}}$ are `limit/lower`, `limit/upper` and $\alpha_0$ is `init_angle` from the base joint. Algebraically this is equivalent to enforcing $l_{\text{user}} \le \theta_{\text{current}} \le u_{\text{user}}$. Let $s$ be `limit/strength`.
 
-Because $x$ is a raw accumulator that is not wrapped to $(-\pi,\pi]$, the limit is well-defined only while $|x| < \pi$; this is the intended operating range (the penalty itself prevents the joint from drifting that far).
+$x$ builds on the base joint's continuously-unwrapped `current_angles` (see [State Update](./affine_body_revolute_joint.md#state-update)), not a fixed build-time reference, so it is not restricted to $(-\pi,\pi]$: `limit/lower` and `limit/upper` may lie beyond $\pm\pi$ and multi-turn limits are supported. The precondition (per-step rotation below $\pi$; resets need an explicit `angle` write) is that of the base joint's [State Update](./affine_body_revolute_joint.md#state-update).
 
 For normal range width ($u>l$):
 
@@ -54,7 +54,7 @@ x=\theta^t+\delta,
 $$
 
 $$
-\theta^t=\Delta\Theta(\mathbf{q}^{t},\mathbf{q}_{ref}), \quad
+\theta^t = c^{(n-1)} - \alpha_0, \quad
 \delta=\Delta\Theta(\mathbf{q},\mathbf{q}^{t}).
 $$
 
@@ -62,8 +62,8 @@ Here:
 
 - $\mathbf{q}$ is the current affine-body DOF.
 - $\mathbf{q}^{t}$ is the previous-time-step DOF.
-- $\mathbf{q}_{ref}$ is the reference DOF captured at initialization.
-- $\theta^t$ is the accumulated revolute angle from the previous step.
+- $c^{(n-1)}$ is the base joint's `current_angles`, the continuously-unwrapped angle committed at the previous step (see [State Update](./affine_body_revolute_joint.md#state-update)), and $\alpha_0$ is `init_angle`.
+- $\theta^t$ is the accumulated revolute angle from the previous step, in the same unbounded frame as $c^{(n-1)}$, so it stays valid across $\pm\pi$ and multiple turns.
 
 Note that $\mathbf{q}$ is the concatenation of the DOF of the two affine bodies connected by the revolute joint.
 
@@ -101,7 +101,7 @@ $$
 $$
 
 The sign of $x$ follows the sign of $\sin\theta$ under this convention.
-The angle branch is $(-\pi,\pi]$.
+$\Delta\Theta$'s own atan2 branch is $(-\pi,\pi]$ — this bounds the per-step increment $\delta$, but not $x$ itself, since $\theta^t$ is the unwrapped multi-turn angle described above.
 
 ## Requirement
 

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint.cu
@@ -40,6 +40,7 @@ class AffineBodyRevoluteJoint final : public InterAffineBodyConstitution
     vector<Vector6>               h_r_basis;  // [n_R, b_R] per joint
     vector<Float>                 h_init_angles;
     vector<Float>                 h_current_angles;
+    vector<Float>                 h_adopted_angles;
 
     muda::DeviceBuffer<Vector2i> body_ids;
     muda::DeviceBuffer<Vector12> rest_positions;
@@ -236,7 +237,8 @@ Edge             = ({}, {}))",
         h_init_angles.resize(init_angles_list.size());
         std::ranges::copy(init_angles_list, h_init_angles.begin());
 
-        h_current_angles.resize(h_init_angles.size());
+        // Seed the persistent unwrapped angle with init_angles (zero relative rotation).
+        h_current_angles = h_init_angles;
 
         body_ids.copy_from(h_body_ids);
         rest_positions.copy_from(h_rest_positions);
@@ -275,11 +277,25 @@ Edge             = ({}, {}))",
                        Float theta;
                        compute_relative_angle(theta, lb, q_i, rb, q_j);
 
-                       Float total_angle = theta + init_angles(I);
-                       current_angles(I) = ::remainder(total_angle, 2.0 * PI);
-                       MUDA_ASSERT(current_angles(I) >= -PI && current_angles(I) <= PI,
-                                   "current_angle out of (-pi, pi]: %f",
-                                   current_angles(I));
+                       // Unwrap the (-pi, pi] atan2 angle against the stored multi-turn angle; exact while per-frame rotation < pi.
+                       Float prev_rel = current_angles(I) - init_angles(I);
+                       Float rel      = unwrap_angle(theta, prev_rel);
+                       // Wrong winding is silent and never self-corrects; warn near the pi aliasing limit.
+                       if(::fabs(rel - prev_rel) > 0.9 * PI)
+                       {
+                           MUDA_KERNEL_WARN_WITH_LOCATION(
+                               "revolute joint %d: per-frame rotation %f rad is "
+                               "close to the pi unwrap limit; current_angle may "
+                               "alias onto a wrong turn",
+                               I,
+                               rel - prev_rel);
+                       }
+                       current_angles(I) = rel + init_angles(I);
+                       MUDA_ASSERT(::isfinite(current_angles(I)),
+                                   "current_angle is not finite: %f (theta=%f, prev_rel=%f)",
+                                   current_angles(I),
+                                   theta,
+                                   prev_rel);
                    });
     }
 
@@ -444,6 +460,53 @@ Edge             = ({}, {}))",
                        });
     }
 
+    void adopt_scene_angles()
+    {
+        auto geo_slots = world().scene().geometries();
+
+        // A mismatch vs h_current_angles (last published) means a user-authored angle (reset/teleport); overlay it, the following resync snaps it to the pose.
+        current_angles.copy_to(h_adopted_angles);
+
+        IndexT geo_joint_index = 0;
+        bool   adopted         = false;
+
+        this->for_each(geo_slots,
+                       [&](geometry::Geometry& geo)
+                       {
+                           auto sc = geo.as<geometry::SimplicialComplex>();
+                           UIPC_ASSERT(sc, "AffineBodyRevoluteJoint: Geometry must be a simplicial complex");
+
+                           auto angle = sc->edges().find<Float>("angle");
+                           if(angle)
+                           {
+                               auto angle_view = angle->view();
+                               auto [offset, count] =
+                                   h_geo_joint_offsets_counts[geo_joint_index];
+                               UIPC_ASSERT(angle_view.size() == count,
+                                           "AffineBodyRevoluteJoint: angle attribute size {} mismatch with joint count {}",
+                                           angle_view.size(),
+                                           count);
+
+                               for(IndexT i = 0; i < count; ++i)
+                               {
+                                   Float user_angle = angle_view[i];
+                                   if(user_angle != h_current_angles[offset + i])
+                                   {
+                                       h_adopted_angles[offset + i] = user_angle;
+                                       adopted = true;
+                                   }
+                               }
+                           }
+
+                           ++geo_joint_index;
+                       });
+
+        if(adopted)
+        {
+            current_angles.copy_from(h_adopted_angles);
+        }
+    }
+
     bool do_dump(DumpInfo& info) override
     {
         auto path  = info.dump_path(UIPC_RELATIVE_SOURCE_FILE);
@@ -490,9 +553,10 @@ class AffineBodyRevoluteJointDofReporter final : public JointDofReporter
 
     void do_update_dof_attributes(UpdateDofAttributesInfo& info) override
     {
-        // Re-sync persistent per-joint angles (current_angles) with the new
-        // vertex/body attribute layout before the next frame uses them.
+        // Adopt user-authored angles (reset/teleport winding a > pi jump can't unwrap), resync current_angles to the new pose, then republish.
+        revolute_joint->adopt_scene_angles();
         revolute_joint->compute_current_angles();
+        revolute_joint->write_scene();
     }
 };
 REGISTER_SIM_SYSTEM(AffineBodyRevoluteJointDofReporter);
@@ -756,19 +820,16 @@ class AffineBodyDrivingRevoluteJoint : public InterAffineBodyConstraint
                            return;
                        }
 
-                       auto  passive   = is_passive(I);
-                       Float kappa     = strength_ratios(I)
-                                         * (body_masses(bids(0)).mass()
-                                            + body_masses(bids(1)).mass());
-                       auto  aim_angle = aim_angles(I);
+                       auto  passive = is_passive(I);
+                       Float kappa   = strength_ratios(I)
+                                     * (body_masses(bids(0)).mass()
+                                        + body_masses(bids(1)).mass());
+                       auto aim_angle = aim_angles(I);
                        if(passive == 1)
                        {
                            // resist external forces passively
                            aim_angle = current_angles(I);
                        }
-
-                       // mapping [min_angle, max_angle] to [min-init_angle, max-init_angle]
-                       Float theta_tilde = aim_angle - init_angles(I);
 
                        Vector12 q_i = qs(bids(0));
                        Vector12 q_j = qs(bids(1));
@@ -783,6 +844,10 @@ class AffineBodyDrivingRevoluteJoint : public InterAffineBodyConstraint
                                          rb.segment<3>(0),
                                          rb.segment<3>(3),
                                          q_j);
+
+                       // Fold the frame-start unwrap shift into theta_tilde (gradient unaffected; see driving_theta_tilde).
+                       Float theta_tilde = driving_theta_tilde(
+                           F01_q, aim_angle, init_angles(I), current_angles(I));
 
                        Float E;
                        DRJ::E(E, kappa, F01_q, theta_tilde);
@@ -841,8 +906,6 @@ class AffineBodyDrivingRevoluteJoint : public InterAffineBodyConstraint
                         aim_angle = current_angles(I);
                     }
 
-                    auto theta_tilde = aim_angle - init_angles(I);
-
                     Vector12 q_i = qs(bids(0));
                     Vector12 q_j = qs(bids(1));
 
@@ -857,6 +920,10 @@ class AffineBodyDrivingRevoluteJoint : public InterAffineBodyConstraint
                                       rb.segment<3>(0),
                                       rb.segment<3>(3),
                                       q_j);
+
+                    // Same unwrap as do_compute_energy (must be bit-identical).
+                    Float theta_tilde = driving_theta_tilde(
+                        F01_q, aim_angle, init_angles(I), current_angles(I));
 
                     // G12s
                     Vector12 G01;
@@ -1079,18 +1146,8 @@ class AffineBodyRevoluteJointExternalForce final : public AffineBodyExternalForc
                        e_j = 0.5 * (e_j + e_i);
                        e_i = -e_j;
 
-                       // affine-body rotational DOF (virtual-work form)
-                       //  F^A_b  = (tau/2) * [e_world_b]_x * A_b^{-T}    (3x3)
-                       auto torque_to_F = [](Float tau, const Vector3& e, const Vector12& q)
-                       {
-                           Matrix3x3 A_inv_T = q_to_A(q).inverse().transpose();
-                           Matrix3x3 FA      = (0.5 * tau) * skew(e) * A_inv_T;
-
-                           Vector12 F      = Vector12::Zero();
-                           F.segment<9>(3) = A_to_q(FA);
-                           return F;
-                       };
-
+                       // affine-body rotational DOF (virtual-work form),
+                       // see torque_to_F in affine_body/utils.h
                        Vector12 F_i = torque_to_F(tau, e_i, q_i);
                        Vector12 F_j = torque_to_F(tau, e_j, q_j);
 
@@ -1104,8 +1161,11 @@ REGISTER_SIM_SYSTEM(AffineBodyRevoluteJointExternalForce);
 // ============================================================================
 // AffineBodyRevoluteJointLimit
 // Penalty energy enforcing `limit/lower <= delta_angle <= limit/upper`.
-// Reuses body_ids / l_basis / r_basis / init_angles from AffineBodyRevoluteJoint
-// (index-aligned). Only ref_qs, lowers, uppers, strengths are owned locally.
+// Reuses body_ids / l_basis / r_basis / init_angles / current_angles from
+// AffineBodyRevoluteJoint (index-aligned). Only lowers, uppers, strengths
+// are owned locally.
+//
+// Temporal contract: kernels read current_angles as the frame-start angle, so it must stay in sync with the qs snapshot copied into q_prevs; any new path that mutates qs between frames must re-sync it or the limit window shifts by a whole-frame delta.
 // ============================================================================
 
 class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
@@ -1122,15 +1182,13 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
 
     SimSystemSlot<AffineBodyRevoluteJoint> revolute_joint;
 
-    vector<Vector24> h_ref_qs;
-    vector<Float>    h_lowers;
-    vector<Float>    h_uppers;
-    vector<Float>    h_strengths;
+    vector<Float> h_lowers;
+    vector<Float> h_uppers;
+    vector<Float> h_strengths;
 
-    muda::DeviceBuffer<Vector24> ref_qs;
-    muda::DeviceBuffer<Float>    lowers;
-    muda::DeviceBuffer<Float>    uppers;
-    muda::DeviceBuffer<Float>    strengths;
+    muda::DeviceBuffer<Float> lowers;
+    muda::DeviceBuffer<Float> uppers;
+    muda::DeviceBuffer<Float> strengths;
 
     void do_build(BuildInfo& info) override
     {
@@ -1141,7 +1199,6 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
     {
         auto geo_slots = world().scene().geometries();
 
-        h_ref_qs.clear();
         h_lowers.clear();
         h_uppers.clear();
         h_strengths.clear();
@@ -1158,19 +1215,6 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
                 auto sc = geo.as<geometry::SimplicialComplex>();
                 UIPC_ASSERT(sc, "AffineBodyRevoluteJointLimit geometry must be SimplicialComplex");
 
-                auto l_geo_id = sc->edges().find<IndexT>("l_geo_id");
-                UIPC_ASSERT(l_geo_id, "AffineBodyRevoluteJointLimit requires `l_geo_id` attribute on edges");
-                auto l_geo_id_view = l_geo_id->view();
-                auto r_geo_id      = sc->edges().find<IndexT>("r_geo_id");
-                UIPC_ASSERT(r_geo_id, "AffineBodyRevoluteJointLimit requires `r_geo_id` attribute on edges");
-                auto r_geo_id_view = r_geo_id->view();
-                auto l_inst_id     = sc->edges().find<IndexT>("l_inst_id");
-                UIPC_ASSERT(l_inst_id, "AffineBodyRevoluteJointLimit requires `l_inst_id` attribute on edges");
-                auto l_inst_id_view = l_inst_id->view();
-                auto r_inst_id      = sc->edges().find<IndexT>("r_inst_id");
-                UIPC_ASSERT(r_inst_id, "AffineBodyRevoluteJointLimit requires `r_inst_id` attribute on edges");
-                auto r_inst_id_view = r_inst_id->view();
-
                 auto lower_attr = sc->edges().find<Float>("limit/lower");
                 UIPC_ASSERT(lower_attr, "AffineBodyRevoluteJointLimit requires `limit/lower` attribute on edges");
                 auto lower_view = lower_attr->view();
@@ -1183,38 +1227,8 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
                 UIPC_ASSERT(strength_attr, "AffineBodyRevoluteJointLimit requires `limit/strength` attribute on edges");
                 auto strength_view = strength_attr->view();
 
-                auto edges = sc->edges().topo().view();
-
-                for(auto&& [i, e] : enumerate(edges))
+                for(SizeT i = 0; i < sc->edges().size(); ++i)
                 {
-                    IndexT l_gid = l_geo_id_view[i];
-                    IndexT r_gid = r_geo_id_view[i];
-                    IndexT l_iid = l_inst_id_view[i];
-                    IndexT r_iid = r_inst_id_view[i];
-
-                    auto* left_sc  = info.body_geo(geo_slots, l_gid);
-                    auto* right_sc = info.body_geo(geo_slots, r_gid);
-
-                    UIPC_ASSERT(l_iid >= 0
-                                    && l_iid < static_cast<IndexT>(
-                                           left_sc->instances().size()),
-                                "AffineBodyRevoluteJointLimit: left instance ID {} out of range [0, {})",
-                                l_iid,
-                                left_sc->instances().size());
-                    UIPC_ASSERT(r_iid >= 0
-                                    && r_iid < static_cast<IndexT>(
-                                           right_sc->instances().size()),
-                                "AffineBodyRevoluteJointLimit: right instance ID {} out of range [0, {})",
-                                r_iid,
-                                right_sc->instances().size());
-
-                    Vector24 ref;
-                    ref.segment<12>(0) =
-                        transform_to_q(left_sc->transforms().view()[l_iid]);
-                    ref.segment<12>(12) =
-                        transform_to_q(right_sc->transforms().view()[r_iid]);
-                    h_ref_qs.push_back(ref);
-
                     UIPC_ASSERT(lower_view[i] <= upper_view[i],
                                 "AffineBodyRevoluteJointLimit: requires `limit/lower <= limit/upper` on edge {}, but got lower={} upper={}",
                                 i,
@@ -1226,16 +1240,16 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
                 }
             });
 
-        // Sanity check: limit constitution reuses body_ids/l_basis/r_basis/init_angles
-        // from AffineBodyRevoluteJoint via the shared index `I`. Both must
-        // therefore enumerate exactly the same (geo, edge) sequence.
-        UIPC_ASSERT(h_ref_qs.size() == revolute_joint->h_body_ids.size(),
+        // Sanity check: limit constitution reuses body_ids/l_basis/r_basis/
+        // init_angles/current_angles from AffineBodyRevoluteJoint via the
+        // shared index `I`. Both must therefore enumerate exactly the same
+        // (geo, edge) sequence.
+        UIPC_ASSERT(h_lowers.size() == revolute_joint->h_body_ids.size(),
                     "AffineBodyRevoluteJointLimit: joint count {} must equal "
                     "AffineBodyRevoluteJoint joint count {} (index alignment required)",
-                    h_ref_qs.size(),
+                    h_lowers.size(),
                     revolute_joint->h_body_ids.size());
 
-        ref_qs.copy_from(h_ref_qs);
         lowers.copy_from(h_lowers);
         uppers.copy_from(h_uppers);
         strengths.copy_from(h_strengths);
@@ -1243,7 +1257,7 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
 
     void do_report_energy_extent(EnergyExtentInfo& info) override
     {
-        info.energy_count(ref_qs.size());
+        info.energy_count(lowers.size());
     }
 
     void do_compute_energy(ComputeEnergyInfo& info) override
@@ -1252,12 +1266,12 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
         namespace ERJ = sym::affine_body_revolute_joint_limit;
         ParallelFor()
             .file_line(__FILE__, __LINE__)
-            .apply(ref_qs.size(),
+            .apply(lowers.size(),
                    [body_ids = revolute_joint->body_ids.cviewer().name("body_ids"),
                     l_basis = revolute_joint->l_basis.cviewer().name("l_basis"),
                     r_basis = revolute_joint->r_basis.cviewer().name("r_basis"),
                     init_angles = revolute_joint->init_angles.cviewer().name("init_angles"),
-                    ref_qs    = ref_qs.cviewer().name("ref_qs"),
+                    current_angles = revolute_joint->current_angles.cviewer().name("current_angles"),
                     lowers    = lowers.cviewer().name("lowers"),
                     uppers    = uppers.cviewer().name("uppers"),
                     strengths = strengths.cviewer().name("strengths"),
@@ -1267,25 +1281,23 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
                    {
                        Vector2i bid = body_ids(I);
 
-                       Vector6  lb    = l_basis(I);
-                       Vector6  rb    = r_basis(I);
-                       Vector24 ref_q = ref_qs(I);
+                       Vector6 lb = l_basis(I);
+                       Vector6 rb = r_basis(I);
 
                        Vector12 qk      = qs(bid[0]);
                        Vector12 ql      = qs(bid[1]);
                        Vector12 q_prevk = q_prevs(bid[0]);
                        Vector12 q_prevl = q_prevs(bid[1]);
-                       Vector12 q_refk  = ref_q.segment<12>(0);
-                       Vector12 q_refl  = ref_q.segment<12>(12);
 
-                       Float theta_prev = 0.0f;
-                       ERJ::DeltaTheta<Float>(theta_prev, lb, q_prevk, q_refk, rb, q_prevl, q_refl);
+                       Float init_a = init_angles(I);
+
+                       // Unwrapped relative angle at the last committed state; valid past +-pi and across turns.
+                       Float theta_prev = current_angles(I) - init_a;
 
                        Float delta = 0.0f;
                        ERJ::DeltaTheta<Float>(delta, lb, qk, q_prevk, rb, ql, q_prevl);
 
                        Float x        = theta_prev + delta;
-                       Float init_a   = init_angles(I);
                        Float lower    = lowers(I) - init_a;
                        Float upper    = uppers(I) - init_a;
                        Float strength = strengths(I);
@@ -1298,11 +1310,11 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
 
     void do_report_gradient_hessian_extent(GradientHessianExtentInfo& info) override
     {
-        info.gradient_count(2 * ref_qs.size());
+        info.gradient_count(2 * lowers.size());
         if(info.gradient_only())
             return;
 
-        info.hessian_count(HalfHessianSize * ref_qs.size());
+        info.hessian_count(HalfHessianSize * lowers.size());
     }
 
     void do_compute_gradient_hessian(ComputeGradientHessianInfo& info) override
@@ -1313,12 +1325,12 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
 
         ParallelFor()
             .file_line(__FILE__, __LINE__)
-            .apply(ref_qs.size(),
+            .apply(lowers.size(),
                    [body_ids = revolute_joint->body_ids.cviewer().name("body_ids"),
                     l_basis = revolute_joint->l_basis.cviewer().name("l_basis"),
                     r_basis = revolute_joint->r_basis.cviewer().name("r_basis"),
                     init_angles = revolute_joint->init_angles.cviewer().name("init_angles"),
-                    ref_qs    = ref_qs.cviewer().name("ref_qs"),
+                    current_angles = revolute_joint->current_angles.cviewer().name("current_angles"),
                     lowers    = lowers.cviewer().name("lowers"),
                     uppers    = uppers.cviewer().name("uppers"),
                     strengths = strengths.cviewer().name("strengths"),
@@ -1330,25 +1342,23 @@ class AffineBodyRevoluteJointLimit final : public InterAffineBodyConstitution
                    {
                        Vector2i bid = body_ids(I);
 
-                       Vector6  lb    = l_basis(I);
-                       Vector6  rb    = r_basis(I);
-                       Vector24 ref_q = ref_qs(I);
+                       Vector6 lb = l_basis(I);
+                       Vector6 rb = r_basis(I);
 
                        Vector12 qk      = qs(bid[0]);
                        Vector12 ql      = qs(bid[1]);
                        Vector12 q_prevk = q_prevs(bid[0]);
                        Vector12 q_prevl = q_prevs(bid[1]);
-                       Vector12 q_refk  = ref_q.segment<12>(0);
-                       Vector12 q_refl  = ref_q.segment<12>(12);
 
-                       Float theta_prev = 0.0f;
-                       ERJ::DeltaTheta<Float>(theta_prev, lb, q_prevk, q_refk, rb, q_prevl, q_refl);
+                       Float init_a = init_angles(I);
+
+                       // Same unwrapped frame-start angle as do_compute_energy.
+                       Float theta_prev = current_angles(I) - init_a;
 
                        Float delta = 0.0f;
                        ERJ::DeltaTheta<Float>(delta, lb, qk, q_prevk, rb, ql, q_prevl);
 
                        Float x        = theta_prev + delta;
-                       Float init_a   = init_angles(I);
                        Float lower    = lowers(I) - init_a;
                        Float upper    = uppers(I) - init_a;
                        Float strength = strengths(I);

--- a/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint_function.h
+++ b/src/backends/cuda/affine_body/constitutions/affine_body_revolute_joint_function.h
@@ -1,8 +1,15 @@
 #pragma once
 #include <type_define.h>
+#include <numbers>
 
 namespace uipc::backend::cuda
 {
+// Unwrap `wrapped_angle` to the 2*pi representative nearest `ref` (energy and gradient must pass identical args).
+UIPC_GENERIC inline Float unwrap_angle(Float wrapped_angle, Float ref)
+{
+    return ref + ::remainder(wrapped_angle - ref, 2.0 * std::numbers::pi);
+}
+
 namespace sym::affine_body_revolute_joint
 {
 #include "sym/affine_body_revolute_joint.inl"
@@ -31,5 +38,17 @@ MUDA_DEVICE MUDA_INLINE void compute_relative_angle(Float&          out_theta,
     sym::affine_body_driving_revolute_joint::F01_q<Float>(
         F01_q, ni_bar, bi_bar, q_i, nj_bar, bj_bar, q_j);
     sym::affine_body_driving_revolute_joint::theta<Float>(out_theta, F01_q);
+}
+
+// Fold `aim_angle` into a theta_tilde matching the wrapped measurement (energy and gradient must pass identical args).
+MUDA_DEVICE MUDA_INLINE Float driving_theta_tilde(const Vector12& F01_q,
+                                                  Float           aim_angle,
+                                                  Float           init_angle,
+                                                  Float           ref_angle)
+{
+    Float theta_a;
+    sym::affine_body_driving_revolute_joint::theta<Float>(theta_a, F01_q);
+    Float theta_eff = unwrap_angle(theta_a, ref_angle - init_angle);
+    return aim_angle - init_angle - (theta_eff - theta_a);
 }
 }  // namespace uipc::backend::cuda

--- a/src/backends/cuda/affine_body/utils.cu
+++ b/src/backends/cuda/affine_body/utils.cu
@@ -1,5 +1,6 @@
 #include <affine_body/utils.h>
 #include <Eigen/Geometry>
+#include <muda/tools/debug_log.h>
 
 namespace uipc::backend::cuda
 {
@@ -186,5 +187,30 @@ UIPC_GENERIC Matrix3x3 skew(const Vector3& v)
     Matrix3x3 S;
     S << 0, -v(2), v(1), v(2), 0, -v(0), -v(1), v(0), 0;
     return S;
+}
+
+UIPC_GENERIC Vector12 torque_to_F(Float tau, const Vector3& e, const Vector12& q)
+{
+    Matrix3x3 A = q_to_A(q);
+
+    // ABD only softly constrains A toward a rotation, so a collapsed body can make it singular and inverting it poisons the solve; guard with the scale-invariant measure |det|/(|a0||a1||a2|) in [0,1] (also NaN-catching) and drop the torque when it collapses.
+    Float row_norm_prod = A.row(0).norm() * A.row(1).norm() * A.row(2).norm();
+    Float det           = A.determinant();
+    if(!(row_norm_prod > 0 && ::fabs(det) >= 1e-6 * row_norm_prod))
+    {
+        MUDA_KERNEL_WARN(
+            "torque_to_F: affine matrix is near-singular "
+            "(det=%f, row_norm_prod=%f); dropping joint torque",
+            det,
+            row_norm_prod);
+        return Vector12::Zero();
+    }
+
+    Matrix3x3 A_inv_T = A.inverse().transpose();
+    Matrix3x3 FA      = (0.5 * tau) * skew(e) * A_inv_T;
+
+    Vector12 F      = Vector12::Zero();
+    F.segment<9>(3) = A_to_q(FA);
+    return F;
 }
 }  // namespace uipc::backend::cuda

--- a/src/backends/cuda/affine_body/utils.h
+++ b/src/backends/cuda/affine_body/utils.h
@@ -19,4 +19,10 @@ UIPC_GENERIC void orthonormal_basis(Vector3& t, Vector3& n, Vector3& b);
 
 // Skew-symmetric matrix [v]_x such that [v]_x * w = v.cross(w).
 UIPC_GENERIC Matrix3x3 skew(const Vector3& v);
+
+// Convert a scalar torque `tau` about the world-space unit axis `e` into an
+// ABD generalized force on the body with DOF `q` (virtual-work form):
+//   F^A = (tau/2) * [e]_x * A^{-T}   (3x3), packed into the rotational
+// segment of the returned Vector12; the translational segment is zero.
+UIPC_GENERIC Vector12 torque_to_F(Float tau, const Vector3& e, const Vector12& q);
 }  // namespace uipc::backend::cuda

--- a/src/core/xmake.lua
+++ b/src/core/xmake.lua
@@ -4,11 +4,13 @@ add_requires(
     "spdlog[shared,header_only=n,fmt_external=y]"
 )
 
+-- Pin fmt to 12.1.0: 12.2.0's long double hexfloat path fails under nvcc (fallback uint128 lacks operator~)
 if is_plat("windows") then
     -- https://forums.developer.nvidia.com/t/utf-8-option-for-the-host-function-in-cuda-msvc/312739
-    add_requireconfs("spdlog.fmt", {override = true, configs = {unicode = false}})
+    add_requireconfs("spdlog.fmt", {override = true, version = "12.1.0", configs = {unicode = false}})
 else
-    add_requireconfs("spdlog", "spdlog.fmt", {override = true, system = false})
+    add_requireconfs("spdlog", {override = true, system = false})
+    add_requireconfs("spdlog.fmt", {override = true, system = false, version = "12.1.0"})
 end
 
 target("uipc_core")


### PR DESCRIPTION
## Summary

Track the revolute joint angle as a **continuously-unwrapped, multi-turn absolute value** instead of a wrapped `(-π, π]` measurement, and add **external-torque** support for the joint.

### Angle unwrap
- The backend advances a persistent reference angle each step via `::remainder` against the previously committed value, so `angle`, driving `aim_angle`, and `limit/lower|upper` now share the same **unbounded frame** and may span beyond `±π` and across multiple turns.
- The unwrap is exact while per-step rotation stays below `π` — an endpoint-sampling aliasing limit, not an implementation choice.
- **Reset/teleport** jumps (which cannot be unwrapped from two wrapped samples) are handled by adopting user-authored `angle` entries during DOF re-sync, then re-syncing `current_angles` to the new pose.

### External torque
- Adds `torque_to_F` converting a scalar joint torque about a world-space axis into an ABD generalized force (virtual-work form `Fᴬ = (τ/2)·[e]ₓ·A⁻ᵀ`).
- Includes a scale-invariant **near-singular guard** (`|det|/(‖a₀‖‖a₁‖‖a₂‖)`) that drops the torque and warns when the affine matrix collapses, avoiding a poisoned solve.

### Docs
- Specification docs for the base joint, limit, and driving joint updated to describe the unbounded-frame semantics (including the aliasing limit and the sub-stepping escape hatch for fast continuous rotation).

## Breaking changes

The `angle` edge attribute is now a continuous multi-turn value rather than wrapped to `(-π, π]`. Consumers that previously assumed a bounded range should read it as an absolute unbounded angle. `aim_angle` and joint limits are interpreted in this same frame.

## Notes

Energy, gradient, and Hessian kernels call the shared unwrap helper with identical arguments to stay a self-consistent triple.
