### PR TITLE
fix(xmake): compile embedded METIS with PIC

### DIFF
--- a/agent_docs/adr/0007-embedded-cpp-metis.md
+++ b/agent_docs/adr/0007-embedded-cpp-metis.md
@@ -23,6 +23,9 @@ license obligations despite not being required by the configured partitioner.
 
 - Build `src/geometry/metis/*.cpp` as the private static `uipc_metis` target in
   both CMake and XMake, with PIC on Unix-like toolchains.
+  CMake uses `POSITION_INDEPENDENT_CODE`; XMake applies a forced C++ `-fPIC`
+  flag without compiler-name filtering. XMake's C++ driver identifier does not
+  reliably match `gcc`/`clang` filters, which can silently drop the flag.
 - Link `uipc_geometry` privately to `uipc_metis`; do not compile the same source
   files directly into `uipc_geometry`.
 - Remove the root `external/` source tree and the old `GKlib`/`metis` targets.
@@ -122,3 +125,13 @@ does not remove that obligation from the remaining derived core.
   integer extremes. Windows/MSVC and Linux/GCC both produced the same
   11,374,128-byte result with SHA-256
   `90B861E306F4482BB5CE268E4B97C1B5599FB628D9FB2BF6FDFB44F41381ADD8`.
+- PR #492 exposed an XMake-only Linux integration failure: its initial
+  compiler-name-filtered `-fPIC` setting was not applied to the C++ objects, so
+  the linker rejected the thread-local GKlib state with an
+  `R_X86_64_TPOFF32` relocation. The unfiltered forced C++ flag fixes the
+  target. An isolated shared-library consumer built with the CI's exact XMake
+  3.0.5 emitted `-fPIC` for every METIS object and linked successfully; a GCC
+  whole-archive probe also confirms that no local-exec TLS relocation remains.
+  The same CI log exposed an ignored GNU `strerror_r` return value; the adapter
+  now handles both GNU pointer-returning and POSIX integer-returning signatures,
+  and a Linux `ENOENT` probe returns a non-empty diagnostic without warnings.

--- a/agent_docs/adr/0007-embedded-cpp-metis.md
+++ b/agent_docs/adr/0007-embedded-cpp-metis.md
@@ -23,9 +23,10 @@ license obligations despite not being required by the configured partitioner.
 
 - Build `src/geometry/metis/*.cpp` as the private static `uipc_metis` target in
   both CMake and XMake, with PIC on Unix-like toolchains.
-  CMake uses `POSITION_INDEPENDENT_CODE`; XMake applies a forced C++ `-fPIC`
-  flag without compiler-name filtering. XMake's C++ driver identifier does not
-  reliably match `gcc`/`clang` filters, which can silently drop the flag.
+  CMake uses `POSITION_INDEPENDENT_CODE`; XMake applies a C++ `-fPIC` flag
+  without compiler-name filtering and retains its normal flag-support probe.
+  XMake's C++ driver identifier does not reliably match `gcc`/`clang` filters,
+  which can silently drop the flag.
 - Link `uipc_geometry` privately to `uipc_metis`; do not compile the same source
   files directly into `uipc_geometry`.
 - Remove the root `external/` source tree and the old `GKlib`/`metis` targets.
@@ -128,8 +129,9 @@ does not remove that obligation from the remaining derived core.
 - PR #492 exposed an XMake-only Linux integration failure: its initial
   compiler-name-filtered `-fPIC` setting was not applied to the C++ objects, so
   the linker rejected the thread-local GKlib state with an
-  `R_X86_64_TPOFF32` relocation. The unfiltered forced C++ flag fixes the
-  target. An isolated shared-library consumer built with the CI's exact XMake
+  `R_X86_64_TPOFF32` relocation. The unfiltered C++ flag fixes the target while
+  allowing XMake to validate toolchain support. An isolated shared-library
+  consumer built with the CI's exact XMake
   3.0.5 emitted `-fPIC` for every METIS object and linked successfully; a GCC
   whole-archive probe also confirms that no local-exec TLS relocation remains.
   The same CI log exposed an ignored GNU `strerror_r` return value; the adapter

--- a/agent_docs/handoff.md
+++ b/agent_docs/handoff.md
@@ -26,8 +26,9 @@
 > codes, edge cuts, and every per-vertex partition ID on the same platform. See
 > [`ADR 0007`](adr/0007-embedded-cpp-metis.md) for exact hashes and boundaries.
 > PR #492's first Linux XMake run caught a compiler-filtered `-fPIC` flag being
-> silently omitted from `uipc_metis`; the target now forces the C++ flag without
-> a tool-name filter, matching CMake's PIC property and allowing its
+> silently omitted from `uipc_metis`; the target now applies the C++ flag
+> without a tool-name filter while retaining XMake's support probe, matching
+> CMake's PIC property and allowing its
 > thread-local GKlib state to link into `libuipc_geometry.so`. The adjacent
 > GNU/POSIX `strerror_r` portability warning was fixed at the same time so Linux
 > error paths return the correct diagnostic string.

--- a/agent_docs/handoff.md
+++ b/agent_docs/handoff.md
@@ -25,6 +25,12 @@
 > configurations on both Windows/MSVC and Linux/GCC produced identical return
 > codes, edge cuts, and every per-vertex partition ID on the same platform. See
 > [`ADR 0007`](adr/0007-embedded-cpp-metis.md) for exact hashes and boundaries.
+> PR #492's first Linux XMake run caught a compiler-filtered `-fPIC` flag being
+> silently omitted from `uipc_metis`; the target now forces the C++ flag without
+> a tool-name filter, matching CMake's PIC property and allowing its
+> thread-local GKlib state to link into `libuipc_geometry.so`. The adjacent
+> GNU/POSIX `strerror_r` portability warning was fixed at the same time so Linux
+> error paths return the correct diagnostic string.
 
 > **AL-IPC sample 88 trajectory correction (2026-09-03, `refactor-main`)**:
 > the severe early trajectory split was traced to AL ignoring the configured

--- a/scripts/tests/test_repository_contracts.py
+++ b/scripts/tests/test_repository_contracts.py
@@ -231,7 +231,7 @@ class RepositoryContractTests(unittest.TestCase):
         self.assertIn('includes("metis")', geometry_xmake)
         self.assertIn('add_deps("uipc_core", "uipc_metis")', geometry_xmake)
         self.assertIn("POSITION_INDEPENDENT_CODE ON", metis_cmake)
-        self.assertIn('add_cxxflags("-fPIC", {force = true})', metis_xmake)
+        self.assertIn('add_cxxflags("-fPIC")', metis_xmake)
         self.assertTrue((embedded / "LICENSE-METIS").is_file())
         self.assertTrue((embedded / "LICENSE-GKlib").is_file())
 

--- a/scripts/tests/test_repository_contracts.py
+++ b/scripts/tests/test_repository_contracts.py
@@ -220,6 +220,8 @@ class RepositoryContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         embedded = ROOT / "src/geometry/metis"
+        metis_cmake = (embedded / "CMakeLists.txt").read_text(encoding="utf-8")
+        metis_xmake = (embedded / "xmake.lua").read_text(encoding="utf-8")
 
         self.assertNotIn("add_subdirectory(external)", root_cmake)
         self.assertNotIn("external/GKlib", root_xmake)
@@ -228,6 +230,8 @@ class RepositoryContractTests(unittest.TestCase):
         self.assertIn("uipc_metis", geometry_cmake)
         self.assertIn('includes("metis")', geometry_xmake)
         self.assertIn('add_deps("uipc_core", "uipc_metis")', geometry_xmake)
+        self.assertIn("POSITION_INDEPENDENT_CODE ON", metis_cmake)
+        self.assertIn('add_cxxflags("-fPIC", {force = true})', metis_xmake)
         self.assertTrue((embedded / "LICENSE-METIS").is_file())
         self.assertTrue((embedded / "LICENSE-GKlib").is_file())
 

--- a/src/geometry/metis/gklib.cpp
+++ b/src/geometry/metis/gklib.cpp
@@ -10,8 +10,10 @@
 
 #include <chrono>
 #include <cstdio>
+#include <cstring>
 #include <ctime>
 #include <mutex>
+#include <type_traits>
 
 /************************ blas.c ************************/
 /*!
@@ -243,9 +245,25 @@ char* gk_strerror(int errnum)
 #ifndef SUNOS
     static __thread char buf[1024];
 
-    strerror_r(errnum, buf, 1024);
+    const auto normalize_result = [errnum](auto result, char* buffer, size_t size)
+    {
+        using Result = decltype(result);
+        if constexpr(std::is_pointer_v<Result>)
+        {
+            if(result == nullptr)
+                std::snprintf(buffer, size, "Unknown error %d", errnum);
+            else if(result != buffer)
+                std::snprintf(buffer, size, "%s", result);
+        }
+        else if(result != 0)
+        {
+            std::snprintf(buffer, size, "Unknown error %d", errnum);
+        }
+    };
 
-    buf[1023] = '\0';
+    normalize_result(strerror_r(errnum, buf, sizeof(buf)), buf, sizeof(buf));
+
+    buf[sizeof(buf) - 1] = '\0';
     return buf;
 #else
     return strerror(errnum);

--- a/src/geometry/metis/xmake.lua
+++ b/src/geometry/metis/xmake.lua
@@ -9,5 +9,5 @@ target("uipc_metis")
     if is_plat("linux") then
         add_defines("LINUX")
         add_syslinks("m")
-        add_cxxflags("-fPIC", {force = true})
+        add_cxxflags("-fPIC")
     end

--- a/src/geometry/metis/xmake.lua
+++ b/src/geometry/metis/xmake.lua
@@ -9,5 +9,5 @@ target("uipc_metis")
     if is_plat("linux") then
         add_defines("LINUX")
         add_syslinks("m")
-        add_cxflags("-fPIC", {tools = {"gcc", "clang"}})
+        add_cxxflags("-fPIC", {force = true})
     end


### PR DESCRIPTION
## Summary
- apply `-fPIC` to the private `uipc_metis` C++ target without a fragile compiler-name filter, while retaining XMake's normal flag-support probe
- keep the CMake/XMake PIC invariant covered by repository contracts
- correctly normalize both GNU and POSIX `strerror_r` return conventions

## Root cause
PR #492's Linux XMake job dropped the compiler-filtered `add_cxflags` setting. The static archive therefore used local-exec TLS relocations and could not link into `libuipc_geometry.so`.

## Validation
- isolated Linux shared consumer with the CI's exact XMake 3.0.5: XMake probed `-fPIC`, every METIS object compiled with it, and the shared link passed
- GCC whole-archive shared-link probe: no `R_X86_64_TPOFF32` relocation
- Linux `gk_strerror(ENOENT)` probe returned a non-empty correct diagnostic without the prior warning
- CMake and XMake Windows `uipc_metis` builds passed
- repository script tests: 49/49
- clang-format-18 and diff checks passed