### PR TITLE
perf(cuda): MAS preconditioner joins the PCG CUDA graph

### DIFF
--- a/agent_docs/05-cuda-backend.md
+++ b/agent_docs/05-cuda-backend.md
@@ -115,8 +115,15 @@ Graph-stability design (no rebuilds from contact-pair fluctuation):
   `spmv_dot/apply_preconditioner`, `IterativeSolver` pass-throughs,
   `ApplyPreconditionerInfo::stream()`, and the ABD/FEM diag preconditioners
   all accept an optional launch stream (default = legacy default stream =
-  unchanged behavior). The MAS preconditioner engine is NOT plumbed; its
-  scenes fail capture and fall back to the plain loop permanently.
+  unchanged behavior). The MAS preconditioner is plumbed too:
+  `MASPreconditionerEngine::apply` and its three phases (restrict /
+  Schwarz local solve / prolongate) plus the unpartitioned-vertex diagonal
+  fallback in `FEMMASPreconditioner::do_apply` all launch on
+  `ApplyPreconditionerInfo::stream()`, so MAS scenes join the captured
+  graph instead of invalidating it. The engine's workspace buffers are
+  sized once at init from the mesh partition (contact does not recluster —
+  collision-aware clustering is deliberately not ported), so the captured
+  pointers stay valid as contact nnz fluctuates.
 - `linear_system/check_interval` is now a registered config key (default 5) —
   it was previously unregistered and silently dropped.
 - Per-iteration "SpMV"/"Apply Preconditioner" Timer entries only exist on

--- a/agent_docs/08-pitfalls-and-debugging.md
+++ b/agent_docs/08-pitfalls-and-debugging.md
@@ -93,6 +93,14 @@ touching that area; several of these have bitten us more than once.
   use it); `Warn` keeps kappa-clamp warnings visible.
 - stdout redirection block-buffers printf in some native code — a timeout
   kill loses logs; instrumented prints need `fflush(stdout)`.
+- **Stale-dll trap when benchmarking solver changes through the python
+  samples:** the samples load the dlls from
+  `<python>\\Lib\\site-packages\\uipc\\_native\\`, NOT from `build/`. After
+  rebuilding backend `.cu` files, re-copy `build/Release/bin/uipc_*.dll`
+  into both `build/python/src/uipc/_native/` and the site-packages
+  `_native/` dir before running — otherwise python silently runs the OLD
+  solver and trajectory/timing comparisons are garbage (this once cost a
+  full debug round chasing a MAS "freeze" that was just a stale dll).
 
 ## Simulation semantics (contact/constraints/ABD)
 

--- a/agent_docs/09-known-issues-and-roadmap.md
+++ b/agent_docs/09-known-issues-and-roadmap.md
@@ -135,6 +135,19 @@ Verdicts:
   now invalidate capture -> automatic fallback). After the fix, MAS averages
   ~41/solve vs diag ~86/solve on the E=1e4 bunny, with trajectories matching
   to 0.3mm at frame 100. The MAS preconditioner itself was never wrong.
+- MAS + CUDA graph (closed 2026-08-23): the engine's `apply` path is now
+  stream-plumbed (`MASPreconditionerEngine::apply(..., stream)` +
+  `FEMMASPreconditioner::do_apply` forwards `info.stream()`), so MAS scenes
+  join the captured graph instead of falling back to plain launches
+  (graph_mode=1 confirmed active with mesh_part present). Validation at
+  E=1e7/100 frames with contact: MAS+graph trajectory identical to the
+  diag+graph reference at 1e-4 print precision; resting centroid -0.7753 vs
+  the rigid-body geometric prediction -0.7731 (2mm compression); iteration
+  counts real (frame-20 solves: MAS 5/20/155/435/495/410/505 vs diag
+  2380/1625/880/1585/1650/1625/785 — MAS 3-4x fewer, no false-convergence
+  signature). Free-fall no-contact: graph on/off bit-identical. One red
+  herring cost a debug round: a "frozen" E=1e4 trajectory turned out to be
+  a stale site-packages dll, not a solver bug (see doc 08 stale-dll trap).
 - Structural reason libuipc's port is stronger: FEMMASPreconditioner
   rebuilds the cluster inverses from the current full diagonal Hessian
   (kinetic + material) every Newton iteration

--- a/agent_docs/09-known-issues-and-roadmap.md
+++ b/agent_docs/09-known-issues-and-roadmap.md
@@ -148,6 +148,12 @@ Verdicts:
   signature). Free-fall no-contact: graph on/off bit-identical. One red
   herring cost a debug round: a "frozen" E=1e4 trajectory turned out to be
   a stale site-packages dll, not a solver bug (see doc 08 stale-dll trap).
+  Measured benefit (89_mas_bunny, E=1e7, 100 frames, 704 solves/~198k PCG
+  iters, identical iteration counts and f100 centroid on both paths):
+  graph on 29.8s vs graph off 36.0s wall = ~17% end-to-end (~32 us/PCG
+  iteration of launch-gap savings). For reference the same scene with the
+  diagonal preconditioner (graph on) takes ~74s — MAS itself is the bigger
+  win (~2.5x), the graph plumbing adds its share on top.
 - Structural reason libuipc's port is stronger: FEMMASPreconditioner
   rebuilds the cluster inverses from the current full diagonal Hessian
   (kinetic + material) every Newton iteration

--- a/src/backends/cuda/finite_element/fem_mas_preconditioner.cu
+++ b/src/backends/cuda/finite_element/fem_mas_preconditioner.cu
@@ -109,13 +109,14 @@ void apply_diag_inv_for_unpartitioned(const cuda_tool::DeviceBuffer<Matrix3x3>& 
                                       cuda_tool::DenseVectorView<Float>  z,
                                       cuda_tool::CDenseVectorView<Float> r,
                                       cuda_tool::CVarView<IndexT> converged,
-                                      SizeT                       num_verts)
+                                      SizeT                       num_verts,
+                                      cudaStream_t                stream)
 {
     int n = (int)num_verts;
     if(n > 0)
     {
         auto k = apply_diag_inv_for_unpartitioned_kernel;
-        k<<<cuda_tool::best_grid_dim(n, k), cuda_tool::best_block_dim(k), 0, nullptr>>>(
+        k<<<cuda_tool::best_grid_dim(n, k), cuda_tool::best_block_dim(k), 0, stream>>>(
             r, z, diag_inv.cview(), unpart_flags.cview(), converged.cviewer(), n);
     }
 }
@@ -463,7 +464,7 @@ class FEMMASPreconditioner : public LocalPreconditioner
         auto converged = info.converged();
 
         // MAS for partitioned vertices
-        engine.apply(info.r(), info.z(), converged);
+        engine.apply(info.r(), info.z(), converged, info.stream());
 
         // Diagonal fallback for unpartitioned vertices
         if(m_has_unpartitioned)
@@ -473,7 +474,8 @@ class FEMMASPreconditioner : public LocalPreconditioner
                                              info.z(),
                                              info.r(),
                                              converged,
-                                             diag_inv.size());
+                                             diag_inv.size(),
+                                             info.stream());
         }
     }
 };

--- a/src/backends/cuda/finite_element/mas_preconditioner_engine.cu
+++ b/src/backends/cuda/finite_element/mas_preconditioner_engine.cu
@@ -1480,7 +1480,8 @@ void MASPreconditionerEngine::invert_cluster_matrices()
 // Restrict: accumulate residual R from fine to all coarser levels
 // ---------------------------------------------------------------------------
 void MASPreconditionerEngine::build_multi_level_R(cuda_tool::CDenseVectorView<Float> R,
-                                                  cuda_tool::CVarView<IndexT> converged)
+                                                  cuda_tool::CVarView<IndexT> converged,
+                                                  cudaStream_t stream)
 {
     using namespace cuda_tool;
     int N = m_total_map_nodes;
@@ -1490,7 +1491,7 @@ void MASPreconditionerEngine::build_multi_level_R(cuda_tool::CDenseVectorView<Fl
     int block_size = DEFAULT_BLOCKSIZE;
     int num_blocks = (N + block_size - 1) / block_size;
 
-    MASPreconditionerEngine_build_multi_level_R_kernel<<<num_blocks, block_size, 0, nullptr>>>(
+    MASPreconditionerEngine_build_multi_level_R_kernel<<<num_blocks, block_size, 0, stream>>>(
         R,
         multi_level_R.view(),
         going_next.cview(0, m_total_num_clusters),
@@ -1506,7 +1507,8 @@ void MASPreconditionerEngine::build_multi_level_R(cuda_tool::CDenseVectorView<Fl
 // ---------------------------------------------------------------------------
 // Local solve: Z = cluster_inverse * R at each level
 // ---------------------------------------------------------------------------
-void MASPreconditionerEngine::schwarz_local_solve(cuda_tool::CVarView<IndexT> converged)
+void MASPreconditionerEngine::schwarz_local_solve(cuda_tool::CVarView<IndexT> converged,
+                                                  cudaStream_t stream)
 {
     using namespace cuda_tool;
     int N = m_total_num_clusters * BANKSIZE;  // one thread per (cluster, node-pair)
@@ -1516,7 +1518,7 @@ void MASPreconditionerEngine::schwarz_local_solve(cuda_tool::CVarView<IndexT> co
     int block_size = BANKSIZE * BANKSIZE;
     int num_blocks = (N + block_size - 1) / block_size;
 
-    MASPreconditionerEngine_schwarz_local_solve_kernel<<<num_blocks, block_size, 0, nullptr>>>(
+    MASPreconditionerEngine_schwarz_local_solve_kernel<<<num_blocks, block_size, 0, stream>>>(
         cluster_inverses.cview(),
         multi_level_R.cview(),
         multi_level_Z.view(),
@@ -1528,7 +1530,8 @@ void MASPreconditionerEngine::schwarz_local_solve(cuda_tool::CVarView<IndexT> co
 // Prolongate: sum Z contributions from all levels for each fine node
 // ---------------------------------------------------------------------------
 void MASPreconditionerEngine::collect_final_Z(cuda_tool::DenseVectorView<Float> Z,
-                                              cuda_tool::CVarView<IndexT> converged)
+                                              cuda_tool::CVarView<IndexT> converged,
+                                              cudaStream_t stream)
 {
     using namespace cuda_tool;
     int N = m_total_nodes;
@@ -1537,7 +1540,7 @@ void MASPreconditionerEngine::collect_final_Z(cuda_tool::DenseVectorView<Float> 
 
     int level_num = (m_active_level_num > 0) ? m_active_level_num : m_level_num;
     auto k        = MASPreconditionerEngine_collect_final_Z_kernel;
-    k<<<cuda_tool::best_grid_dim(N, k), cuda_tool::best_block_dim(k), 0, nullptr>>>(
+    k<<<cuda_tool::best_grid_dim(N, k), cuda_tool::best_block_dim(k), 0, stream>>>(
         Z,
         multi_level_Z.cview(),
         coarse_tables.cview(),
@@ -1553,7 +1556,8 @@ void MASPreconditionerEngine::collect_final_Z(cuda_tool::DenseVectorView<Float> 
 
 void MASPreconditionerEngine::apply(cuda_tool::CDenseVectorView<Float> r,
                                     cuda_tool::DenseVectorView<Float>  z,
-                                    cuda_tool::CVarView<IndexT> converged)
+                                    cuda_tool::CVarView<IndexT> converged,
+                                    cudaStream_t                stream)
 {
     if(m_total_nodes < 1)
         return;
@@ -1569,19 +1573,19 @@ void MASPreconditionerEngine::apply(cuda_tool::CDenseVectorView<Float> r,
     {
         multi_level_R
             .view(m_total_map_nodes, m_total_num_clusters - m_total_map_nodes)
-            .fill(Eigen::Vector3f::Zero());
+            .fill(Eigen::Vector3f::Zero(), stream);
     }
 
-    multi_level_Z.view(0, m_total_num_clusters).fill(float3{0, 0, 0});
+    multi_level_Z.view(0, m_total_num_clusters).fill(float3{0, 0, 0}, stream);
 
     // 1. Restrict: accumulate residual down through levels
-    build_multi_level_R(r, converged);
+    build_multi_level_R(r, converged, stream);
 
     // 2. Local solve: Z = cluster_inverse * R at each level
-    schwarz_local_solve(converged);
+    schwarz_local_solve(converged, stream);
 
     // 3. Prolongate: sum Z from all levels back to fine nodes
-    collect_final_Z(z, converged);
+    collect_final_Z(z, converged, stream);
 }
 
 void MASPreconditionerEngine::dump_cluster_matrices_debug(std::string_view output_dir,

--- a/src/backends/cuda/finite_element/mas_preconditioner_engine.h
+++ b/src/backends/cuda/finite_element/mas_preconditioner_engine.h
@@ -90,7 +90,8 @@ class MASPreconditionerEngine
 
     void apply(cuda_tool::CDenseVectorView<Float> r,
                cuda_tool::DenseVectorView<Float>  z,
-               cuda_tool::CVarView<IndexT>        converged);
+               cuda_tool::CVarView<IndexT>        converged,
+               cudaStream_t                       stream = nullptr);
 
     bool is_initialized() const { return m_initialized; }
 
@@ -153,10 +154,13 @@ class MASPreconditionerEngine
 
     // Preconditioning steps
     void build_multi_level_R(cuda_tool::CDenseVectorView<Float> R,
-                             cuda_tool::CVarView<IndexT>        converged);
-    void schwarz_local_solve(cuda_tool::CVarView<IndexT> converged);
+                             cuda_tool::CVarView<IndexT>        converged,
+                             cudaStream_t stream = nullptr);
+    void schwarz_local_solve(cuda_tool::CVarView<IndexT> converged,
+                             cudaStream_t                stream = nullptr);
     void collect_final_Z(cuda_tool::DenseVectorView<Float> Z,
-                         cuda_tool::CVarView<IndexT>       converged);
+                         cuda_tool::CVarView<IndexT>       converged,
+                         cudaStream_t                      stream = nullptr);
 
   private:
     // ---- State ----


### PR DESCRIPTION
## What
- Stream-plumb the MAS preconditioner apply path (restrict / Schwarz local solve / prolongate + unpartitioned diagonal fallback) so MAS scenes are captured into the block-replay PCG graph instead of permanently falling back to plain launches.
- Docs: MAS graph validation results, measured benefit, stale-dll pitfall.

## Validation (89_mas_bunny, E=1e7, 100 frames, contact)
- Trajectory identical to diag+graph reference at 1e-4 print precision; resting centroid matches rigid-body prediction (-0.7753 vs -0.7731).
- Real iteration counts (MAS ~282/solve avg vs diag ~1350/solve), no false-convergence signature.
- Measured benefit: 29.8s vs 36.0s wall for 100 frames = ~17% end-to-end (identical iteration counts both paths).
- Full suite 95/95 (14214 assertions); 88 benchmark median 229ms, no regression.