### PR TITLE
fix(cuda_tool): dispatch cudaGraphAddNode signature for CUDA 13.0

### DIFF
--- a/agent_docs/09-known-issues-and-roadmap.md
+++ b/agent_docs/09-known-issues-and-roadmap.md
@@ -112,3 +112,34 @@ assertions).
 - `88_stiff_gipc_benchmark` — the Stiff-GIPC set_case2 benchmark with a GUI
   (default) and the original headless loop (`--headless [N]`); both modes
   write `traj.csv` + timing summary.
+
+## MAS preconditioner parity check (2026-08-23, case 89)
+
+Cross-project comparison on the same scene (SNK bunny2, E=1e7, 100 frames;
+libuipc samples `89_mas_bunny` vs Stiff-GIPC `set_case7`, both with MAS):
+
+| run | total PCG | avg per solve | Newton/frame |
+|---|---|---|---|
+| Stiff MAS (P_type=1) | 60293 | 236 | 2.55 |
+| libuipc MAS (mesh_partition) | 3500 | **5** | 6.0 |
+| Stiff diag (P_type=0) | 376877 | 1513 | 2.49 |
+| libuipc diag (NO_MAS=1) | 922185 | 1310 | 6.0 |
+
+Verdicts:
+- diag-vs-diag is same order (1310 vs 1513) — solvers/systems are comparable.
+- libuipc's MAS is NOT under-performing Stiff's — it is ~47x fewer
+  iterations on this scene, and the trajectory matches the well-converged
+  diag reference to sub-millimetre at frame 100 (centroid y -0.7748 vs
+  -0.7753), so the fast convergence is genuine, not an early-exit artifact.
+- Structural reason libuipc's port is stronger: FEMMASPreconditioner
+  rebuilds the cluster inverses from the current full diagonal Hessian
+  (kinetic + material) every Newton iteration
+  (`fem_mas_preconditioner.cu` `set_preconditioner(A.values(), ...)`).
+- Not ported by design: Stiff's collision-aware clustering
+  (`_buildCollisionConnection`, deliberately skipped per owner decision)
+  and the size-specialized Schwarz kernels (`_schwarzLocalXSym3/6/9`,
+  `__inverse6_P96x96`) — the latter is a throughput optimization lead.
+- Stiff-GIPC local benchmark edits (uncommitted, local only): `set_case7`
+  in `gl_main.cu` (single bunny, E=1e7, P_type=1), a 100-frame cap writing
+  `timeCost.txt` (totalNT/totalCgCount), and a `GIPC_PTYPE` env var to flip
+  the preconditioner type.

--- a/src/backends/cuda/cuda_tool/graph.h
+++ b/src/backends/cuda/cuda_tool/graph.h
@@ -18,6 +18,8 @@
 //       10.x - 11.3:   only the legacy 5-arg cudaGraphInstantiate(exec,
 //                      graph, pErrorNode, pLogBuffer, bufferSize) exists.
 //   The dispatch below therefore covers 10.x/11.x/12.x/13.x at compile time.
+//   Also note cudaGraphAddNode gained the edge-data parameter in CUDA 13.0
+//   (5-arg form before) — dispatched at the call site via CUDART_VERSION.
 //   Tested on 12.8 and 13.2.
 //
 // Contract / traps (see agent_docs/08):
@@ -274,7 +276,12 @@ class GraphWhile
         params.conditional.type    = cudaGraphCondTypeWhile;
         params.conditional.size    = 1;
         cudaGraphNode_t while_node;
+#if CUDART_VERSION >= 13000
         err = cudaGraphAddNode(&while_node, m_graph, &setup_node, nullptr, 1, &params);
+#else
+        // CUDA 11.x-12.x: no edge-data parameter
+        err = cudaGraphAddNode(&while_node, m_graph, &setup_node, 1, &params);
+#endif
         cudaGraph_t body_container =
             params.conditional.phGraph_out ? params.conditional.phGraph_out[0] : nullptr;
         if(err != cudaSuccess || body_container == nullptr)


### PR DESCRIPTION
Follow-up to #470 (merged before this landed): CUDA 13.0 added the edge-data parameter to `cudaGraphAddNode` (5-arg form before), so the GraphWhile assembly failed to compile on CUDA 12.8 CI runners. The call is now dispatched by `CUDART_VERSION`.

Local build (CUDA 13.2) passes; the 12.8 path is exercised by CI.