### PR TITLE
fix(cuda_tool): use a blocking stream for graph capture

### DIFF
--- a/agent_docs/08-pitfalls-and-debugging.md
+++ b/agent_docs/08-pitfalls-and-debugging.md
@@ -163,6 +163,15 @@ touching that area; several of these have bitten us more than once.
   - Graph replay vs plain launches can schedule blocks differently →
     different atomic-add arrival order → ULP divergence → chaotic scenes
     diverge after contact onset. Expected; do not chase bit-equality there.
+  - **Use a BLOCKING stream as the capture stream** (cudaStreamDefault).
+    With a non-blocking capture stream, a callee launching into the legacy
+    default stream during capture neither invalidates the capture nor joins
+    the graph — the kernel just EXECUTES, uncaptured: the graph then replays
+    with that work frozen at its capture-time output. (In FusedPCG this made
+    MAS scenes replay with a frozen preconditioner output — false rᵀz
+    collapse, "converged" in 5 iterations with residual 3.3×‖b‖, wrong
+    physics at E=1e4. Caught by a dump-based residual check + a trajectory
+    A/B against the diagonal preconditioner.)
   - **A WHILE conditional node is not automatically faster than host-checked
     block replay**: per-iteration condition evaluation + body dispatch cost
     real microseconds; measured on ~85-iteration solves the block path (host

--- a/agent_docs/09-known-issues-and-roadmap.md
+++ b/agent_docs/09-known-issues-and-roadmap.md
@@ -127,10 +127,14 @@ libuipc samples `89_mas_bunny` vs Stiff-GIPC `set_case7`, both with MAS):
 
 Verdicts:
 - diag-vs-diag is same order (1310 vs 1513) — solvers/systems are comparable.
-- libuipc's MAS is NOT under-performing Stiff's — it is ~47x fewer
-  iterations on this scene, and the trajectory matches the well-converged
-  diag reference to sub-millimetre at frame 100 (centroid y -0.7748 vs
-  -0.7753), so the fast convergence is genuine, not an early-exit artifact.
+- ITERATION-COUNT CAVEAT (corrected 2026-08-23 evening): the 5/solve figure
+  was an artifact of a graph-capture bug — the non-blocking capture stream
+  let the un-plumbed MAS engine execute during capture instead of joining
+  the graph, so replays ran with a frozen preconditioner (false r^Tz
+  collapse). Fixed by using a blocking capture stream (un-plumbed callees
+  now invalidate capture -> automatic fallback). After the fix, MAS averages
+  ~41/solve vs diag ~86/solve on the E=1e4 bunny, with trajectories matching
+  to 0.3mm at frame 100. The MAS preconditioner itself was never wrong.
 - Structural reason libuipc's port is stronger: FEMMASPreconditioner
   rebuilds the cluster inverses from the current full diagonal Hessian
   (kinetic + material) every Newton iteration

--- a/src/backends/cuda/cuda_tool/graph.h
+++ b/src/backends/cuda/cuda_tool/graph.h
@@ -65,7 +65,14 @@ class GraphCapture
         reset_graph();
 
         if(!m_capture_stream)
-            cudaStreamCreateWithFlags(&m_capture_stream, cudaStreamNonBlocking);
+            // blocking on purpose: any callee launching into the legacy
+            // default stream during capture then INVALIDATES the capture
+            // (our automatic fallback signal). With a non-blocking capture
+            // stream, such kernels would silently EXECUTE during capture and
+            // be missing from the graph — the replayed graph would run the
+            // solver with the preconditioner frozen at its capture-time
+            // output (this produced false PCG convergence on MAS scenes).
+            cudaStreamCreateWithFlags(&m_capture_stream, cudaStreamDefault);
 
         cudaError_t err =
             cudaStreamBeginCapture(m_capture_stream, cudaStreamCaptureModeThreadLocal);
@@ -232,7 +239,14 @@ class GraphWhile
             return fail(Result::Unsupported);
 
         if(!m_capture_stream)
-            cudaStreamCreateWithFlags(&m_capture_stream, cudaStreamNonBlocking);
+            // blocking on purpose: any callee launching into the legacy
+            // default stream during capture then INVALIDATES the capture
+            // (our automatic fallback signal). With a non-blocking capture
+            // stream, such kernels would silently EXECUTE during capture and
+            // be missing from the graph — the replayed graph would run the
+            // solver with the preconditioner frozen at its capture-time
+            // output (this produced false PCG convergence on MAS scenes).
+            cudaStreamCreateWithFlags(&m_capture_stream, cudaStreamDefault);
 
         cudaError_t err;
         // 1) main graph + conditional handle first: both bodies bake the


### PR DESCRIPTION
Follow-up fix to the FusedPCG CUDA-graph work (#470).

**Bug**: with a non-blocking capture stream, callees launching into the legacy default stream during capture neither invalidate the capture nor join the graph — their kernels simply execute uncaptured. In MAS scenes the (un-plumbed) MAS engine therefore ran only at capture time, and replayed PCG used a **frozen preconditioner output**: r^Tz collapsed within 5 iterations while ||Ax-b||/||b|| stayed ~3 — visibly wrong physics at E=1e4.

**Fix**: blocking capture stream (cudaStreamDefault), so such launches invalidate the capture and the existing automatic fallback takes over.

**Verified**: full sim suite 95/95 (14214 assertions); E=1e4 bunny MAS trajectory matches the diagonal-preconditioner reference to 0.3mm at frame 100 (avg 41 PCG iters vs diag 86); samples 88 benchmark median 224ms with graph still engaged.