### PR TITLE
fix(ci): make clang-format check merge-race safe

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -37,8 +37,9 @@ jobs:
 
       - name: Check changed C++ files
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          FILES=$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- '*.h' '*.hpp' '*.cpp' '*.inl' '*.cu' '*.cuh')
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" -- '*.h' '*.hpp' '*.cpp' '*.inl' '*.cu' '*.cuh')
           if [ -z "$FILES" ]; then
             echo "No C++ files changed."
             exit 0

--- a/agent_docs/handoff.md
+++ b/agent_docs/handoff.md
@@ -6,6 +6,13 @@
 > experiments belong in `agent_docs/performance/`. Add a short handoff pointer
 > instead of growing this file as the only source of truth.
 
+> **Post-merge clang-format race fix (2026-09-01)**: PR #486 merged while its
+> format job was running. The job then fetched moving `origin/main` with
+> `--depth=1`, replacing the original PR base and producing `no merge base`;
+> no source formatting violation occurred. The workflow now diffs the immutable
+> pull-request `base.sha...head.sha`, and a repository contract prevents the
+> moving shallow-fetch pattern from returning.
+
 > **QR-SVD float sign hardening (2026-09-01)**: the Wilkinson shift in
 > libuipc, GPU_IPC, and Stiff-GIPC now computes its magnitude in the template
 > scalar type and applies the sign with `d < 0 ? -shift : shift`, explicitly

--- a/scripts/tests/test_repository_contracts.py
+++ b/scripts/tests/test_repository_contracts.py
@@ -145,6 +145,15 @@ class RepositoryContractTests(unittest.TestCase):
         self.assertIn("if(d < (T)0)", qr_svd)
         self.assertIn("shift = -shift;", qr_svd)
 
+    def test_clang_format_uses_immutable_pull_request_shas(self) -> None:
+        workflow = (
+            ROOT / ".github/workflows/clang-format.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("github.event.pull_request.base.sha", workflow)
+        self.assertIn("github.event.pull_request.head.sha", workflow)
+        self.assertNotIn('git fetch origin "${{ github.base_ref }}" --depth=1', workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- compare clang-format inputs using the immutable pull-request base/head SHAs
- remove the moving shallow fetch that can lose the merge base when a PR merges while the job is running
- add a repository contract for the workflow invariant

## Validation

- Repository Contracts: 32/32
- local clang-format-18 check for the merged source change: passed