### PR TITLE
build: adopt libuipc-samples as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "scripts/SymEigen"]
 	path = scripts/SymEigen
 	url = https://github.com/MuGdxy/SymEigen.git
+[submodule "libuipc-samples"]
+	path = libuipc-samples
+	url = https://github.com/spiriMirror/libuipc-samples.git


### PR DESCRIPTION
Registers spiriMirror/libuipc-samples as a git submodule (gitlink at f9bc5f9) so clones with --recurse-submodules pull it alongside the project. No code changes; does not affect the wheel build.