### PR TITLE
fix(docs): remove unauthorized polyfill script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,5 @@
 # This workflow automatically builds and deploys documentation to the libuipc-doc repository
-# when docs/ directory, mkdocs*.yml files, or this workflow file is updated in the main branch.
+# when docs/, a MkDocs config, or this workflow file is updated in the main branch.
 #
 # Setup required:
 # 1. Create a Personal Access Token (PAT) with 'repo' scope in GitHub Settings > Developer settings > Personal access tokens
@@ -15,6 +15,7 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs*.yml'
+      - 'mkdocs*.yaml'
       - '.github/workflows/docs.yml'
   pull_request:
     types: [opened, synchronize, closed]
@@ -23,6 +24,7 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs*.yml'
+      - 'mkdocs*.yaml'
       - '.github/workflows/docs.yml'
   workflow_dispatch: # Allow manual triggering
 

--- a/agent_docs/08-pitfalls-and-debugging.md
+++ b/agent_docs/08-pitfalls-and-debugging.md
@@ -31,6 +31,11 @@ touching that area; several of these have bitten us more than once.
   incidents".
 - **`.github/workflows/*.yml` are CRLF files** — edit them with a
   CRLF-aware tool (python binary read/write), not a naive LF editor.
+- **Do not load scripts from `polyfill.io` in the documentation.** The
+  service returns HTTP 401 and causes browsers to show an authentication
+  popup on every page load. MathJax 3 does not need that ES6 polyfill; both
+  MkDocs configurations intentionally load only the local MathJax setup and
+  the MathJax bundle from jsDelivr.
 - In-progress GitHub Actions jobs expose logs only for **completed steps**;
   grep on a running step returns nothing. Use `gh run view --job <id>` for
   step status instead.

--- a/agent_docs/08-pitfalls-and-debugging.md
+++ b/agent_docs/08-pitfalls-and-debugging.md
@@ -36,6 +36,10 @@ touching that area; several of these have bitten us more than once.
   popup on every page load. MathJax 3 does not need that ES6 polyfill; both
   MkDocs configurations intentionally load only the local MathJax setup and
   the MathJax bundle from jsDelivr.
+- The documentation workflow must watch both `mkdocs*.yml` and
+  `mkdocs*.yaml`. The repository's real configurations use the `.yaml`
+  suffix; watching only `.yml` silently leaves configuration-only fixes
+  undeployed.
 - In-progress GitHub Actions jobs expose logs only for **completed steps**;
   grep on a running step returns nothing. Use `gh run view --job <id>` for
   step status instead.

--- a/agent_docs/handoff.md
+++ b/agent_docs/handoff.md
@@ -71,7 +71,10 @@
 >   site still loaded `polyfill.io` globally from both MkDocs configs. The
 >   service now returns HTTP 401, causing a browser authentication dialog on
 >   every page. The obsolete ES6 polyfill was removed; MathJax 3 remains
->   loaded from jsDelivr.
+>   loaded from jsDelivr. The docs workflow's path filters were also fixed
+>   to watch the repository's actual `mkdocs*.yaml` files (it previously
+>   watched only the unused `.yml` suffix, so config-only fixes did not
+>   deploy).
 >
 > Older header note (2026-08-20, pre-merge): the muda→cuda_tool migration
 > is complete AND fully verified: all apps/tests pass, including the

--- a/agent_docs/handoff.md
+++ b/agent_docs/handoff.md
@@ -66,6 +66,12 @@
 > - **Samples repo**: 87 robot_hand, 88 case2 benchmark, 89 MAS parity
 >   bunny (NO_MAS/NO_GRAPH env A/B), 90-93 = the remaining Stiff set_cases
 >   1/4/5/6 (see doc 09 samples section for the mapping + asset notes).
+> - **Documentation authentication-popup fix (2026-08-24)**: replacing
+>   Bilibili iframes with links removed one popup source, but the deployed
+>   site still loaded `polyfill.io` globally from both MkDocs configs. The
+>   service now returns HTTP 401, causing a browser authentication dialog on
+>   every page. The obsolete ES6 polyfill was removed; MathJax 3 remains
+>   loaded from jsDelivr.
 >
 > Older header note (2026-08-20, pre-merge): the muda→cuda_tool migration
 > is complete AND fully verified: all apps/tests pass, including the

--- a/mkdocs-with-api.yaml
+++ b/mkdocs-with-api.yaml
@@ -72,7 +72,6 @@ extra_css:
   - stylesheets/doxide.css
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -72,7 +72,6 @@ extra_css:
   - stylesheets/doxide.css
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 


### PR DESCRIPTION
## Summary

- remove the obsolete polyfill.io script from both MkDocs configurations
- prevent the HTTP 401 response from triggering browser authentication dialogs
- record the deployment pitfall in agent_docs

## Verification

- confirmed the deployed site still requests polyfill.io
- confirmed polyfill.io currently returns HTTP 401
- confirmed the remaining MathJax bundle returns HTTP 200
- git diff --check passes

MkDocs is not installed in the local environment; the documentation workflow provides the authoritative build check.