### PR TITLE
feat(cuda): MAS all-or-nothing — scene config switch + internal auto-partition

### DIFF
--- a/agent_docs/05-cuda-backend.md
+++ b/agent_docs/05-cuda-backend.md
@@ -124,6 +124,18 @@ Graph-stability design (no rebuilds from contact-pair fluctuation):
   sized once at init from the mesh partition (contact does not recluster —
   collision-aware clustering is deliberately not ported), so the captured
   pointers stay valid as contact nnz fluctuates.
+- MAS activation (all-or-nothing, since 2026-08-23): scene config
+  `linear_system/fem_preconditioner = "mas"` (default `"diag"`) selects the
+  FEM local preconditioner. When on, `FEMMASPreconditioner::do_init`
+  auto-partitions EVERY non-Empty FEM SimplicialComplex internally (fixed
+  cluster size = `MASPreconditionerEngine::BANKSIZE` 16 — the only size the
+  Schwarz kernels' shared-memory layout accepts) on a private clone, so
+  scene geometries are never mutated; a pre-existing `mesh_part` vertex
+  attribute (custom C++ partitioning) is respected as-is. Empty-constitution
+  geometries are skipped and stay on the internal diagonal fallback. If the
+  switch is on but nothing is partitionable, `do_apply` falls back to z=r.
+  The python `mesh_partition` export is gone — per-mesh manual tagging no
+  longer activates MAS (partial coverage measured net-negative, doc 09).
 - `linear_system/check_interval` is now a registered config key (default 5) —
   it was previously unregistered and silently dropped.
 - Per-iteration "SpMV"/"Apply Preconditioner" Timer entries only exist on

--- a/agent_docs/09-known-issues-and-roadmap.md
+++ b/agent_docs/09-known-issues-and-roadmap.md
@@ -154,6 +154,22 @@ Verdicts:
   iteration of launch-gap savings). For reference the same scene with the
   diagonal preconditioner (graph on) takes ~74s — MAS itself is the bigger
   win (~2.5x), the graph plumbing adds its share on top.
+- COVERAGE RULE (measured on 88_stiff_gipc_benchmark, E=1e7, two 19k-vert
+  bunnies + 4.2k-vert cloth, 60 frames, 2026-08-23): MAS only pays off when
+  it covers nearly all of the stiff DoFs. Partial coverage is net NEGATIVE:
+  | config | total PCG | avg/solve | wall |
+  |---|---|---|---|
+  | all diagonal | 366875 | 853 | 60s |
+  | MAS on upper bunny only (~45% of FEM verts) | 397730 | 923 | 73s |
+  | MAS on both bunnies (~90%) | 79225 | 184 | 29s |
+  f59 centroids identical in all three — physics unaffected; only the
+  preconditioner spectrum changes. PCG converges at the rate of the
+  worst-preconditioned block, so a diag-covered stiff block (the lower
+  bunny in ground contact + the cloth) dominates and the MAS per-iteration
+  overhead (cluster-inverse assembly + 5-launch apply) is pure cost.
+  Practical rule: partition ALL stiff FEM objects (`mesh_partition`); leave
+  only soft/small ones unpartitioned. `NO_MAS=1` / `ALL_MAS=1` env switches
+  in the sample reproduce this table.
 - Structural reason libuipc's port is stronger: FEMMASPreconditioner
   rebuilds the cluster inverses from the current full diagonal Hessian
   (kinetic + material) every Newton iteration

--- a/agent_docs/09-known-issues-and-roadmap.md
+++ b/agent_docs/09-known-issues-and-roadmap.md
@@ -139,7 +139,7 @@ Verdicts:
   stream-plumbed (`MASPreconditionerEngine::apply(..., stream)` +
   `FEMMASPreconditioner::do_apply` forwards `info.stream()`), so MAS scenes
   join the captured graph instead of falling back to plain launches
-  (graph_mode=1 confirmed active with mesh_part present). Validation at
+  (graph_mode=1 confirmed active in MAS scenes). Validation at
   E=1e7/100 frames with contact: MAS+graph trajectory identical to the
   diag+graph reference at 1e-4 print precision; resting centroid -0.7753 vs
   the rigid-body geometric prediction -0.7731 (2mm compression); iteration
@@ -167,9 +167,23 @@ Verdicts:
   worst-preconditioned block, so a diag-covered stiff block (the lower
   bunny in ground contact + the cloth) dominates and the MAS per-iteration
   overhead (cluster-inverse assembly + 5-launch apply) is pure cost.
-  Practical rule: partition ALL stiff FEM objects (`mesh_partition`); leave
-  only soft/small ones unpartitioned. `NO_MAS=1` / `ALL_MAS=1` env switches
-  in the sample reproduce this table.
+  This table was measured with per-mesh tagging; it is the direct
+  motivation for the all-or-nothing redesign below.
+- ALL-OR-NOTHING REDESIGN (2026-08-23): MAS activation is now a scene
+  config switch — `linear_system/fem_preconditioner = "mas"` (default
+  `"diag"`). When on, `FEMMASPreconditioner::do_init` auto-partitions
+  EVERY non-Empty FEM SimplicialComplex internally on a private clone
+  (fixed cluster size = `BANKSIZE` 16, the only size the engine's shared-
+  memory kernels accept); a pre-existing `mesh_part` attribute (custom C++
+  partitioning) is still respected as-is, but manual tagging alone no
+  longer activates MAS. The python `uipc.geometry.mesh_partition` export
+  was removed (the exposed `part_max_size` was a footgun — any value > 16
+  trips the BANKSIZE assert). Defensive fix included: switch on but
+  nothing partitionable (e.g. all-Empty FEM) -> do_apply falls back to
+  z=r instead of leaving z stale. Migrated: sim_case 53-61/81 + the
+  stitch regression (config switch instead of mesh_partition calls;
+  58_hybrid_mix now verifies custom + auto partitions coexist), samples
+  88/89 (NO_MAS=1 env flips the switch to "diag").
 - Structural reason libuipc's port is stronger: FEMMASPreconditioner
   rebuilds the cluster inverses from the current full diagonal Hessian
   (kinetic + material) every Newton iteration

--- a/apps/tests/regression/fem_mas_soft_vertex_stitch_regression.cpp
+++ b/apps/tests/regression/fem_mas_soft_vertex_stitch_regression.cpp
@@ -26,6 +26,7 @@ TEST_CASE("fem_mas_soft_vertex_stitch_regression", "[fem][mas][stitch][regressio
     config["contact"]["d_hat"]              = 0.002;
     config["line_search"]["max_iter"]       = 8;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -49,8 +50,6 @@ TEST_CASE("fem_mas_soft_vertex_stitch_regression", "[fem][mas][stitch][regressio
 
     label_surface(cloth_a);
     label_surface(cloth_b);
-    mesh_partition(cloth_a, 16);
-    mesh_partition(cloth_b, 16);
 
     NeoHookeanShell      nhs;
     DiscreteShellBending dsb;

--- a/apps/tests/sim_case/53_fem_mas_single_tet.cpp
+++ b/apps/tests/sim_case/53_fem_mas_single_tet.cpp
@@ -21,6 +21,7 @@ TEST_CASE("53_fem_mas_small_cube", "[fem][mas]")
     config["gravity"]                   = Vector3{0, -9.8, 0};
     config["contact"]["enable"]         = false;
     config["linear_system"]["tol_rate"] = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -39,15 +40,6 @@ TEST_CASE("53_fem_mas_small_cube", "[fem][mas]")
 
         label_surface(mesh);
         label_triangle_orient(mesh);
-
-        mesh_partition(mesh, 16);
-
-        {
-            auto mp = mesh.vertices().find<IndexT>("mesh_part");
-            REQUIRE(mp);
-            auto mp_v = mp->view();
-            REQUIRE(std::ranges::all_of(mp_v, [](IndexT v) { return v == 0; }));
-        }
 
         auto parm = ElasticModuli::youngs_poisson(1e5, 0.499);
         snh.apply_to(mesh, parm, 1e3);

--- a/apps/tests/sim_case/54_fem_mas_cube_ground.cpp
+++ b/apps/tests/sim_case/54_fem_mas_cube_ground.cpp
@@ -23,6 +23,7 @@ TEST_CASE("54_fem_mas_cube_ground", "[fem][mas]")
     config["contact"]["friction"]["enable"] = false;
     config["line_search"]["max_iter"]       = 8;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     SimplicialComplexIO io;
@@ -46,9 +47,6 @@ TEST_CASE("54_fem_mas_cube_ground", "[fem][mas]")
 
         label_surface(cube);
         label_triangle_orient(cube);
-
-        // Enable MAS preconditioner
-        mesh_partition(cube, 16);
 
         auto parm = ElasticModuli::youngs_poisson(1e5, 0.49);
         snh.apply_to(cube, parm);

--- a/apps/tests/sim_case/55_fem_mas_stiff_stack.cpp
+++ b/apps/tests/sim_case/55_fem_mas_stiff_stack.cpp
@@ -24,6 +24,7 @@ TEST_CASE("55_fem_mas_stiff_stack", "[fem][mas]")
     config["contact"]["friction"]["enable"] = false;
     config["line_search"]["max_iter"]       = 8;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     SimplicialComplexIO io;
@@ -47,9 +48,6 @@ TEST_CASE("55_fem_mas_stiff_stack", "[fem][mas]")
 
         label_surface(cube);
         label_triangle_orient(cube);
-
-        // Enable MAS preconditioner
-        mesh_partition(cube, 16);
 
         // Stiff material (1 MPa) - this is where MAS should shine vs diagonal
         auto parm = ElasticModuli::youngs_poisson(1.0_MPa, 0.49);

--- a/apps/tests/sim_case/56_fem_mas_bunny_ground.cpp
+++ b/apps/tests/sim_case/56_fem_mas_bunny_ground.cpp
@@ -23,6 +23,7 @@ TEST_CASE("56_fem_mas_bunny_ground", "[fem][mas]")
     config["contact"]["friction"]["enable"] = false;
     config["line_search"]["max_iter"]       = 8;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -38,9 +39,6 @@ TEST_CASE("56_fem_mas_bunny_ground", "[fem][mas]")
 
         label_surface(bunny);
         label_triangle_orient(bunny);
-
-        // Enable MAS preconditioner
-        mesh_partition(bunny, 16);
 
         auto parm = ElasticModuli::youngs_poisson(1e5, 0.49);
         snh.apply_to(bunny, parm);

--- a/apps/tests/sim_case/57_fem_mas_two_cubes.cpp
+++ b/apps/tests/sim_case/57_fem_mas_two_cubes.cpp
@@ -27,6 +27,7 @@ TEST_CASE("57_fem_mas_two_bunnies", "[fem][mas]")
     config["contact"]["friction"]["enable"] = false;
     config["line_search"]["max_iter"]       = 8;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -44,7 +45,6 @@ TEST_CASE("57_fem_mas_two_bunnies", "[fem][mas]")
             auto bunny_a = io.read(fmt::format("{}/bunny0.msh", tetmesh_dir));
             label_surface(bunny_a);
             label_triangle_orient(bunny_a);
-            mesh_partition(bunny_a, 16);
 
             auto parm = ElasticModuli::youngs_poisson(1e5, 0.49);
             snh.apply_to(bunny_a, parm);
@@ -58,14 +58,14 @@ TEST_CASE("57_fem_mas_two_bunnies", "[fem][mas]")
             auto bunny_b = io.read(fmt::format("{}/bunny0.msh", tetmesh_dir));
             label_surface(bunny_b);
             label_triangle_orient(bunny_b);
-            mesh_partition(bunny_b, 16);
 
             auto parm = ElasticModuli::youngs_poisson(1e5, 0.49);
             snh.apply_to(bunny_b, parm);
             default_element.apply_to(bunny_b);
 
             auto pos = view(bunny_b.positions());
-            for(auto& p : pos) p[1] += 2.0;
+            for(auto& p : pos)
+                p[1] += 2.0;
 
             object->geometries().create(bunny_b);
         }

--- a/apps/tests/sim_case/58_fem_mas_hybrid_mix.cpp
+++ b/apps/tests/sim_case/58_fem_mas_hybrid_mix.cpp
@@ -2,11 +2,9 @@
 #include <uipc/uipc.h>
 #include <uipc/constitution/stable_neo_hookean.h>
 
-// Test: One mesh WITH mesh_partition() + one mesh WITHOUT.
-// Tests the hybrid MAS+Diag path.
-// Before fix: current "all or nothing" logic rejects the scene
-//             (FEMDiagPreconditioner defers, FEMMASPreconditioner requires all).
-// After fix: MAS handles partitioned mesh, diagonal handles unpartitioned mesh.
+// Test: MAS switch on; one mesh carries a custom mesh_part partition
+// (respected as-is) + one mesh untagged (auto-partitioned internally).
+// Verifies that custom and automatic partitioning coexist in one scene.
 TEST_CASE("58_fem_mas_hybrid_mix", "[fem][mas]")
 {
     using namespace uipc;
@@ -26,6 +24,7 @@ TEST_CASE("58_fem_mas_hybrid_mix", "[fem][mas]")
     config["contact"]["friction"]["enable"] = false;
     config["line_search"]["max_iter"]       = 8;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -37,30 +36,31 @@ TEST_CASE("58_fem_mas_hybrid_mix", "[fem][mas]")
         auto object = scene.objects().create("hybrid");
 
         Matrix4x4 pre_trans = Matrix4x4::Identity();
-        pre_trans(0, 0) = 0.2;
-        pre_trans(1, 1) = 0.2;
-        pre_trans(2, 2) = 0.2;
+        pre_trans(0, 0)     = 0.2;
+        pre_trans(1, 1)     = 0.2;
+        pre_trans(2, 2)     = 0.2;
 
         SimplicialComplexIO scaled_io(pre_trans);
 
-        // Mesh A — WITH partition (MAS)
+        // Mesh A — custom mesh_part partition (respected as-is)
         {
             auto cube_a = scaled_io.read(fmt::format("{}/cube.msh", tetmesh_dir));
             label_surface(cube_a);
             label_triangle_orient(cube_a);
-            mesh_partition(cube_a, 16);  // <-- partitioned
+            mesh_partition(cube_a, 16);  // <-- custom partition
 
             auto parm = ElasticModuli::youngs_poisson(1e5, 0.49);
             snh.apply_to(cube_a, parm);
             default_element.apply_to(cube_a);
 
             auto pos = view(cube_a.positions());
-            for(auto& p : pos) p[1] += 0.5;
+            for(auto& p : pos)
+                p[1] += 0.5;
 
             object->geometries().create(cube_a);
         }
 
-        // Mesh B — WITHOUT partition (should use diagonal fallback)
+        // Mesh B — untagged (auto-partitioned internally at world.init)
         {
             auto cube_b = scaled_io.read(fmt::format("{}/cube.msh", tetmesh_dir));
             label_surface(cube_b);
@@ -72,7 +72,8 @@ TEST_CASE("58_fem_mas_hybrid_mix", "[fem][mas]")
             default_element.apply_to(cube_b);
 
             auto pos = view(cube_b.positions());
-            for(auto& p : pos) p[1] += 1.0;
+            for(auto& p : pos)
+                p[1] += 1.0;
 
             object->geometries().create(cube_b);
         }

--- a/apps/tests/sim_case/59_fem_mas_vs_diag_benchmark.cpp
+++ b/apps/tests/sim_case/59_fem_mas_vs_diag_benchmark.cpp
@@ -29,6 +29,8 @@ void run_bunny_scene(const std::string& output_path, bool use_mas)
     config["contact"]["friction"]["enable"] = false;
     config["line_search"]["max_iter"]       = 8;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    if(use_mas)
+        config["linear_system"]["fem_preconditioner"] = "mas";
     // this benchmark reads the per-iteration "SpMV" timer counts, which only
     // exist on the plain launch path; CUDA-graph replay intentionally has no
     // per-iteration host observation
@@ -47,9 +49,6 @@ void run_bunny_scene(const std::string& output_path, bool use_mas)
 
         label_surface(bunny);
         label_triangle_orient(bunny);
-
-        if(use_mas)
-            mesh_partition(bunny, 16);
 
         // Stiff material — MAS shines more with higher stiffness
         auto parm = ElasticModuli::youngs_poisson(10.0_MPa, 0.49);

--- a/apps/tests/sim_case/60_fem_mas_cloth.cpp
+++ b/apps/tests/sim_case/60_fem_mas_cloth.cpp
@@ -21,6 +21,7 @@ TEST_CASE("60_fem_mas_cloth", "[fem][mas]")
     config["contact"]["enable"]             = true;
     config["contact"]["friction"]["enable"] = false;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -31,11 +32,11 @@ TEST_CASE("60_fem_mas_cloth", "[fem][mas]")
         auto object = scene.objects().create("cloth");
 
         // Build a grid cloth mesh (N x N quads -> 2*N*N triangles)
-        constexpr int N = 10;
+        constexpr int   N          = 10;
         constexpr Float cloth_size = 0.5;
-        constexpr Float spacing = cloth_size / N;
+        constexpr Float spacing    = cloth_size / N;
 
-        vector<Vector3> Vs;
+        vector<Vector3>  Vs;
         vector<Vector3i> Fs;
 
         for(int i = 0; i <= N; i++)
@@ -58,9 +59,6 @@ TEST_CASE("60_fem_mas_cloth", "[fem][mas]")
         auto mesh = trimesh(Vs, Fs);
         label_surface(mesh);
 
-        // Partition for MAS
-        mesh_partition(mesh, 16);
-
         auto parm = ElasticModuli2D::youngs_poisson(1.0_MPa, 0.49);
         nhs.apply_to(mesh, parm);
         default_contact.apply_to(mesh);
@@ -68,8 +66,8 @@ TEST_CASE("60_fem_mas_cloth", "[fem][mas]")
         // Fix two corners
         auto is_fixed      = mesh.vertices().find<IndexT>(builtin::is_fixed);
         auto is_fixed_view = view(*is_fixed);
-        is_fixed_view[0]         = 1;  // corner (0,0)
-        is_fixed_view[N]         = 1;  // corner (0,N)
+        is_fixed_view[0]   = 1;  // corner (0,0)
+        is_fixed_view[N]   = 1;  // corner (0,N)
 
         object->geometries().create(mesh);
     }

--- a/apps/tests/sim_case/61_fem_mas_rod.cpp
+++ b/apps/tests/sim_case/61_fem_mas_rod.cpp
@@ -22,6 +22,7 @@ TEST_CASE("61_fem_mas_rod", "[fem][mas]")
     config["contact"]["enable"]             = true;
     config["contact"]["friction"]["enable"] = false;
     config["linear_system"]["tol_rate"]     = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -32,8 +33,8 @@ TEST_CASE("61_fem_mas_rod", "[fem][mas]")
 
         auto object = scene.objects().create("rods");
 
-        constexpr int   n = 20;  // nodes per rod
-        constexpr int   num_rods = 3;
+        constexpr int n        = 20;  // nodes per rod
+        constexpr int num_rods = 3;
 
         for(int r = 0; r < num_rods; r++)
         {
@@ -48,18 +49,15 @@ TEST_CASE("61_fem_mas_rod", "[fem][mas]")
             auto mesh = linemesh(Vs, Es);
             label_surface(mesh);
 
-            // Partition for MAS
-            mesh_partition(mesh, 16);
-
             hs.apply_to(mesh, 10.0_MPa);
             krb.apply_to(mesh, 1.0_MPa);
             default_contact.apply_to(mesh);
 
             // Fix first two nodes
-            auto is_fixed      = mesh.vertices().find<IndexT>(builtin::is_fixed);
+            auto is_fixed = mesh.vertices().find<IndexT>(builtin::is_fixed);
             auto is_fixed_view = view(*is_fixed);
-            is_fixed_view[0] = 1;
-            is_fixed_view[1] = 1;
+            is_fixed_view[0]   = 1;
+            is_fixed_view[1]   = 1;
 
             object->geometries().create(mesh);
         }

--- a/apps/tests/sim_case/81_fem_mas_cloth_with_empty.cpp
+++ b/apps/tests/sim_case/81_fem_mas_cloth_with_empty.cpp
@@ -29,6 +29,7 @@ TEST_CASE("81_fem_mas_cloth_with_empty", "[fem][mas][regression]")
     config["gravity"]                   = Vector3{0, -9.8, 0};
     config["contact"]["enable"]         = false;
     config["linear_system"]["tol_rate"] = 1e-3;
+    config["linear_system"]["fem_preconditioner"] = "mas";
     test::Scene::dump_config(config, output_path);
 
     Scene scene{config};
@@ -64,7 +65,6 @@ TEST_CASE("81_fem_mas_cloth_with_empty", "[fem][mas][regression]")
 
         auto cloth_mesh = trimesh(Vs, Fs);
         label_surface(cloth_mesh);
-        mesh_partition(cloth_mesh, 16);
 
         auto parm = ElasticModuli2D::youngs_poisson(1.0_MPa, 0.49);
         nhs.apply_to(cloth_mesh, parm);

--- a/include/uipc/geometry/utils/mesh_partition.h
+++ b/include/uipc/geometry/utils/mesh_partition.h
@@ -9,7 +9,13 @@ namespace uipc::geometry
  * create a `mesh_part` <IndexT> attribute on the simplicial complex' vertices
  * 
  * @param sc simplicial complex
- * @param part_max_size the vertex number in each partition <= part_max_size
+ * @param part_max_size the vertex number in each partition <= part_max_size.
+ *        NOTE: the CUDA MAS preconditioner hard-codes BANKSIZE=16, so 16 is
+ *        the only value it accepts. End users should not call this to enable
+ *        MAS — set scene config `linear_system/fem_preconditioner = "mas"`
+ *        instead, which auto-partitions every FEM geometry internally with
+ *        the fixed size. This function remains for custom C++ partitioning
+ *        (a pre-existing mesh_part attribute is respected by MAS as-is).
  * 
  */
 void UIPC_GEOMETRY_API mesh_partition(SimplicialComplex& sc, SizeT part_max_size);

--- a/src/backends/cuda/finite_element/fem_diag_preconditioner.cu
+++ b/src/backends/cuda/finite_element/fem_diag_preconditioner.cu
@@ -75,23 +75,13 @@ class FEMDiagPreconditioner : public LocalPreconditioner
         fem_linear_subsystem        = &require<FEMLinearSubsystem>();
         auto& global_vertex_manager = require<GlobalVertexManager>();
 
-        // If ANY FEM geometry has mesh_part, defer to FEMMASPreconditioner,
-        // which handles both partitioned (MAS) and unpartitioned (diag) vertices.
-        auto geo_slots = world().scene().geometries();
-        for(SizeT i = 0; i < geo_slots.size(); i++)
+        // MAS is selected via config; defer to FEMMASPreconditioner when on.
+        auto precond = world().scene().config().find<std::string>("linear_system/fem_preconditioner");
+        if(precond && precond->view()[0] == "mas")
         {
-            auto& geo = geo_slots[i]->geometry();
-            auto* sc  = geo.as<geometry::SimplicialComplex>();
-            if(sc && sc->dim() >= 1)
-            {
-                auto mesh_part = sc->vertices().find<IndexT>("mesh_part");
-                if(mesh_part)
-                {
-                    throw SimSystemException(
-                        "FEMDiagPreconditioner: mesh_part found, "
-                        "deferring to FEMMASPreconditioner.");
-                }
-            }
+            throw SimSystemException(
+                "FEMDiagPreconditioner: linear_system/fem_preconditioner == \"mas\", "
+                "deferring to FEMMASPreconditioner.");
         }
 
         // This FEMDiagPreconditioner depends on FEMLinearSubsystem

--- a/src/backends/cuda/finite_element/fem_mas_preconditioner.cu
+++ b/src/backends/cuda/finite_element/fem_mas_preconditioner.cu
@@ -8,10 +8,12 @@
 #include <finite_element/mas_preconditioner_engine.h>
 #include <uipc/builtin/attribute_name.h>
 #include <uipc/geometry/simplicial_complex.h>
+#include <uipc/geometry/utils/mesh_partition.h>
 #include <uipc/common/log.h>
 #include <backends/common/backend_path_tool.h>
 #include <sim_engine.h>
 #include <set>
+#include <memory>
 
 namespace uipc::backend::cuda
 {
@@ -128,11 +130,13 @@ void apply_diag_inv_for_unpartitioned(const cuda_tool::DeviceBuffer<Matrix3x3>& 
  * simpler diagonal (Jacobi) preconditioner for much better convergence
  * on stiff problems. Based on the StiffGIPC paper.
  *
- * Prerequisites:
- *   The user must call `mesh_partition(sc, 16)` on their SimplicialComplex
- *   BEFORE `world.init()` to create a "mesh_part" vertex attribute.
- *   If this attribute is absent, the system will not be built and the
- *   default FEMDiagPreconditioner will be used instead.
+ * Activation:
+ *   Set scene config `linear_system/fem_preconditioner = "mas"`. MAS is
+ *   all-or-nothing: every non-Empty FEM SimplicialComplex is partitioned
+ *   internally (fixed cluster size = BANKSIZE 16) in do_init; a
+ *   pre-existing `mesh_part` vertex attribute (custom C++ partitioning)
+ *   is respected as-is. Partial manual tagging alone does NOT activate
+ *   MAS (measured net-negative — see agent_docs/09 coverage rule).
  */
 class FEMMASPreconditioner : public LocalPreconditioner
 {
@@ -162,28 +166,10 @@ class FEMMASPreconditioner : public LocalPreconditioner
         fem_linear_subsystem        = &require<FEMLinearSubsystem>();
         auto& global_vertex_manager = require<GlobalVertexManager>();
 
-        // MAS activates if ANY FEM geometry has mesh_part attribute.
-        // Unpartitioned meshes get diagonal (block-Jacobi) fallback internally.
-        auto geo_slots      = world().scene().geometries();
-        bool found_any_part = false;
-        for(SizeT i = 0; i < geo_slots.size(); i++)
+        auto precond = world().scene().config().find<std::string>("linear_system/fem_preconditioner");
+        if(!precond || precond->view()[0] != "mas")
         {
-            auto& geo = geo_slots[i]->geometry();
-            auto* sc  = geo.as<geometry::SimplicialComplex>();
-            if(sc && sc->dim() >= 1)
-            {
-                auto mesh_part = sc->vertices().find<IndexT>("mesh_part");
-                if(mesh_part)
-                {
-                    found_any_part = true;
-                    break;
-                }
-            }
-        }
-
-        if(!found_any_part)
-        {
-            throw SimSystemException("FEMMASPreconditioner: No 'mesh_part' attribute found on any geometry.");
+            throw SimSystemException("FEMMASPreconditioner: linear_system/fem_preconditioner != \"mas\", disabled.");
         }
 
         info.connect(fem_linear_subsystem);
@@ -238,7 +224,13 @@ class FEMMASPreconditioner : public LocalPreconditioner
                 h_neighbor_list.push_back(n);
         }
 
-        // ---- 3. Read mesh_part attribute and build partition mappings ----
+        // ---- 3. Partition every FEM geometry and build partition mappings ----
+        //
+        // MAS is all-or-nothing: every non-Empty FEM SimplicialComplex is
+        // covered. A pre-existing mesh_part attribute (custom C++
+        // partitioning) is respected as-is; everything else is partitioned
+        // internally on a private clone with the fixed cluster size
+        // (BANKSIZE), so the user's scene geometry is never mutated.
 
         std::vector<IndexT> part_ids(vert_num, -1);
         bool                has_parts = false;
@@ -254,20 +246,35 @@ class FEMMASPreconditioner : public LocalPreconditioner
             auto& geo_slot = geo_slots[geo_info.geo_slot_index];
             auto& geo      = geo_slot->geometry();
             auto* sc       = geo.as<geometry::SimplicialComplex>();
-            if(!sc)
+            if(!sc || sc->dim() < 1 || geo_info.vertex_count == 0)
                 continue;
 
-            auto mesh_part = sc->vertices().find<IndexT>("mesh_part");
-            if(!mesh_part)
+            // Empty constitution (no material): skip, stays on the
+            // diagonal fallback
+            auto cuid = geo.meta().find<U64>(builtin::constitution_uid);
+            if(!cuid || cuid->view()[0] == kEmptyConstitutionUID)
                 continue;
 
-            has_parts      = true;
-            auto part_view = mesh_part->view();
+            std::vector<IndexT> local_parts;
+            if(auto mesh_part = sc->vertices().find<IndexT>("mesh_part"))
+            {
+                auto pv = mesh_part->view();
+                local_parts.assign(pv.begin(), pv.end());
+            }
+            else
+            {
+                auto tmp_geo = std::static_pointer_cast<geometry::Geometry>(geo.clone());
+                auto* tmp_sc = tmp_geo->as<geometry::SimplicialComplex>();
+                geometry::mesh_partition(*tmp_sc, BANKSIZE);
+                auto pv = tmp_sc->vertices().find<IndexT>("mesh_part")->view();
+                local_parts.assign(pv.begin(), pv.end());
+            }
 
+            has_parts        = true;
             IndexT local_max = 0;
             for(SizeT v = 0; v < geo_info.vertex_count; v++)
             {
-                IndexT local_pid = part_view[v];
+                IndexT local_pid = local_parts[v];
                 part_ids[geo_info.vertex_offset + v] = local_pid + partition_offset;
                 local_max = std::max(local_max, local_pid);
             }
@@ -459,7 +466,14 @@ class FEMMASPreconditioner : public LocalPreconditioner
     virtual void do_apply(GlobalLinearSystem::ApplyPreconditionerInfo& info) override
     {
         if(!m_has_partition || !engine.is_initialized())
+        {
+            // switch enabled but nothing partitionable (e.g. all FEM
+            // geometries are Empty constitution): identity fallback so
+            // this subsystem's z is never left stale
+            cuda_tool::BufferLaunch(info.stream())
+                .copy(info.z().buffer_view(), info.r().buffer_view());
             return;
+        }
 
         auto converged = info.converged();
 

--- a/src/core/core/scene_default_config.cpp
+++ b/src/core/core/scene_default_config.cpp
@@ -36,6 +36,13 @@ geometry::AttributeCollection default_scene_config() noexcept
     //  - linear_pcg (30% slower)
     config.create("linear_system/solver", std::string{"fused_pcg"});
 
+    // FEM local preconditioner:
+    //  - "diag" (default): 3x3 block-Jacobi
+    //  - "mas": Multi-Level Additive Schwarz; ALL FEM geometries are
+    //    auto-partitioned internally (fixed cluster size 16 = MAS BANKSIZE),
+    //    no per-mesh user tagging needed
+    config.create("linear_system/fem_preconditioner", std::string{"diag"});
+
     // FusedPCG CUDA graph mode: 1 = replay check_interval-sized iteration
     // blocks (default, fastest measured); 2 = full-GPU while-loop graph
     // (CUDA >= 12.4; keeps the CPU out of the loop entirely); 0 = plain

--- a/src/pybind/pyuipc/geometry/utils.cpp
+++ b/src/pybind/pyuipc/geometry/utils.cpp
@@ -226,20 +226,6 @@ Args:
 Returns:
     SimplicialComplex: Point cloud.)");
 
-    m.def("mesh_partition",
-          &mesh_partition,
-          py::arg("sc"),
-          py::arg("part_max_size") = 16,
-          R"(Partition the simplicial complex using METIS graph partitioning.
-
-Creates a 'mesh_part' vertex attribute on the simplicial complex.
-This must be called before world.init() to enable the MAS preconditioner.
-
-Args:
-    sc: SimplicialComplex to partition.
-    part_max_size: Maximum number of vertices per partition (default: 16).
-)");
-
     m.def("closest_vertex_triangle_pairs",
           &closest_vertex_triangle_pairs,
           py::arg("vertex_mesh"),


### PR DESCRIPTION
## What
- New scene config key `linear_system/fem_preconditioner` (`"diag"` default / `"mas"`). When `mas`, FEMMASPreconditioner auto-partitions EVERY non-Empty FEM SimplicialComplex internally on a private clone (fixed cluster size = BANKSIZE 16); scene geometries are never mutated. Custom C++ mesh_part partitions are still respected, but manual tagging alone no longer activates MAS.
- FEMDiag defers on the switch; do_apply falls back to z=r when nothing is partitionable.
- Python `uipc.geometry.mesh_partition` export removed (part_max_size was a footgun — any value >16 trips the BANKSIZE assert). C++ utility kept for internal use.
- Tests migrated (sim_case 53-61, 81, stitch regression); 58 now verifies custom + auto partitions coexist.
- agent_docs: coverage rule (partial coverage is net-negative) + the redesign record.

## Why
Measured on 88 (E=1e7, two 19k-vert bunnies + cloth, 60 frames): partial MAS coverage is net NEGATIVE (+8% PCG iters, +20% wall vs all-diag); near-full coverage gives 4.6x fewer iterations and 2.1x faster wall. So MAS is now all-or-nothing by design.

## Validation
- 89_mas_bunny switch=mas reproduces the old mesh_partition path bit-for-bit (f100 centroid, 704 solves).
- 88 default (full auto-coverage incl. cloth): avg 176 PCG/solve, mean 429ms/frame = 2.3x faster than all-diagonal; identical physics.
- Full suite 95/95 (14212 assertions), backend_cuda 9/9, regression green.