### PR TITLE
feat(cuda): scene-adaptive kappa corridor from Stiff-GIPC suggest/upperBoundKappa

### DIFF
--- a/agent_docs/02-core-architecture.md
+++ b/agent_docs/02-core-architecture.md
@@ -66,7 +66,7 @@ Configuration is stored in an `AttributeCollection` (resize(1)). Key entries:
 
 **Config strictness**: `from_config_json` recursively validates the user json against the registered defaults and **throws a guided error on unregistered keys** (they were silently dropped before). Two consequences: (1) adding a new config key REQUIRES registering its default in `scene_default_config.cpp`; (2) old scenes with typo/dead keys now fail loudly — fix the key, don't bypass the check.
 
-**Default kappa policy**: if `default_model(...)` is never called, the effective default contact stiffness is `contact/adaptive/min_kappa` (default 1e8); a user-set value is clamped into [min_kappa, max_kappa] with a range-printing warning; negative kappa (adaptive-kappa opt-in marker) is never clamped. See handoff "Default kappa policy".
+**Default kappa policy**: the scene-adaptive corridor (Stiff-GIPC `suggestKappa`/`upperBoundKappa` ported with the $/dt^2$ conversion, computed at `GlobalContactManager::init` from scene diagonal, mean mass and `d_hat`) rules all clamping; `contact/adaptive/{min,max}_kappa` are only the fallback when the corridor is not computable. If `default_model(...)` is never called, the effective default stiffness is the corridor lower bound; a user-set value is clamped into the corridor with a range-printing warning; negative kappa (adaptive-kappa opt-in marker) is never clamped. The evaluation scale is configurable via `contact/adaptive/kappa_eval_scale` (default `1e-16`, Stiff's value; the $/dt^2$ conversion makes it dt-independent).
 
 See `docs/specification/scene_config.md` for the full key table.
 

--- a/agent_docs/09-known-issues-and-roadmap.md
+++ b/agent_docs/09-known-issues-and-roadmap.md
@@ -208,8 +208,7 @@ Verdicts:
   win (~2.5x), the graph plumbing adds its share on top.
 - COVERAGE RULE (measured on 88_stiff_gipc_benchmark, E=1e7, two 19k-vert
   bunnies + 4.2k-vert cloth, 60 frames, 2026-08-23): MAS only pays off when
-  it covers nearly all of the stiff DoFs. Partial coverage is net NEGATIVE:
-  | config | total PCG | avg/solve | wall |
+  it covers nearly all of the stiff DoFs. Partial coverage is net NEGATIVE:  | config | total PCG | avg/solve | wall |
   |---|---|---|---|
   | all diagonal | 366875 | 853 | 60s |
   | MAS on upper bunny only (~45% of FEM verts) | 397730 | 923 | 73s |
@@ -236,6 +235,18 @@ Verdicts:
   stitch regression (config switch instead of mesh_partition calls;
   58_hybrid_mix now verifies custom + auto partitions coexist), samples
   88/89 (NO_MAS=1 env flips the switch to "diag").
+- SCENE-ADAPTIVE KAPPA CORRIDOR (2026-08-24): Stiff-GIPC's
+  `suggestKappa`/`upperBoundKappa` (`GIPC.cu:9850-9888`) is ported into
+  `GlobalContactManager::init` with the dt^2 conversion (their barrier
+  applies kappa raw, ours scales by dt^2 → computed values divided by
+  dt^2). The corridor [suggest, 100×suggest] now rules all kappa clamping
+  (default-model resolution, per-model clamps, the adaptive strategy's
+  projection); `contact/adaptive/{min,max}_kappa` are fallback-only when
+  the corridor is not computable. The evaluation scale is user-configurable
+  via `contact/adaptive/kappa_eval_scale` (default 1e-16 — Stiff's value;
+  the /dt^2 conversion keeps it valid for any dt). Measured corridors:
+  case 89 → [4.4e7, 4.4e9], case 88 → [4.7e6, 4.7e8]; the established
+  κ=1e8 sits inside both, so aligned scenes are behaviorally unchanged.
 - Structural reason libuipc's port is stronger: FEMMASPreconditioner
   rebuilds the cluster inverses from the current full diagonal Hessian
   (kinetic + material) every Newton iteration

--- a/docs/specification/scene_config.md
+++ b/docs/specification/scene_config.md
@@ -73,11 +73,14 @@ See [Newton Solver Details](scene_configs/newton.md) for the convergence criteri
 
 Only takes effect when `contact/constitution = "ipc"` **and** the contact tabular contains a resistance set to `-1.0` (i.e. `adaptive(-1.0)`), which triggers the adaptive $\kappa$ mechanism.
 
+At init the engine computes a **scene-adaptive $\kappa$ corridor** (a port of Stiff-GIPC's `suggestKappa`/`upperBoundKappa`, `GIPC.cu:9850-9888`, with the $dt^2$ convention conversion — their barrier applies $\kappa$ raw, ours is scaled by $dt^2$, so the computed values are divided by $dt^2$): $\kappa_{suggest} = c \cdot \bar m / (4 \cdot s \cdot \mathrm{diag}^2 \cdot H_b) / dt^2$ with $\bar m$ = total scene mass / vertex count, $\mathrm{diag}$ = rest-bbox diagonal, $s$ = `kappa_eval_scale`, $H_b$ the barrier curvature at $d = s \cdot \mathrm{diag}^2$ vs $\hat d^2$, and $\kappa_{upper} = 100 \times \kappa_{suggest}$. **The computed corridor rules** — all clamping (default-model resolution, per-model clamps, the adaptive strategy's projection result) uses it; the config `min/max_kappa` below only serve as fallback when the corridor is not computable.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `contact/adaptive/min_kappa` | Float | `1e8` | Minimum adaptive contact stiffness ($Pa$, 100 MPa) |
+| `contact/adaptive/min_kappa` | Float | `1e8` | Fallback minimum adaptive contact stiffness ($Pa$, 100 MPa) — used only when the corridor is not computable |
 | `contact/adaptive/init_kappa` | Float | `1e9` | Initial adaptive contact stiffness ($Pa$, 1 GPa) |
-| `contact/adaptive/max_kappa` | Float | `1e11` | Maximum adaptive contact stiffness ($Pa$, 100 GPa) |
+| `contact/adaptive/max_kappa` | Float | `1e11` | Fallback maximum adaptive contact stiffness ($Pa$, 100 GPa) — used only when the corridor is not computable |
+| `contact/adaptive/kappa_eval_scale` | Float | `1e-16` | Evaluation-point scale $s$ for the corridor (Stiff's raw-$\kappa$ value; the $/dt^2$ conversion makes it valid for any `dt`) |
 
 ### AL-IPC
 

--- a/src/backends/cuda/contact_system/adaptive_strategies/gipc_adaptive_parameter_strategy.cu
+++ b/src/backends/cuda/contact_system/adaptive_strategies/gipc_adaptive_parameter_strategy.cu
@@ -200,19 +200,27 @@ class GIPCAdaptiveParameterStrategy : public AdaptiveContactParameterReporter
         // 1. No contact contribution -> keep initial kappa
         Float proj_kappa = (contact2 == 0.0) ? init_kappa : -proj / contact2;
 
-        // 2. Clamp to [min_kappa, max_kappa]
-        new_kappa = std::clamp(proj_kappa, min_kappa, max_kappa);
+        // 2. Clamp to the scene-adaptive corridor when the manager computed
+        //    one (Stiff-GIPC suggestKappa/upperBoundKappa); config min/max
+        //    are only the fallback
+        Float lo = contact_manager->kappa_lower_bound();
+        Float hi = contact_manager->kappa_upper_bound();
+        if(lo <= 0.0)
+            lo = min_kappa;
+        if(hi <= 0.0)
+            hi = max_kappa;
+        new_kappa = std::clamp(proj_kappa, lo, hi);
 
         logger::info(R"(Adaptive Contact Parameter: > Kappa = {:e}
 * ProjKappa = {:e}, Contact^2 = {:e}, Contact.NonContact = {:e}
-* MinKappa = {:e}, InitKappa={:e}, MaxKappa = {:e})",
+* LoBound = {:e}, InitKappa={:e}, HiBound = {:e})",
                      new_kappa,
                      proj_kappa,
                      contact2,
                      proj,
-                     min_kappa,
+                     lo,
                      init_kappa,
-                     max_kappa);
+                     hi);
 
         if(adaptive_topos.size() > 0)
             do_compute_parameters_kernel<<<

--- a/src/backends/cuda/contact_system/global_contact_manager.cu
+++ b/src/backends/cuda/contact_system/global_contact_manager.cu
@@ -13,6 +13,10 @@
 #include <utils/codim_thickness.h>
 #include <global_geometry/global_simplicial_surface_manager.h>
 #include <contact_system/adaptive_contact_parameter_reporter.h>
+#include <finite_element/finite_element_method.h>
+#include <affine_body/affine_body_dynamics.h>
+#include <numeric>
+#include <cmath>
 #include <cuda_tool/cub.h>
 
 namespace uipc::backend
@@ -181,6 +185,8 @@ void GlobalContactManager::do_build()
     m_impl.global_vertex_manager    = require<GlobalVertexManager>();
     m_impl.global_trajectory_filter = find<GlobalTrajectoryFilter>();
     m_impl.global_surface_manager   = find<GlobalSimplicialSurfaceManager>();
+    m_impl.finite_element_method    = find<FiniteElementMethod>();
+    m_impl.affine_body_dynamics     = find<AffineBodyDynamics>();
 
 
     auto d_hat_attr = config.find<Float>("contact/d_hat");
@@ -241,6 +247,74 @@ void GlobalContactManager::Impl::init(WorldVisitor& world)
         }
     }
 
+    // 0.2) Scene-adaptive kappa corridor: port of Stiff-GIPC's
+    //    suggestKappa/upperBoundKappa (GIPC.cu:9850-9888). Their barrier
+    //    applies kappa raw while ours is scaled by dt^2, so the computed
+    //    values are divided by dt^2 to stay in our convention.
+    {
+        kappa_lower_bound = -1.0;
+        kappa_upper_bound = -1.0;
+
+        Float diag       = global_vertex_manager->scene_diagonal();
+        SizeT vert_count = global_vertex_manager->positions().size();
+        if(diag > 0.0 && vert_count > 0)
+        {
+            // meanMass = total scene mass / total vertex count (Stiff
+            // convention: FEM vertex masses directly; ABD bodies contribute
+            // their scalar body mass once)
+            Float total_mass = 0.0;
+            if(finite_element_method)
+            {
+                auto               fem_masses = finite_element_method->masses();
+                std::vector<Float> h_masses(fem_masses.size());
+                fem_masses.copy_to(h_masses.data());
+                total_mass =
+                    std::accumulate(h_masses.begin(), h_masses.end(), Float{0});
+            }
+            if(affine_body_dynamics)
+            {
+                auto body_masses = affine_body_dynamics->body_masses();
+                std::vector<ABDJacobiDyadicMass> h_body_masses(body_masses.size());
+                body_masses.copy_to(h_body_masses.data());
+                for(auto& bm : h_body_masses)
+                    total_mass += static_cast<Float>(bm.mass());
+            }
+            Float mean_mass = total_mass / vert_count;
+
+            Float scale = world.scene()
+                              .config()
+                              .find<Float>("contact/adaptive/kappa_eval_scale")
+                              ->view()[0];
+            constexpr Float min_kappa_coef = 1e11;  // Stiff's minKappaCoef
+            Float           dt             = dt_attr->view()[0];
+            Float           d              = scale * diag * diag;
+            Float dHat = d_hat * d_hat;  // Stiff's dHat is a squared distance
+            if(d > 0.0 && dHat > 0.0 && dt > 0.0)
+            {
+                Float t = d - dHat;
+                Float H_b = -2.0 * std::log(d / dHat) - 4.0 * t / d + (t * t) / (d * d);
+                if(std::isfinite(H_b) && H_b > 0.0)
+                {
+                    Float base = min_kappa_coef / (4.0 * d * H_b);
+                    if(mean_mass > 0.0)
+                        base *= mean_mass;
+                    kappa_lower_bound = base / (dt * dt);
+                    kappa_upper_bound = 100.0 * kappa_lower_bound;
+                }
+            }
+            logger::info(
+                "Adaptive kappa corridor: [{:e}, {:e}] "
+                "(meanMass={:e}, diag={}, d_hat={}, scale={:e}, dt={})",
+                kappa_lower_bound,
+                kappa_upper_bound,
+                mean_mass,
+                diag,
+                d_hat,
+                scale,
+                dt);
+        }
+    }
+
     // 1) init tabular
     _build_contact_tabular(world);
     _build_subscene_tabular(world);
@@ -296,18 +370,24 @@ void GlobalContactManager::Impl::_build_contact_tabular(WorldVisitor& world)
     auto mask_map = Eigen::Map<MaskMatrix>(h_contact_mask_tabular.data(), N, N);
 
     // Default contact stiffness policy:
-    //  - user never called default_model() -> use contact/adaptive/min_kappa
-    //  - user set it -> clamp into [min_kappa, max_kappa] and remind the range
+    //  - the scene-adaptive corridor [kappa_lower_bound, kappa_upper_bound]
+    //    (Stiff-GIPC suggestKappa/upperBoundKappa, computed in init) rules;
+    //  - when it is not computable for the scene, fall back to the
+    //    contact/adaptive/{min,max}_kappa config values;
     //  - negative kappa (adaptive-kappa opt-in) is never clamped
     auto& scene_cfg = world.scene().config();
     Float min_kappa = scene_cfg.find<Float>("contact/adaptive/min_kappa")->view()[0];
     Float max_kappa = scene_cfg.find<Float>("contact/adaptive/max_kappa")->view()[0];
+    if(kappa_lower_bound > 0.0)
+        min_kappa = kappa_lower_bound;
+    if(kappa_upper_bound > 0.0)
+        max_kappa = kappa_upper_bound;
 
     Float default_kappa = resistance_view[0];
     if(!world.scene().contact_tabular().default_model_is_user_set())
     {
         default_kappa = min_kappa;
-        logger::info("Contact default kappa not set by user; using contact/adaptive/min_kappa = {}",
+        logger::info("Contact default kappa not set by user; using the kappa lower bound = {}",
                      min_kappa);
     }
     else if(default_kappa >= 0.0 && (default_kappa < min_kappa || default_kappa > max_kappa))
@@ -579,6 +659,16 @@ Float GlobalContactManager::d_hat() const
 Float GlobalContactManager::eps_velocity() const
 {
     return m_impl.eps_velocity;
+}
+
+Float GlobalContactManager::kappa_lower_bound() const
+{
+    return m_impl.kappa_lower_bound;
+}
+
+Float GlobalContactManager::kappa_upper_bound() const
+{
+    return m_impl.kappa_upper_bound;
 }
 
 bool GlobalContactManager::cfl_enabled() const

--- a/src/backends/cuda/contact_system/global_contact_manager.h
+++ b/src/backends/cuda/contact_system/global_contact_manager.h
@@ -14,6 +14,8 @@ class ContactReceiver;
 class GlobalTrajectoryFilter;
 class GlobalSimplicialSurfaceManager;
 class AdaptiveContactParameterReporter;
+class FiniteElementMethod;
+class AffineBodyDynamics;
 
 class GlobalContactManager final : public SimSystem
 {
@@ -63,6 +65,8 @@ class GlobalContactManager final : public SimSystem
         SimSystemSlot<GlobalVertexManager>            global_vertex_manager;
         SimSystemSlot<GlobalTrajectoryFilter>         global_trajectory_filter;
         SimSystemSlot<GlobalSimplicialSurfaceManager> global_surface_manager;
+        SimSystemSlot<FiniteElementMethod>            finite_element_method;
+        SimSystemSlot<AffineBodyDynamics>             affine_body_dynamics;
 
         bool cfl_enabled = false;
 
@@ -79,6 +83,14 @@ class GlobalContactManager final : public SimSystem
         Float                                   kappa = 0.0;
         S<const geometry::AttributeSlot<Float>> dt_attr;
         Float                                   eps_velocity = 0.0;
+
+        // Scene-adaptive kappa corridor, ported from Stiff-GIPC's
+        // suggestKappa/upperBoundKappa (GIPC.cu:9850-9888) with the dt^2
+        // convention conversion. Computed once in init(); <= 0 means "not
+        // computable for this scene" and callers fall back to the
+        // contact/adaptive/{min,max}_kappa config values.
+        Float kappa_lower_bound = -1.0;
+        Float kappa_upper_bound = -1.0;
 
 
         /***********************************************************************
@@ -100,6 +112,11 @@ class GlobalContactManager final : public SimSystem
     Float d_hat() const;
     Float eps_velocity() const;
     bool  cfl_enabled() const;
+
+    // Scene-adaptive kappa corridor (Stiff-GIPC suggestKappa/upperBoundKappa
+    // with the dt^2 conversion); <= 0 = not computable, use config fallback
+    Float kappa_lower_bound() const;
+    Float kappa_upper_bound() const;
 
     cuda_tool::CBuffer2DView<ContactCoeff> contact_tabular() const noexcept;
     cuda_tool::CBuffer2DView<IndexT> contact_mask_tabular() const noexcept;

--- a/src/core/core/scene_default_config.cpp
+++ b/src/core/core/scene_default_config.cpp
@@ -92,6 +92,12 @@ geometry::AttributeCollection default_scene_config() noexcept
     config.create("contact/adaptive/min_kappa", Float{100.0_MPa});
     config.create("contact/adaptive/init_kappa", Float{1.0_GPa});
     config.create("contact/adaptive/max_kappa", Float{100.0_GPa});
+    // Evaluation-point scale for the scene-adaptive kappa corridor
+    // (Stiff-GIPC's 1e-16 in their raw-kappa convention; the computed
+    // suggest/upper bounds are divided by dt^2 to match our dt^2-scaled
+    // barrier, so the same value works for any dt). The computed corridor
+    // rules; these min/max only serve as fallback when it is not computable.
+    config.create("contact/adaptive/kappa_eval_scale", Float{1e-16});
 
 
     // default:


### PR DESCRIPTION
## What
Ports Stiff-GIPC's suggestKappa/upperBoundKappa (GIPC.cu:9850-9888) into GlobalContactManager::init with the dt^2 convention conversion (their barrier applies kappa raw; ours is scaled by dt^2, so computed values are divided by dt^2):

  suggest = minKappaCoef * meanMass / (4 * scale * diag^2 * H_b) / dt^2
  upper   = 100 * suggest

- meanMass = total scene mass / vertex count (FEM vertex masses + ABD body masses)
- diag = rest-bbox diagonal, H_b = Stiff's barrier curvature at d = scale*diag^2 vs d_hat^2
- The corridor now rules ALL kappa clamping: default-model resolution, per-model clamps, and the adaptive strategy's projection. contact/adaptive/{min,max}_kappa are fallback-only (not computable scenes).
- New config key contact/adaptive/kappa_eval_scale (default 1e-16, Stiff's value; the /dt^2 conversion keeps it valid for any dt).

## Validation
- Corridors measured: case 89 → [4.4e7, 4.4e9] (meanMass matches hand computation exactly), case 88 → [4.7e6, 4.7e8]; the established kappa=1e8 sits inside both, so aligned scenes are behaviorally unchanged (89 trajectory identical).
- Full suite 95/95 (14212 assertions), backend_cuda 9/9, regression green.
- Docs: spec scene_config.md table, agent_docs 02 default-kappa policy, 09 note.