### PR TITLE
fix(xmake): read pybind build type from configuration

### DIFF
--- a/src/pybind/xmake.lua
+++ b/src/pybind/xmake.lua
@@ -61,7 +61,8 @@ target("pyuipc")
                 'UIPC_PY_CUDA_TOOLKIT_VERSION="none"'
             )
         end
-        target:add("defines", 'UIPC_PY_BUILD_TYPE="' .. target:mode() .. '"')
+        local build_type = get_config("mode") or "release"
+        target:add("defines", 'UIPC_PY_BUILD_TYPE="' .. build_type .. '"')
         -- depend on backend
         if has_config("backend_cuda") then
             target:add("deps", "cuda", {inherit = false})


### PR DESCRIPTION
## Summary

- Replace the invalid `target:mode()` call in the pybind target with XMake's project configuration API.
- Preserve `release` as a fallback when no build mode is configured.
- Restore pybind-enabled configuration while remaining compatible with the repository's minimum supported XMake version.

## Breaking Changes

None.

## Validation

- `xmake f --pybind=true --python_system=true --python_version=3.12.x -m releasedbg -c -y -vD`
- `xmake show --target=pyuipc` reports `UIPC_PY_BUILD_TYPE="releasedbg"`
- `git diff --check upstream/main...HEAD`

## Checklist

### Fast fail

- N/A: no runtime assertions or user-facing inputs changed.

### C++ style

- N/A: no C++ source files changed.

### GPU / CUDA (if touched)

- N/A: no GPU or CUDA code changed.

### Constitution / material (if touched)

- N/A: no constitution or material code changed.

### Build / bindings (if touched)

- [x] The existing pybind target now reads the configured project build mode without changing the public C++ or Python API.

### Tests

- [x] The failing pybind-enabled XMake configuration was reproduced before the fix and succeeds after it.
- [ ] No automated regression test was added; the change is limited to an XMake DSL API call and was validated through configuration and target inspection.
